### PR TITLE
Fix incorrect mapping of curly single quotes in to_ascii

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -91,8 +91,8 @@ json_field_info_code = config.json_field_info_code
 unicode_trans = {
     '\u2014': dash_marker,  # unicode long dash
     '\u2022': bullet_marker,  # unicode bullet
-    '\u2019': '"',  # single quote
-    '\u2018': '"',  # single quote
+    '\u2019': "'",  # single quote
+    '\u2018': "'",  # single quote
     '\u2212': '-',  # minus sign
     '\xe6': 'ae',  # ae symbol
     '\xfb': 'u',  # u with caret

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,8 +62,8 @@ def test_to_ascii():
     # Test common replacements
     assert utils.to_ascii("\u2014") == config.dash_marker
     assert utils.to_ascii("\u2022") == config.bullet_marker
-    assert utils.to_ascii("\u2019") == '"'
-    assert utils.to_ascii("\u2018") == '"'
+    assert utils.to_ascii("\u2019") == "'"
+    assert utils.to_ascii("\u2018") == "'"
     assert utils.to_ascii("\u2212") == '-'
 
     # Test accented characters


### PR DESCRIPTION
Updated the `unicode_trans` table in `lib/utils.py` to correctly map curly single quotes to ASCII single quotes. Also updated the corresponding unit tests in `tests/test_utils.py`.

---
*PR created automatically by Jules for task [12720673593603894257](https://jules.google.com/task/12720673593603894257) started by @RainRat*