### PR TITLE
Fix supertype classification in csv2json.py

### DIFF
--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -55,11 +55,17 @@ with open(args.csv_file) as csvfile, open(args.json_output, 'w') as jsonfile:
             card["toughness"] = pt[1]
 
         # supertypes, types, subtypes
-        typelist = row[2].split(" ")
-        if typelist[0] == "Legendary":
-            card["supertypes"] = [typelist[0]]
-            typelist.remove("Legendary")
-        card["types"] = typelist
+        known_supertypes = {'Legendary', 'Basic', 'Snow', 'World', 'Ongoing'}
+        supertypes = []
+        types = []
+        for t in row[2].split():
+            if t in known_supertypes:
+                supertypes.append(t)
+            else:
+                types.append(t)
+        if supertypes:
+            card["supertypes"] = supertypes
+        card["types"] = types
         if row[3] != "":
             card["subtypes"] = row[3].split(" ")
 


### PR DESCRIPTION
Updated `scripts/csv2json.py` to correctly identify and separate multiple MTG supertypes from the type list tokens. Previously, only "Legendary" as the first word was recognized, causing supertypes like "Basic" or "Snow" to be incorrectly classified as regular types. This fix ensures the generated JSON adheres better to MTGJSON standards.

---
*PR created automatically by Jules for task [2916557108581370632](https://jules.google.com/task/2916557108581370632) started by @RainRat*