### PR TITLE
Remove redundant logic in `to_unary` function

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -129,14 +129,12 @@ def to_unary(s, warn = False):
         i = int(n)
         if i in unary_exceptions:
             return unary_exceptions[i]
-        elif i > unary_max:
+        if i > unary_max:
             # original code capped it at unary_max (20)
             if warn:
                 print(s)
             i = unary_max
-            return unary_marker + unary_counter * i
-        else:
-            return unary_marker + unary_counter * i
+        return unary_marker + unary_counter * i
 
     return _number_decimal_re.sub(replace_number, s)
 


### PR DESCRIPTION
* **What:** Refactored the `replace_number` helper inside `to_unary` to consolidate the return statement. Previously, two separate branches (capping a number and the default case) performed identical calculations and return operations.
* **Why:** This change reduces code duplication and improves readability without changing the function's external behavior. Existing tests verify that number conversion and capping at `unary_max` still work as expected.

---
*PR created automatically by Jules for task [14545697129434911197](https://jules.google.com/task/14545697129434911197) started by @RainRat*