### PR TITLE
Fix logic bug in mtg_open_file card counts

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -338,9 +338,13 @@ def mtg_open_file(fname, verbose = False,
                     if verbose:
                         print ('Invalid card: ' + card_src, file=sys.stderr)
                     if report_fobj:
-                         report_fobj.write(card_src + utils.cardsep)
-                    else:
-                        unparsed += 1
+                        report_fobj.write(card_src + utils.cardsep)
+                else:
+                    unparsed += 1
+                    if verbose:
+                        print ('Failed to parse card: ' + card_src, file=sys.stderr)
+                    if report_fobj:
+                        report_fobj.write(card_src + utils.cardsep)
 
         if verbose:
              print((str(valid) + ' valid, ' + str(skipped) + ' skipped, '

--- a/tests/test_jdecode_counts.py
+++ b/tests/test_jdecode_counts.py
@@ -1,0 +1,46 @@
+import pytest
+import io
+import os
+import sys
+from lib import jdecode, cardlib, utils
+
+def test_mtg_open_file_counts(tmp_path, capsys):
+    # fmt_ordered_named = [name, types, supertypes, subtypes, loyalty, pt, text, cost, rarity] (9 fields)
+
+    # 1. Valid card (Land - no PT/Loyalty required)
+    # |name|types|supertypes|subtypes|loyalty|pt|text|cost|rarity|
+    valid_card = "|Valid Land|land|basic||||some text|||"
+    # 2. Invalid card (Creature without P/T)
+    invalid_card = "|Invalid Card|creature|||||some text|||"
+    # 3. Unparsed card (Extra field - 10 fields)
+    unparsed_card = "|Unparsed|creature|||||text|||EXTRA|"
+
+    sep = utils.cardsep
+    test_content = valid_card + sep + invalid_card + sep + unparsed_card
+
+    d = tmp_path / "test_counts.txt"
+    with open(d, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(test_content)
+
+    # We need to use verbose=True to get the summary in stderr
+    cards = jdecode.mtg_open_file(str(d), verbose=True, fmt_ordered=cardlib.fmt_ordered_named)
+
+    captured = capsys.readouterr()
+
+    assert "1 valid" in captured.err
+    assert "1 invalid" in captured.err
+    assert "1 failed to parse" in captured.err
+
+def test_mtg_open_file_counts_no_double_count(tmp_path, capsys):
+    # Test specifically for the double counting of invalid cards as unparsed when no report file is present
+    invalid_card = "|Invalid|creature|||||text|||"
+
+    d = tmp_path / "test_invalid.txt"
+    with open(d, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(invalid_card)
+
+    jdecode.mtg_open_file(str(d), verbose=True, fmt_ordered=cardlib.fmt_ordered_named)
+    captured = capsys.readouterr()
+
+    assert "1 invalid" in captured.err
+    assert "0 failed to parse" in captured.err


### PR DESCRIPTION
Improved the accuracy of card loading statistics in `lib/jdecode.py`.

- Fixed a logic bug where unparsed cards (parsing failed) were not being counted when loading encoded text files.
- Resolved an issue where invalid cards (parsed but failed validation) were being double-counted as both "invalid" and "failed to parse" when no report file was provided.
- Ensured that unparsed cards are also written to the failure report file if one is specified.
- Made the counting logic for text files consistent with the existing logic for JSON and CSV files.
- Added a comprehensive test suite `tests/test_jdecode_counts.py` to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [10134440357555174272](https://jules.google.com/task/10134440357555174272) started by @RainRat*