### PR TITLE
[TEST] Fix sentencecase newline preservation and add tests

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -36,6 +36,8 @@ def sentencecase(s):
                 sentences = sent_tokenizer.tokenize(part)
                 cparts += [' '.join([cap(sent) for sent in sentences])]
             clines += [': '.join(cparts)]
+        else:
+            clines += ['']
     return utils.newline.join(clines).replace(utils.reserved_marker, utils.x_marker)
 
 # These are used later to determine what the fields of the Card object are called.

--- a/tests/test_sentencecase.py
+++ b/tests/test_sentencecase.py
@@ -1,0 +1,37 @@
+import pytest
+from lib.cardlib import sentencecase
+from lib import utils
+
+def test_sentencecase_basic():
+    assert sentencecase("hello world") == "Hello world"
+    assert sentencecase("this is a test. another test.") == "This is a test. Another test."
+
+def test_sentencecase_with_activated_ability():
+    assert sentencecase("tap: do something.") == "Tap: Do something."
+    assert sentencecase("{t}: add {w}.") == "{T}: Add {w}."
+
+def test_sentencecase_preserves_empty_lines():
+    # utils.newline is '\\'
+    input_text = f"line 1{utils.newline}{utils.newline}line 2"
+    expected = f"Line 1{utils.newline}{utils.newline}Line 2"
+    assert sentencecase(input_text) == expected
+
+def test_sentencecase_trailing_newline():
+    input_text = f"line 1{utils.newline}"
+    expected = f"Line 1{utils.newline}"
+    assert sentencecase(input_text) == expected
+
+def test_sentencecase_leading_newline():
+    input_text = f"{utils.newline}line 1"
+    expected = f"{utils.newline}Line 1"
+    assert sentencecase(input_text) == expected
+
+def test_sentencecase_multiple_newlines():
+    input_text = f"line 1{utils.newline}{utils.newline}{utils.newline}line 2"
+    expected = f"Line 1{utils.newline}{utils.newline}{utils.newline}Line 2"
+    assert sentencecase(input_text) == expected
+
+def test_sentencecase_only_newlines():
+    input_text = f"{utils.newline}{utils.newline}"
+    expected = f"{utils.newline}{utils.newline}"
+    assert sentencecase(input_text) == expected


### PR DESCRIPTION
I fixed a bug in the `sentencecase` function where empty lines (consecutive newlines) were being lost during the decoding process. I also added a new test file `tests/test_sentencecase.py` to ensure this function is correctly covered and to prevent future regressions.

---
*PR created automatically by Jules for task [5085292161525253996](https://jules.google.com/task/5085292161525253996) started by @RainRat*