### PR TITLE
[UI/UX] Improve visual hierarchy in card formatting

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -891,6 +891,10 @@ class Card:
                     outstr += ' ((' + loyalty + '))'
 
         if formatted_mtext:
+            # Add a blank line before the rules text for better readability
+            # in plain text, color, and markdown formats.
+            if not for_html and not for_forum:
+                outstr += linebreak
             outstr += linebreak + formatted_mtext
 
         if not gatherer:

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -87,7 +87,7 @@ def test_card_format(sample_card_json):
     gatherer_output = card.format(gatherer=True)
     expected_gatherer_output = (
         "Ornithopter {0} (uncommon)\n"
-        "Artifact Creature ~ Thopter (0/2)\n"
+        "Artifact Creature ~ Thopter (0/2)\n\n"
         "Flying"
     )
     assert gatherer_output == expected_gatherer_output
@@ -96,7 +96,7 @@ def test_card_format(sample_card_json):
     default_output = card.format(gatherer=False)
     expected_default_output = (
         "Ornithopter {0}\n"
-        "Artifact Creature ~ Thopter (uncommon)\n"
+        "Artifact Creature ~ Thopter (uncommon)\n\n"
         "Flying\n"
         "(0/2)"
     )
@@ -118,7 +118,7 @@ def test_card_format(sample_card_json):
     # Construction of default format with colors
     expected_colored_output = (
         f"{expected_name} {expected_cost}\n"
-        f"{expected_type} ({expected_rarity})\n"
+        f"{expected_type} ({expected_rarity})\n\n"
         "Flying\n"
         f"({expected_pt})"
     )


### PR DESCRIPTION
Improved visual hierarchy in card formatting by adding a blank line between the card metadata (name, cost, type line) and the rules text. This significantly enhances readability in CLI, plain text, and Markdown outputs. Verified the change with existing tests and manual CLI testing.

---
*PR created automatically by Jules for task [580115409547541844](https://jules.google.com/task/580115409547541844) started by @RainRat*