### PR TITLE
[TEST] [Fix consistency in mtg_open_file exclusions and linetrans]

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -346,7 +346,7 @@ def fields_from_json(src_json, linetrans = True):
     return parsed, valid and fields_check_valid(fields), fields
 
 
-def fields_from_format(src_text, fmt_ordered, fmt_labeled, fieldsep):
+def fields_from_format(src_text, fmt_ordered, fmt_labeled, fieldsep, linetrans = False):
     parsed = True
     valid = True
     fields = {}
@@ -403,6 +403,8 @@ def fields_from_format(src_text, fmt_ordered, fmt_labeled, fieldsep):
             valid = valid and fval.valid
             addf(fields, fname, (idx, fval))
         elif fname in [field_text]:
+            if linetrans:
+                textfield = transforms.text_pass_11_linetrans(textfield)
             fval = Manatext(textfield)
             valid = valid and fval.valid
             addf(fields, fname, (idx, fval))
@@ -469,7 +471,8 @@ class Card:
                                   fieldsep = fieldsep,
                                   linetrans = linetrans)
             p_success, v_success, parsed_fields = fields_from_format(sides[0], fmt_ordered, 
-                                                                     fmt_labeled,  fieldsep)
+                                                                     fmt_labeled,  fieldsep,
+                                                                     linetrans = linetrans)
             self.parsed = p_success
             self.valid = v_success
             self.fields = parsed_fields

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -356,7 +356,18 @@ def mtg_open_file(fname, verbose = False,
 
         for card_src in text.split(utils.cardsep):
             if card_src:
-                card = cardlib.Card(card_src, fmt_ordered=fmt_ordered)
+                card = cardlib.Card(card_src, fmt_ordered=fmt_ordered, linetrans=linetrans)
+
+                # Apply exclusions to cards from encoded text
+                skip = False
+                for cardtype in card.types:
+                    if exclude_types(cardtype):
+                        skip = True
+
+                if skip:
+                    skipped += 1
+                    continue
+
                 # unlike opening from json, we still want to return invalid cards
                 cards += [card]
                 if card.valid:

--- a/tests/test_jdecode_consistency.py
+++ b/tests/test_jdecode_consistency.py
@@ -1,0 +1,75 @@
+
+import sys
+import os
+import unittest
+from io import StringIO
+from unittest.mock import patch
+import tempfile
+import shutil
+
+# Ensure lib is in path
+libdir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'lib')
+if libdir not in sys.path:
+    sys.path.append(libdir)
+
+import jdecode
+import utils
+import cardlib
+
+class TestJDecodeConsistency(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_exclude_types_stdin(self):
+        # Conspiracy card: |5conspiracy|1backup plan|
+        # Standard exclude_types includes 'conspiracy'
+        card_text = "|5conspiracy|1backup plan|"
+
+        with patch('sys.stdin', StringIO(card_text)):
+             # This should return 0 cards if exclude_types is respected
+             cards = jdecode.mtg_open_file('-', verbose=False)
+
+        self.assertEqual(len(cards), 0, "Conspiracy card should be excluded when loading from stdin")
+
+    def test_exclude_types_text_file(self):
+        card_text = "|5conspiracy|1backup plan|"
+        path = os.path.join(self.test_dir, 'cards.txt')
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(card_text)
+
+        # This should return 0 cards if exclude_types is respected
+        cards = jdecode.mtg_open_file(path, verbose=False)
+        self.assertEqual(len(cards), 0, "Conspiracy card should be excluded when loading from single text file")
+
+    def test_linetrans_text_file(self):
+        # Card with lines that would be reordered by linetrans
+        # Original:
+        # destroy target creature.
+        # flying
+        # linetrans (True) should put 'flying' first.
+        # |5creature|9destroy target creature.\flying|1test|
+
+        # We need to use a format that linetrans actually affects.
+        # In cardlib.py, text_pass_11_linetrans reorders lines.
+
+        card_text = "|5creature|1test|9destroy target creature.\\flying|"
+        path = os.path.join(self.test_dir, 'cards.txt')
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(card_text)
+
+        # 1. With linetrans=True (default)
+        cards_true = jdecode.mtg_open_file(path, verbose=False, linetrans=True)
+        text_true = cards_true[0].text.encode()
+        # linetrans should put 'flying' (keyline) before 'destroy...' (mainline)
+        self.assertTrue(text_true.startswith("flying"), f"Expected text to start with 'flying', got: {text_true}")
+
+        # 2. With linetrans=False
+        cards_false = jdecode.mtg_open_file(path, verbose=False, linetrans=False)
+        text_false = cards_false[0].text.encode()
+        self.assertTrue(text_false.startswith("destroy"), f"Expected text to start with 'destroy', got: {text_false}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Type: Gap Analysis / Bug Fix
* What: Implemented missing `exclude_types` filtering and `linetrans` propagation in `jdecode.mtg_open_file` for single text files and stdin. Added `tests/test_jdecode_consistency.py` to verify this behavior.
* Why: Ensure that all input sources (JSON, CSV, directory, single file, stdin) follow the same filtering and transformation rules, preventing inconsistencies when processing different dataset formats.

---
*PR created automatically by Jules for task [3192112637809309242](https://jules.google.com/task/3192112637809309242) started by @RainRat*