### PR TITLE
[FEAT] JSON output and limit flags for summarize.py

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -406,3 +406,26 @@ class Datamine:
         elif len(self.unparsed_cards) > 0:
             print('Not summarizing.')
         print('====================')
+
+    def to_dict(self):
+        """Returns a dictionary representation of the collected statistics."""
+        result = {
+            'counts': {
+                'valid': len(self.cards),
+                'invalid': len(self.invalid_cards),
+                'parsed': len(self.allcards),
+                'unparsed': len(self.unparsed_cards),
+            },
+            'indices': {}
+        }
+        for name, index in self.indices.items():
+            result['indices'][name] = {str(k): len(v) for k, v in index.items()}
+
+        if self.by_textlen:
+            result['stats'] = {
+                'textlen_min': min(self.by_textlen),
+                'textlen_max': max(self.by_textlen),
+                'textlines_min': min(self.by_textlines),
+                'textlines_max': max(self.by_textlines),
+            }
+        return result

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import argparse
+import json
 
 libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
 sys.path.append(libdir)
@@ -9,13 +10,16 @@ import utils
 import jdecode
 from datalib import Datamine
 
-def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = False):
+def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = False, limit = 0, json_out = False):
     # Use the robust mtg_open_file for all loading and filtering.
     # We disable default exclusions to match original summarize.py behavior.
     cards = jdecode.mtg_open_file(fname, verbose=verbose, grep=grep,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False)
+
+    if limit > 0:
+        cards = cards[:limit]
 
     card_srcs = []
     for card in cards:
@@ -25,9 +29,12 @@ def main(fname, verbose = True, outliers = False, dump_all = False, grep = None,
             card_srcs.append(card.raw if card.raw else card.encode())
 
     mine = Datamine(card_srcs)
-    mine.summarize(use_color=use_color)
-    if outliers or dump_all:
-        mine.outliers(dump_invalid = dump_all, use_color=use_color)
+    if json_out:
+        print(json.dumps(mine.to_dict(), indent=2))
+    else:
+        mine.summarize(use_color=use_color)
+        if outliers or dump_all:
+            mine.outliers(dump_invalid = dump_all, use_color=use_color)
 
 
 if __name__ == '__main__':
@@ -37,6 +44,8 @@ if __name__ == '__main__':
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
                         help='encoded card file or json corpus to process. Defaults to stdin (-).')
+    io_group.add_argument('--json', action='store_true',
+                        help='Output statistics in JSON format.')
 
     # Group: Processing Options
     proc_group = parser.add_argument_group('Processing Options')
@@ -44,6 +53,8 @@ if __name__ == '__main__':
                         help='show additional diagnostics and edge cases')
     proc_group.add_argument('-a', '--all', action='store_true',
                         help='show all information and dump invalid cards')
+    proc_group.add_argument('-n', '--limit', type=int, default=0,
+                        help='Limit the number of cards to process.')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
     
@@ -68,5 +79,5 @@ if __name__ == '__main__':
     elif args.color is None and sys.stdout.isatty():
         use_color = True
 
-    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = use_color)
+    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = use_color, limit = args.limit, json_out = args.json)
     exit(0)

--- a/tests/test_datalib.py
+++ b/tests/test_datalib.py
@@ -169,6 +169,37 @@ def test_datamine_with_invalid_card():
     finally:
         sys.stdout = old_stdout
 
+def test_datamine_to_dict(datamine_instance):
+    result = datamine_instance.to_dict()
+
+    # Check structure
+    assert 'counts' in result
+    assert 'indices' in result
+    assert 'stats' in result
+
+    # Check counts
+    assert result['counts']['valid'] == 3
+    assert result['counts']['invalid'] == 0
+    assert result['counts']['parsed'] == 3
+    assert result['counts']['unparsed'] == 0
+
+    # Check indices
+    assert 'by_name' in result['indices']
+    assert result['indices']['by_name']['card a'] == 1
+    assert 'by_color' in result['indices']
+    assert result['indices']['by_color']['R'] == 1
+    assert result['indices']['by_color']['U'] == 1
+    assert result['indices']['by_color']['A'] == 1
+
+    # Check stats
+    # Text lengths in sample data: "Text A" (6), "Text B" (6), "Text C" (6)
+    # Note: text.encode() might add newlines or markers.
+    # Manatext("Text A").encode() -> "Text A"
+    assert result['stats']['textlen_min'] == 6
+    assert result['stats']['textlen_max'] == 6
+    assert result['stats']['textlines_min'] == 1
+    assert result['stats']['textlines_max'] == 1
+
 def test_datamine_with_parsed_but_invalid_card():
     # Card that parses (has name/types/etc in roughly correct format)
     # but fails validation (e.g. creature without P/T)


### PR DESCRIPTION
This PR introduces two new features to the `summarize.py` utility to improve its usefulness in automated pipelines and for large datasets:

1. **Machine-Readable Output (`--json`):** A new `--json` flag allows users to get dataset statistics (counts, frequencies, text length stats) in a structured format. This was achieved by adding a `to_dict()` method to the `Datamine` class.
2. **Sampling Support (`--limit`):** A new `-n` / `--limit` flag allows processing only the first N cards of a dataset, which is useful for quick checks or sampling large corpora.

These changes follow the **Interoperability**, **Symmetry**, and **Batching** heuristics, making the summarization tool as flexible as the decoding and encoding tools.

---
*PR created automatically by Jules for task [16413486630503422981](https://jules.google.com/task/16413486630503422981) started by @RainRat*