### PR TITLE
[FEAT] Compact Summary Output Format for decode.py

### DIFF
--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -124,6 +124,24 @@ def test_card_format(sample_card_json):
     )
     assert colored_output == expected_colored_output
 
+def test_card_summary(sample_card_json):
+    card = Card(sample_card_json)
+
+    # Test plain summary
+    output = card.summary()
+    assert output == "[U] Ornithopter {0} - Artifact Creature ~ Thopter - 0/2"
+
+    # Test colored summary
+    colored_output = card.summary(ansi_color=True)
+    expected_name = utils.colorize("Ornithopter", utils.Ansi.BOLD + utils.Ansi.CYAN)
+    expected_cost = utils.colorize("{0}", utils.Ansi.CYAN)
+    expected_type = utils.colorize("Artifact Creature ~ Thopter", utils.Ansi.GREEN)
+    expected_pt = utils.colorize("0/2", utils.Ansi.RED)
+    expected_rarity_indicator = utils.colorize("U", utils.Ansi.BOLD + utils.Ansi.CYAN)
+
+    expected_colored_summary = f"[{expected_rarity_indicator}] {expected_name} {expected_cost} - {expected_type} - {expected_pt}"
+    assert colored_output == expected_colored_summary
+
 def test_planeswalker_to_mse_formatting():
     planeswalker_json = {
         "name": "Jules, the Wise",

--- a/tests/test_decode_autoformat.py
+++ b/tests/test_decode_autoformat.py
@@ -43,6 +43,16 @@ def test_auto_format_csv(encoded_file, tmp_path):
     content = outfile.read_text()
     assert 'name,mana_cost,type' in content
 
+def test_auto_format_summary(encoded_file, tmp_path):
+    outfile = tmp_path / "output.sum"
+    run_decode(encoded_file, str(outfile))
+
+    assert outfile.exists()
+    content = outfile.read_text()
+    # Summary format: [?] Test Card - Creature
+    assert 'Test Card' in content
+    assert '-' in content
+
 def test_explicit_flag_overrides_extension(encoded_file, tmp_path):
     # Extension is .json but we force --text
     outfile = tmp_path / "output.json"


### PR DESCRIPTION
Identified a "missing piece" of functionality for scanning large generated datasets and implemented a compact, one-line summary output format in `decode.py`. This feature provides immediate value for data analysis and conforms to the project's existing patterns.

---
*PR created automatically by Jules for task [6705694102803702222](https://jules.google.com/task/6705694102803702222) started by @RainRat*