### PR TITLE
[FEAT] Add --limit flag to processing scripts

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -22,7 +22,7 @@ from namediff import Namediff
 def main(fname, oname = None, verbose = True, encoding = 'std',
          gatherer = True, for_forum = False, for_mse = False,
          creativity = False, vdump = False, html = False, text = False, json_out = False, csv_out = False, quiet=False,
-         report_file=None, color_arg=None):
+         report_file=None, color_arg=None, limit=0):
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
@@ -81,6 +81,9 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         raise ValueError('decode.py: unknown encoding: ' + encoding)
 
     cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file)
+
+    if limit > 0:
+        cards = cards[:limit]
 
     if creativity:
         namediff = Namediff()
@@ -430,6 +433,8 @@ if __name__ == '__main__':
     proc_group = parser.add_argument_group('Processing & Debugging')
     proc_group.add_argument('-c', '--creativity', action='store_true',
                         help="Enable 'creativity' mode: calculate similarity to existing cards using CBOW (slow).")
+    proc_group.add_argument('-n', '--limit', type=int, default=0,
+                        help='Limit the number of cards to decode.')
     proc_group.add_argument('-d', '--dump', action='store_true',
                         help='Debug mode: print detailed information about cards that failed to validate.')
     proc_group.add_argument('-v', '--verbose', action='store_true',
@@ -448,6 +453,6 @@ if __name__ == '__main__':
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          gatherer = args.gatherer, for_forum = args.forum, for_mse = args.mse,
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text, json_out = args.json, csv_out = args.csv, quiet=args.quiet,
-         report_file = args.report_failed, color_arg=args.color)
+         report_file = args.report_failed, color_arg=args.color, limit=args.limit)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, randomize = False, nolabel = False, stable = False,
-         report_file=None, quiet=False):
+         report_file=None, quiet=False, limit=0):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
     fieldsep = utils.fieldsep
@@ -62,6 +62,9 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
     if not stable:
         random.seed(1371367)
         random.shuffle(cards)
+
+    if limit > 0:
+        cards = cards[:limit]
 
     def writecards(writer):
         for card in tqdm(cards, disable=quiet):
@@ -112,6 +115,8 @@ if __name__ == '__main__':
     proc_group = parser.add_argument_group('Data Processing')
     proc_group.add_argument('-r', '--randomize', action='store_true',
                         help='Shuffle mana symbols (e.g., {W}{U} vs {U}{W}) for data augmentation.')
+    proc_group.add_argument('-n', '--limit', type=int, default=0,
+                        help='Limit the number of cards to encode.')
     proc_group.add_argument('-s', '--stable', action='store_true',
                         help='Preserve the original order of cards from the input file (do not shuffle).')
 
@@ -127,5 +132,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          nolinetrans = args.nolinetrans, randomize = args.randomize, nolabel = args.nolabel,
-         stable = args.stable, report_file = args.report_unparsed, quiet=args.quiet)
+         stable = args.stable, report_file = args.report_unparsed, quiet=args.quiet,
+         limit=args.limit)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -206,6 +206,11 @@ Supports any encoding format supported by encode.py/decode.py.""",
     enc_group.add_argument('-e', '--encoding', default='std', choices=utils.formats,
                         help="Format of the input data. 'std' (default) puts the name last. 'named' puts the name first. Must match the format of the input file.")
 
+    # Group: Processing Options
+    proc_group = parser.add_argument_group('Processing Options')
+    proc_group.add_argument('-n', '--limit', type=int, default=0,
+                        help='Limit the number of cards to sort.')
+
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
     debug_group.add_argument('-v', '--verbose', action='store_true',
@@ -274,6 +279,9 @@ Supports any encoding format supported by encode.py/decode.py.""",
         except Exception as e:
             if verbose:
                 print(f"Warning: Failed to parse card: {e}", file=sys.stderr)
+
+    if args.limit > 0:
+        cards = cards[:args.limit]
 
     classes = sortcards(cards, verbose=verbose)
 


### PR DESCRIPTION
Identified and implemented the "missing piece" of functionality: a limit flag for processing cards. This adds immediate value for users working with large datasets who need to preview or test their pipelines with smaller samples.

Heuristics applied:
- Convenience: Wrapped a common need (slicing output) into a single flag.
- Symmetry: Applied the same limit control across all primary card processing tools.

Non-breaking: Default behavior (no limit) is preserved.
Zero-configuration: Works out of the box with standard argparse.

---
*PR created automatically by Jules for task [14390088684447635821](https://jules.google.com/task/14390088684447635821) started by @RainRat*