### PR TITLE
[UI/UX] Organize decode.py output format flags into a titled group

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -415,9 +415,9 @@ if __name__ == '__main__':
 
     # Group: Output Format (Mutually Exclusive)
     # We use a mutually exclusive group to enforce one output format.
-    # Note: We cannot attach this directly to a titled argument group in argparse easily while keeping the title.
-    # So we define the arguments in the main parser but link them via a mutex group.
-    fmt_group = parser.add_mutually_exclusive_group()
+    # By adding the mutex group to a titled argument group, we improve the help output's visual hierarchy.
+    fmt_group_title = parser.add_argument_group('Output Format')
+    fmt_group = fmt_group_title.add_mutually_exclusive_group()
     fmt_group.add_argument('--text', action='store_true',
                            help='Force plain text output (Default unless detected from extension).')
     fmt_group.add_argument('--html', action='store_true',


### PR DESCRIPTION
**Context:** CLI (Command Line Interface)

**Problem:** In `decode.py`, the output format flags (like `--html`, `--json`, etc.) were previously added to the default 'options' group. This caused them to be mixed with the general `-h, --help` flag, making the help output cluttered and these key options harder to discover.

**Solution:** I have reorganized the `argparse` configuration in `decode.py` by creating a titled argument group called 'Output Format' and adding the mutually exclusive format group to it. This cleanly separates the output formats from other processing and logging options, following better visual hierarchy principles for CLI tools.

**Changes:**
*   Modified `decode.py` to use `parser.add_argument_group('Output Format')` and link the mutually exclusive group to it.
*   Updated comments in `decode.py` to reflect the improved organization.

---
*PR created automatically by Jules for task [9231630006299343889](https://jules.google.com/task/9231630006299343889) started by @RainRat*