### PR TITLE
[UI/UX] Implement automatic output format detection in decode.py

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -369,7 +369,7 @@ if __name__ == '__main__':
     io_group.add_argument('infile', nargs='?', default='-',
                         help='Input file containing encoded cards (or a JSON corpus) to decode. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
-                        help='Path to save the decoded output. If not provided, output prints to the console.')
+                        help='Path to save the decoded output. If not provided, output prints to the console. Format is automatically inferred from extension (.html, .json, .csv, .mse-set) if not explicitly specified.')
 
     # Group: Output Format (Mutually Exclusive)
     # We use a mutually exclusive group to enforce one output format.
@@ -427,6 +427,20 @@ if __name__ == '__main__':
                         help='File path to save the text of cards that failed to parse/validate (useful for debugging).')
 
     args = parser.parse_args()
+
+    # If no output format is specified, try to infer it from the outfile extension
+    if not any([args.text, args.html, args.json, args.csv, args.mse]) and args.outfile:
+        ext = os.path.splitext(args.outfile)[1].lower()
+        if ext == '.html':
+            args.html = True
+        elif ext == '.json':
+            args.json = True
+        elif ext == '.csv':
+            args.csv = True
+        elif ext == '.mse-set':
+            args.mse = True
+        elif ext == '.txt':
+            args.text = True
 
     # If --mse is used, we must have an output filename.
     if args.mse and not args.outfile:

--- a/test_auto_noext
+++ b/test_auto_noext
@@ -1,0 +1,79 @@
+mse version: 0.3.8
+game: magic
+stylesheet: m15
+set info:
+	symbol:
+styling:
+	magic-m15:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-m15-clear:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-m15-extra-improved:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		pt box symbols: magic-pt-symbols-extra.mse-symbol-font
+		overlay:
+	magic-m15-planeswalker:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-m15-planeswalker-promo-black:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-m15-promo-dka:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-m15-token-clear:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-new-planeswalker:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-new-planeswalker-4abil:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-new-planeswalker-clear:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+	magic-new-planeswalker-promo-black:
+		text box mana symbols: magic-mana-small.mse-symbol-font
+		overlay:
+card:
+	name: Uthros Research Craft
+	rarity: rare
+	casting cost: 2U
+	super type: Artifact
+	sub type: Spacecraft
+	power: 0
+	toughness: 8
+	rule text:
+		Station
+		Station 3+
+		Station 12+
+		Flying
+		Whenever you cast an artifact spell, draw a card. Put a charge counter on this spacecraft.
+		This spacecraft gets +1/+0 for each artifact you control.
+	has styling: false
+	time created:2015-07-20 22:53:07
+	time modified:2015-07-20 22:53:08
+	extra data:
+	image:
+	card code text:
+	copyright:
+	image 2:
+	copyright 2:
+	notes:
+		raw:
+		|5artifact|4|6spacecraft|7|8&/&^^^^^^^^|9station\station &^^^+\station &^^^^^^^^^^^^+\flying\whenever you cast an artifact spell, draw a card. put a % counter on this spacecraft.\this spacecraft gets +&^/+& for each artifact you control.\countertype % charge|3{^^UU}|0A|1uthros research craft|
+
+		Uthros Research Craft {2}{U} (rare)
+		Artifact ~ Spacecraft (0/8)
+		Station
+		Station 3+
+		Station 12+
+		Flying
+		Whenever you cast an artifact spell, draw a card. Put a charge counter on this spacecraft.
+		This spacecraft gets +1/+0 for each artifact you control.
+version control:
+	type: none
+apprentice code:


### PR DESCRIPTION
**PR Title:** [UI/UX] Implement automatic output format detection in decode.py

**Description:**
* **Context:** CLI
* **Problem:** Users have to explicitly type format flags (e.g., `--json`, `--html`) even when providing an output filename with a clear extension, leading to redundant keystrokes.
* **Solution:** Added logic to `decode.py` to automatically infer the output format from the `outfile` extension if no explicit format flag is provided. This reduces friction for common decoding workflows.


---
*PR created automatically by Jules for task [8099743453758986377](https://jules.google.com/task/8099743453758986377) started by @RainRat*