### PR TITLE
Fix redundant JSON escaping in csv2json.py

### DIFF
--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -44,10 +44,10 @@ with open(args.csv_file) as csvfile, open(args.json_output, 'w') as jsonfile:
         card = {
             "layout": "normal",
             "manaCost": row[1],
-            "name": row[0].replace("\"", ""),
+            "name": row[0],
             "rarity": temprarity,
             "setCode": "CUS",
-            "text": row[4].replace("\\", "\\n").replace("\"", "\\\""),
+            "text": row[4],
         }
         if row[5] != "":
             pt = row[5].split("/")

--- a/tests/test_csv2json.py
+++ b/tests/test_csv2json.py
@@ -1,0 +1,47 @@
+import json
+import os
+import subprocess
+import tempfile
+import pytest
+
+def test_csv2json_escaping():
+    csv_content = 'name,manaCost,types,subtypes,text,pt,rarity\n"""Giant"" Growth","{1}","Creature","Soldier","He said ""Hello"".\\nNew line.","2/2","C"\n'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, 'test.csv')
+        json_path = os.path.join(tmpdir, 'test.json')
+
+        with open(csv_path, 'w', encoding='utf-8') as f:
+            f.write(csv_content)
+
+        # Run scripts/csv2json.py
+        # We assume we are running from the root of the repo
+        script_path = os.path.join(os.getcwd(), 'scripts', 'csv2json.py')
+        subprocess.run(['python3', script_path, csv_path, json_path], check=True)
+
+        with open(json_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        card = data['data']['CUS']['cards'][0]
+        assert card['name'] == '"Giant" Growth'
+        # We expect the text to be exactly as in CSV (after csv.reader parsing)
+        # "He said ""Hello"".\\nNew line." in CSV -> He said "Hello".\nNew line. (literal \ and n)
+        assert card['text'] == 'He said "Hello".\\nNew line.'
+
+def test_csv2json_newlines():
+    # Test with actual newlines in CSV cells (requires quoting)
+    csv_content = 'name,manaCost,types,subtypes,text,pt,rarity\n"Newlines","{0}","Artifact","","Line 1\nLine 2","","C"\n'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, 'test.csv')
+        json_path = os.path.join(tmpdir, 'test.json')
+
+        with open(csv_path, 'w', encoding='utf-8') as f:
+            f.write(csv_content)
+
+        script_path = os.path.join(os.getcwd(), 'scripts', 'csv2json.py')
+        subprocess.run(['python3', script_path, csv_path, json_path], check=True)
+
+        with open(json_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        card = data['data']['CUS']['cards'][0]
+        assert card['text'] == 'Line 1\nLine 2'


### PR DESCRIPTION
This PR addresses a logic bug in the `scripts/csv2json.py` utility where rules text and card names were being manually (and incorrectly) escaped before being passed to `json.dump`.

Key changes:
- Removed `.replace("\\", "\\n")` and `.replace("\"", "\\\"")` from the rules text processing.
- Removed `.replace("\"", "")` from the card name processing.
- Added `tests/test_csv2json.py` to ensure proper JSON output for names with quotes and text with literal `\n`.

These changes ensure that the output JSON correctly represents the source CSV data without character corruption or unintended data loss in names.

---
*PR created automatically by Jules for task [8877018072968974768](https://jules.google.com/task/8877018072968974768) started by @RainRat*