### PR TITLE
[DOCS] Add missing file extensions to README auto-detection list

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If you provide an output filename, the tool automatically selects the format bas
 *   `.json` -> JSON data
 *   `.csv`  -> CSV spreadsheet
 *   `.md`   -> Markdown document
+*   `.sum`, `.summary` -> Compact one-line summary
 *   `.mse-set` -> Magic Set Editor file
 
 ### Power User Tip: Piping


### PR DESCRIPTION
Updated the README.md to include the missing '.sum' and '.summary' file extensions in the "Automatic Format Detection" section for decode.py. This ensures users are aware that these extensions can be used to automatically trigger the compact one-line summary output format. Removed temporary verification files and followed strict documentation style guidelines.

---
*PR created automatically by Jules for task [5502127155011530790](https://jules.google.com/task/5502127155011530790) started by @RainRat*