### PR TITLE
[FEAT] Add regex-based card filtering to all CLI tools

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -22,7 +22,7 @@ from namediff import Namediff
 def main(fname, oname = None, verbose = True, encoding = 'std',
          gatherer = True, for_forum = False, for_mse = False,
          creativity = False, vdump = False, html = False, text = False, json_out = False, csv_out = False, quiet=False,
-         report_file=None, color_arg=None, limit=0):
+         report_file=None, color_arg=None, limit=0, grep=None):
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
@@ -80,7 +80,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
     else:
         raise ValueError('decode.py: unknown encoding: ' + encoding)
 
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file)
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep)
 
     if limit > 0:
         cards = cards[:limit]
@@ -443,6 +443,8 @@ if __name__ == '__main__':
                         help='Suppress the progress bar.')
     proc_group.add_argument('--report-failed',
                         help='File path to save the text of cards that failed to parse/validate (useful for debugging).')
+    proc_group.add_argument('--grep', action='append',
+                        help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
 
     args = parser.parse_args()
 
@@ -453,6 +455,6 @@ if __name__ == '__main__':
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          gatherer = args.gatherer, for_forum = args.forum, for_mse = args.mse,
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text, json_out = args.json, csv_out = args.csv, quiet=args.quiet,
-         report_file = args.report_failed, color_arg=args.color, limit=args.limit)
+         report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, randomize = False, nolabel = False, stable = False,
-         report_file=None, quiet=False, limit=0):
+         report_file=None, quiet=False, limit=0, grep=None):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
     fieldsep = utils.fieldsep
@@ -55,7 +55,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         if not line_transformations:
             print('  NOT using line reordering transformations', file=sys.stderr)
 
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=line_transformations, report_file=report_file)
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=line_transformations, report_file=report_file, grep=grep)
 
     # This should give a random but consistent ordering, to make comparing changes
     # between the output of different versions easier.
@@ -119,6 +119,8 @@ if __name__ == '__main__':
                         help='Limit the number of cards to encode.')
     proc_group.add_argument('-s', '--stable', action='store_true',
                         help='Preserve the original order of cards from the input file (do not shuffle).')
+    proc_group.add_argument('--grep', action='append',
+                        help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -133,5 +135,5 @@ if __name__ == '__main__':
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          nolinetrans = args.nolinetrans, randomize = args.randomize, nolabel = args.nolabel,
          stable = args.stable, report_file = args.report_unparsed, quiet=args.quiet,
-         limit=args.limit)
+         limit=args.limit, grep=args.grep)
     exit(0)

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -8,21 +8,41 @@ import utils
 import jdecode
 from datalib import Datamine
 
-def main(fname, verbose = True, outliers = False, dump_all = False):
-    if fname[-5:] == '.json':
-        if verbose:
-            print('This looks like a json file: ' + fname)
-        json_srcs = jdecode.mtg_open_json(fname, verbose)
-        card_srcs = []
-        for json_cardname in sorted(json_srcs):
-            if len(json_srcs[json_cardname]) > 0:
-                card_srcs += [json_srcs[json_cardname][0]]
-    else:
-        if verbose:
-            print('Opening encoded card file: ' + fname)
-        with open(fname, 'rt') as f:
-            text = f.read()
-        card_srcs = text.split(utils.cardsep)
+def main(fname, verbose = True, outliers = False, dump_all = False, grep = None):
+    # Use the robust mtg_open_file for all loading and filtering.
+    # We disable default exclusions to match original summarize.py behavior.
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, grep=grep,
+                                  exclude_sets=lambda x: False,
+                                  exclude_types=lambda x: False,
+                                  exclude_layouts=lambda x: False)
+    # Datamine expects card_srcs (strings) or Card objects?
+    # Let's check datalib.py again.
+
+    # Actually, Datamine.__init__ does:
+    # for card_src in card_srcs:
+    #     card = Card(card_src)
+    # But it also works if card_src IS a Card object?
+    # Wait, Card(card_object) might fail?
+
+    # If I pass Card objects to Datamine, it might re-parse them if I'm not careful.
+    # Let's check cardlib.py Card constructor again.
+
+    # In Card.__init__(self, src, ...):
+    # if isinstance(src, dict): ...
+    # else: self.raw = src ...
+
+    # If I pass a Card object, it will be treated as "else" and it might fail.
+    # So I should pass the raw strings or dicts.
+
+    # Actually, I can just pass the list of Cards and update Datamine to handle it.
+    # But it's easier to just pass card.raw or card.json.
+
+    card_srcs = []
+    for card in cards:
+        if card.json:
+            card_srcs.append(card.json)
+        else:
+            card_srcs.append(card.raw if card.raw else card.encode())
 
     mine = Datamine(card_srcs)
     mine.summarize()
