### PR TITLE
[TEST] [BUGFIX] Fix Manatext placeholder collision with literal '$'

### DIFF
--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -157,6 +157,9 @@ class Manatext:
             self.raw = src
             manastrs = re.findall(utils.mana_regex, src)
             
+        # Escape existing literal reserved_mana_marker characters to avoid collision
+        self.text = self.text.replace(utils.reserved_mana_marker, '\u001e')
+
         for manastr in manastrs:
             cost = Manacost(manastr, fmt)
             if not cost.valid:
@@ -174,7 +177,8 @@ class Manatext:
         text = self.text
         for cost in self.costs:
             text = text.replace(utils.reserved_mana_marker, str(cost), 1)
-        return text
+        # Unescape literal reserved_mana_marker characters
+        return text.replace('\u001e', utils.reserved_mana_marker)
 
     def format(self, for_forum = False, for_html = False, ansi_color = False):
         text = self.text
@@ -182,13 +186,15 @@ class Manatext:
             text = text.replace(utils.reserved_mana_marker, cost.format(for_forum=for_forum, for_html=for_html, ansi_color=ansi_color), 1)
         if for_html:
             text = text.replace('\n', '<br>\n')
-        return text
+        # Unescape literal reserved_mana_marker characters
+        return text.replace('\u001e', utils.reserved_mana_marker)
 
     def encode(self, randomize = False):
         text = self.text
         for cost in self.costs:
             text = text.replace(utils.reserved_mana_marker, cost.encode(randomize = randomize), 1)
-        return text
+        # Unescape literal reserved_mana_marker characters
+        return text.replace('\u001e', utils.reserved_mana_marker)
 
     def vectorize(self):
         text = self.text
@@ -210,4 +216,6 @@ class Manatext:
         text = text.replace('/', '/ /')
         for cost in self.costs:
             text = text.replace(utils.reserved_mana_marker, cost.vectorize(), 1)
+        # Unescape literal reserved_mana_marker characters
+        text = text.replace('\u001e', utils.reserved_mana_marker)
         return ' '.join(text.split())

--- a/tests/test_manatext_collision.py
+++ b/tests/test_manatext_collision.py
@@ -1,0 +1,38 @@
+import pytest
+from lib.manalib import Manatext
+from lib import utils
+
+def test_manatext_placeholder_collision():
+    # utils.reserved_mana_marker is '$'
+    src = "Costs $10. {W}"
+    # When initialized, {W} is replaced by '$'
+    # So internal text becomes "Costs $10. $"
+    mt = Manatext(src, fmt='json')
+
+    # When formatting, the first '$' is replaced by the first cost ({W})
+    # Resulting in "Costs {W}10. $" instead of "Costs $10. {W}"
+    formatted = mt.format()
+
+    # This assertion is expected to FAIL before the fix
+    assert formatted == "Costs $10. {W}"
+
+def test_manatext_multiple_collisions():
+    src = "$1 and $2. {W} {U}"
+    mt = Manatext(src, fmt='json')
+
+    formatted = mt.format()
+    assert formatted == "$1 and $2. {W} {U}"
+
+def test_manatext_encode_collision():
+    src = "Costs $10. {W}"
+    mt = Manatext(src, fmt='json')
+
+    # encode() should also handle the collision
+    encoded = mt.encode()
+    assert encoded == "Costs $10. {WW}" # {W} is encoded as {WW}
+
+def test_manatext_str_collision():
+    src = "Costs $10. {W}"
+    mt = Manatext(src, fmt='json')
+
+    assert str(mt) == "Costs $10. {W}"


### PR DESCRIPTION
This PR addresses a logic bug in the `Manatext` class where literal characters in the source text that match the internal `reserved_mana_marker` (typically `$`) would cause formatting errors. The solution implements a sentinel-based escaping mechanism using `\u001e` as a temporary placeholder.

### Changes:
- Modified `lib/manalib.py`:
    - `Manatext.__init__`: Escape literal `$` characters.
    - `Manatext.__str__`, `Manatext.format`, `Manatext.encode`, `Manatext.vectorize`: Unescape literal `$` characters.
- Added `tests/test_manatext_collision.py`:
    - New test suite covering single and multiple collision scenarios across all relevant methods.


---
*PR created automatically by Jules for task [16077879325218832054](https://jules.google.com/task/16077879325218832054) started by @RainRat*