### PR TITLE
Remove redundant P/T logic in CSV output

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -121,15 +121,6 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 'loyalty': d.get('loyalty', d.get('defense', '')),
                 'rarity': d.get('rarity', ''),
             }
-            if 'pt' in d and 'power' not in d:
-                    # Handle case where pt is "X/Y" string in to_dict but split in CSV logic
-                    if '/' in d['pt']:
-                        p, t = d['pt'].split('/', 1)
-                        row['power'] = p
-                        row['toughness'] = t
-                    else:
-                        row['power'] = d['pt'] # Fallback?
-
             csv_writer.writerow(row)
 
     def hoverimg(cardname, dist, nd, for_html=False, for_md=False):


### PR DESCRIPTION
Removed a redundant code block in `decode.py` that was responsible for splitting Power/Toughness strings. This functionality is already correctly handled by the `to_dict()` method in `lib/cardlib.py`, making the extra check in `decode.py` unnecessary. verified with tests.

---
*PR created automatically by Jules for task [15328404969176036522](https://jules.google.com/task/15328404969176036522) started by @RainRat*