### PR TITLE
[TEST] Improve card validation logic and test coverage

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -152,14 +152,20 @@ def fields_check_valid(fields):
         return False
     if not field_types in fields:
         return False
-    # creatures and vehicles have p/t, other things don't
+
     iscreature = False
     isartifact = False
+    isplaneswalker = False
+    isbattle = False
     for idx, value in fields[field_types]:
         if 'creature' in value:
             iscreature = True
         if 'artifact' in value:
             isartifact = True
+        if 'planeswalker' in value:
+            isplaneswalker = True
+        if 'battle' in value:
+            isbattle = True
 
     if field_subtypes in fields:
         for idx, value in fields[field_subtypes]:
@@ -171,19 +177,27 @@ def fields_check_valid(fields):
         for idx, value in fields[field_text]:
             text += value.text
 
+    # P/T requirements
     if iscreature:
-        return field_pt in fields
-    # Station cards can become creatures
+        if not field_pt in fields:
+            return False
+    # Station cards can become creatures, so they are allowed to NOT have P/T.
+    # We also allow them to HAVE P/T if they want.
     elif isartifact and 'station' in text:
-        return True
-    # Planeswalkers don't have p/t
-    elif any('planeswalker' in val for _, val in fields[field_types]):
-        return True
-    # Battles don't have p/t
-    elif any('battle' in val for _, val in fields[field_types]):
-        return field_loyalty in fields
+        pass
     else:
-        return not field_pt in fields
+        if field_pt in fields:
+            return False
+
+    # Loyalty / Defense requirements
+    if isplaneswalker or isbattle:
+        if not field_loyalty in fields:
+            return False
+    else:
+        if field_loyalty in fields:
+            return False
+
+    return True
 
 
 # These functions take a bunch of source data in some format and turn

--- a/tests/test_card_validation.py
+++ b/tests/test_card_validation.py
@@ -138,3 +138,31 @@ def test_fields_check_valid_battle_brittle_check_no_loyalty():
     }
     # Should be invalid because battles need loyalty
     assert not fields_check_valid(fields)
+
+def test_fields_check_valid_planeswalker_missing_loyalty():
+    fields = {
+        field_name: [(-1, "jace")],
+        field_types: [(-1, ["planeswalker"])],
+        # No loyalty
+    }
+    # Should be invalid because planeswalkers need loyalty
+    assert not fields_check_valid(fields)
+
+def test_fields_check_valid_battle_creature_missing_loyalty():
+    fields = {
+        field_name: [(-1, "battle creature")],
+        field_types: [(-1, ["battle", "creature"])],
+        field_pt: [(-1, "1/1")],
+        # No loyalty
+    }
+    # Should be invalid because battles need loyalty even if they are creatures
+    assert not fields_check_valid(fields)
+
+def test_fields_check_valid_instant_with_loyalty():
+    fields = {
+        field_name: [(-1, "instant with loyalty")],
+        field_types: [(-1, ["instant"])],
+        field_loyalty: [(-1, "3")]
+    }
+    # Should be invalid because instants don't have loyalty
+    assert not fields_check_valid(fields)


### PR DESCRIPTION
This PR improves the robustness of card validation in the `fields_check_valid` function and extends the test suite to cover previously identified gaps.

### Changes:
- **`lib/cardlib.py`**: Refactored `fields_check_valid` to use independent validation blocks for P/T and Loyalty. This ensures that cards with multiple types (e.g., Battle Creatures) are correctly validated for all required fields. It also strictly enforces that Planeswalkers and Battles have loyalty, and that non-applicable types do not have these fields.
- **`tests/test_card_validation.py`**: Added three new test cases:
    - `test_fields_check_valid_planeswalker_missing_loyalty`
    - `test_fields_check_valid_battle_creature_missing_loyalty`
    - `test_fields_check_valid_instant_with_loyalty`

These changes increase test coverage and ensure higher data integrity during card parsing and encoding.

---
*PR created automatically by Jules for task [15714015193461449681](https://jules.google.com/task/15714015193461449681) started by @RainRat*