### PR TITLE
[UI/UX] Improve encode.py CLI flexibility and feedback

### DIFF
--- a/encode.py
+++ b/encode.py
@@ -44,7 +44,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
     final_sep = config.get('final_sep', final_sep)
 
     if verbose:
-        print('Preparing to encode:', file=sys.stderr)
+        print(utils.colorize('Preparing to encode:', utils.Ansi.BOLD + utils.Ansi.CYAN), file=sys.stderr)
         print('  Using encoding ' + repr(encoding), file=sys.stderr)
         if stable:
             print('  NOT randomizing order of cards.', file=sys.stderr)
@@ -82,7 +82,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     if oname:
         if verbose:
-            print('Writing output to: ' + oname, file=sys.stderr)
+            print(utils.colorize('Writing output to: ', utils.Ansi.BOLD + utils.Ansi.CYAN) + oname, file=sys.stderr)
         with open(oname, 'w', encoding='utf8') as ofile:
             writecards(ofile)
     else:
@@ -96,8 +96,8 @@ if __name__ == '__main__':
     
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
-    io_group.add_argument('infile',
-                        help='Input JSON file containing card data (e.g., AllPrintings.json), a CSV file, or an already encoded file.')
+    io_group.add_argument('infile', nargs='?', default='-',
+                        help='Input JSON file containing card data (e.g., AllPrintings.json), a CSV file, or an already encoded file. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console (stdout).')
 


### PR DESCRIPTION
The `encode.py` script now supports defaulting to standard input (`-`) if the `infile` argument is omitted, matching the behavior of `decode.py` and `summarize.py`. Additionally, `lib/jdecode.py` has been enhanced with automatic format detection for stdin, enabling it to correctly process JSON or CSV data from pipes even when the generic stdin argument is used. Finally, `encode.py` now utilizes ANSI colorization for its verbose status messages, providing better visual feedback and consistency with other tools in the repository.

---
*PR created automatically by Jules for task [13957390920954031126](https://jules.google.com/task/13957390920954031126) started by @RainRat*