### PR TITLE
[FEAT] Add Markdown output support to decode.py

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -666,7 +666,7 @@ class Card:
 
         return outstr
 
-    def format(self, gatherer=False, for_forum=False, vdump=False, for_html=False, ansi_color=False):
+    def format(self, gatherer=False, for_forum=False, vdump=False, for_html=False, ansi_color=False, for_md=False):
         """Formats the card data into a human-readable string.
 
         Args:
@@ -679,6 +679,8 @@ class Card:
             for_html (bool, optional): Whether to create a .html file with pretty forum formatting.
                 Defaults to False.
             ansi_color (bool, optional): Whether to use ANSI color codes for terminal output.
+                Defaults to False.
+            for_md (bool, optional): Whether to use Markdown formatting.
                 Defaults to False.
 
         Returns:
@@ -730,6 +732,8 @@ class Card:
             outstr += '<b>' + cardname + '</b>'
         elif for_forum:
             outstr += '[b]' + cardname + '[/b]'
+        elif for_md:
+            outstr += '**' + cardname + '**'
         else:
             outstr += cardname
 
@@ -813,12 +817,16 @@ class Card:
                 outstr += '<i>'
             elif for_forum:
                 outstr += '[i]'
+            elif for_md:
+                outstr += '_'
             else:
                 outstr += utils.dash_marker * 2
 
             for i, (idx, value) in enumerate(self.__dict__[field_other]):
                 if for_html and i > 0:
                     outstr += '<br>\n'
+                elif for_md and i > 0:
+                    outstr += '  \n'
                 else:
                     outstr += linebreak
                 outstr += '(' + str(idx) + ') ' + str(value)
@@ -827,12 +835,14 @@ class Card:
                 outstr += '</i>'
             elif for_forum:
                 outstr += '[/i]'
+            elif for_md:
+                outstr += '_'
 
         if self.bside:
             outstr += linebreak
             if not for_html:
                 outstr += utils.dash_marker * 8 + linebreak
-            outstr += self.bside.format(gatherer=gatherer, for_forum=for_forum and not for_html, for_html=for_html, vdump=vdump, ansi_color=ansi_color)
+            outstr += self.bside.format(gatherer=gatherer, for_forum=for_forum and not for_html, for_html=for_html, vdump=vdump, ansi_color=ansi_color, for_md=for_md)
 
         if for_html:
             outstr += "</div>"

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -1,0 +1,43 @@
+import pytest
+import sys
+import os
+from io import StringIO
+
+# Add lib directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+import cardlib
+import decode
+
+def test_markdown_format():
+    src = "|1Markdown Card|5Creature|6Human|3{W}|81/1|9Lifelink"
+    card = cardlib.Card(src)
+    formatted = card.format(for_md=True)
+    assert "**Markdown Card**" in formatted
+    assert "Creature ~ Human" in formatted
+    assert "(1/1)" in formatted
+    assert "Lifelink" in formatted
+
+def test_decode_markdown_cli(tmp_path):
+    infile = tmp_path / "input.txt"
+    infile.write_text("|1Markdown Card|5Creature|6Human|3{W}|81/1|9Lifelink", encoding="utf-8")
+    outfile = tmp_path / "output.md"
+
+    # Run main via programmatic call
+    decode.main(str(infile), str(outfile), md_out=True, quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert "**Markdown Card**" in content
+    assert "Creature ~ Human (1/1)" in content
+
+def test_decode_markdown_auto_extension(tmp_path):
+    infile = tmp_path / "input.txt"
+    infile.write_text("|1Auto Card|5Sorcery|9Draw a card.", encoding="utf-8")
+    outfile = tmp_path / "output.md"
+
+    # Should detect .md extension
+    decode.main(str(infile), str(outfile), quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert "**Auto Card**" in content


### PR DESCRIPTION
This PR introduces a new Markdown output format to the `decode.py` script, allowing users to generate formatted card text suitable for sharing on GitHub, documentation, or other Markdown-supported platforms.

### Key Changes:
- **`lib/cardlib.py`**: Updated `Card.format()` to support a `for_md` flag, which applies Markdown styling (bolding names, italicizing debug info).
- **`decode.py`**: Added `--md` CLI option and support for automatic format detection from `.md` file extensions.
- **Creativity Mode**: Enhanced `hoverimg` to generate Scryfall links for Markdown output.
- **Tests**: Added `tests/test_markdown_output.py` to ensure correctness and prevent regressions.

This feature follows the "Symmetry" and "Interoperability" heuristics by providing a missing common output format that complements existing HTML, JSON, and CSV exports.

---
*PR created automatically by Jules for task [18124300282197819216](https://jules.google.com/task/18124300282197819216) started by @RainRat*