@@ -42,7 +62,9 @@ if __name__ == '__main__':
                         help='show all information and dump invalid cards')
     parser.add_argument('-v', '--verbose', action='store_true', 
                         help='verbose output')
+    parser.add_argument('--grep', action='append',
+                        help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
     
     args = parser.parse_args()
-    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all)
+    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep)
     exit(0)

--- a/test_cards.txt
+++ b/test_cards.txt
@@ -1,0 +1,3 @@
+|1Fire Dragon|5Creature|6Dragon|3{4}{R}{R}|7rare|85/5|9Flying
+
+|1Water Elemental|5Creature|6Elemental|3{3}{U}{U}|7uncommon|85/4|9Islandwalk

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -1,0 +1,102 @@
+import os
+import sys
+import pytest
+import tempfile
+import json
+
+# Ensure lib is in path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from lib import jdecode, cardlib
+
+def test_grep_filtering():
+    # Setup sample data
+    cards_data = [
+        {
+            "name": "Fire Dragon",
+            "types": ["Creature"],
+            "subtypes": ["Dragon"],
+            "text": "Flying\n{R}: Fire Dragon deals 1 damage.",
+            "manaCost": "{4}{R}{R}",
+            "power": "5",
+            "toughness": "5",
+            "rarity": "rare"
+        },
+        {
+            "name": "Water Elemental",
+            "types": ["Creature"],
+            "subtypes": ["Elemental"],
+            "text": "Islandwalk",
+            "manaCost": "{3}{U}{U}",
+            "power": "5",
+            "toughness": "4",
+            "rarity": "uncommon"
+        },
+        {
+            "name": "Fireball",
+            "types": ["Sorcery"],
+            "text": "Fireball deals X damage.",
+            "manaCost": "{X}{R}",
+            "rarity": "uncommon"
+        }
+    ]
+
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.json', delete=False, encoding='utf-8') as tmp:
+        json.dump(cards_data, tmp)
+        tmp_path = tmp.name
+
+    try:
+        # Test 1: Grep for "Dragon"
+        cards = jdecode.mtg_open_file(tmp_path, grep=["Dragon"])
+        assert len(cards) == 1
+        assert cards[0].name == "fire dragon"
+
+        # Test 2: Grep for "Fire"
+        cards = jdecode.mtg_open_file(tmp_path, grep=["Fire"])
+        assert len(cards) == 2
+        names = [c.name for c in cards]
+        assert "fire dragon" in names
+        assert "fireball" in names
+
+        # Test 3: Multiple greps (AND logic) - "Fire" and "Dragon"
+        cards = jdecode.mtg_open_file(tmp_path, grep=["Fire", "Dragon"])
+        assert len(cards) == 1
+        assert cards[0].name == "fire dragon"
+
+        # Test 4: Grep for something that doesn't exist
+        cards = jdecode.mtg_open_file(tmp_path, grep=["Zombie"])
+        assert len(cards) == 0
+
+        # Test 5: Grep by rules text
+        cards = jdecode.mtg_open_file(tmp_path, grep=["Islandwalk"])
+        assert len(cards) == 1
+        assert cards[0].name == "water elemental"
+
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+def test_grep_encoded_text():
+    # Setup sample encoded data
+    encoded_text = (
+        "|1Fire Dragon|5Creature|6Dragon|3{4}{R}{R}|7rare|85/5|9Flying\\{R}: Fire Dragon deals 1 damage.\n\n"
+        "|1Water Elemental|5Creature|6Elemental|3{3}{U}{U}|7uncommon|85/4|9Islandwalk\n\n"
+    )
+
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.txt', delete=False, encoding='utf-8') as tmp:
+        tmp.write(encoded_text)
+        tmp_path = tmp.name
+
+    try:
+        # Test 1: Grep for "Elemental"
+        cards = jdecode.mtg_open_file(tmp_path, grep=["Elemental"])
+        assert len(cards) == 1
+        assert cards[0].name.lower() == "water elemental"
+
+        # Test 2: Grep for "Flying"
+        cards = jdecode.mtg_open_file(tmp_path, grep=["Flying"])
+        assert len(cards) == 1
+        assert cards[0].name.lower() == "fire dragon"
+
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)


### PR DESCRIPTION
This PR introduces a powerful new filtering feature across the entire `mtgencode` toolset. By adding a `--grep` flag to the main scripts, users can now easily isolate specific subsets of cards (e.g., all Dragons, all red cards, all cards with specific keywords) using regular expressions. 

Key changes:
- Logic centralized in `lib/jdecode.py` for high leverage and consistency.
- Support for multiple `--grep` flags using AND logic.
- Improved codebase health by refactoring secondary scripts to use shared loading functions.
- Bug fix in `summarize.py` regarding JSON return types.
- New test suite for filtering.

---
*PR created automatically by Jules for task [7153012134280075050](https://jules.google.com/task/7153012134280075050) started by @RainRat*