### PR TITLE
Fix IndexError in scripts/csv2json.py P/T parsing

### DIFF
--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -51,8 +51,11 @@ with open(args.csv_file) as csvfile, open(args.json_output, 'w') as jsonfile:
         }
         if row[5] != "":
             pt = row[5].split("/")
-            card["power"] = pt[0]
-            card["toughness"] = pt[1]
+            if len(pt) >= 2:
+                card["power"] = pt[0]
+                card["toughness"] = pt[1]
+            else:
+                card["pt"] = row[5]
 
         # supertypes, types, subtypes
         known_supertypes = {'Legendary', 'Basic', 'Snow', 'World', 'Ongoing'}


### PR DESCRIPTION
The patch addresses a logic bug in `scripts/csv2json.py` where a potential `IndexError` could occur if the P/T (Power/Toughness) field in the input CSV does not contain the expected forward-slash separator (`/`).

I added a check for the number of parts after `split("/")`. If the slash is present, it continues splitting into `power` and `toughness`. If the slash is absent, it assigns the entire string to a `pt` key in the card dictionary, which is consistent with how the rest of the codebase handles such data.

Verified with a new test case and ensured all existing tests pass.

---
*PR created automatically by Jules for task [9217696607937162572](https://jules.google.com/task/9217696607937162572) started by @RainRat*