### PR TITLE
Inline redundant sort_cmc wrapper in sortlib.py

### DIFF
--- a/lib/sortlib.py
+++ b/lib/sortlib.py
@@ -43,10 +43,6 @@ def sort_type(card_set):
 
     return sorted(card_set, key=type_priority)
 
-def sort_cmc(card_set):
-    """Sorts cards by their converted mana cost."""
-    return sorted(card_set, key=lambda c: c.cost.cmc)
-
 def sort_cards(cards, criterion, quiet=False):
     """Sorts a list of cards based on the specified criterion."""
     if not criterion:
@@ -55,7 +51,7 @@ def sort_cards(cards, criterion, quiet=False):
     if criterion == 'name':
         return sorted(cards, key=lambda c: c.name.lower())
     elif criterion == 'cmc':
-        return sort_cmc(cards)
+        return sorted(cards, key=lambda c: c.cost.cmc)
     elif criterion == 'color':
         # Flatten the list of lists returned by sort_colors
         segments = sort_colors(cards, quiet=quiet)


### PR DESCRIPTION
This PR inlines the `sort_cmc` function into `sort_cards` within `lib/sortlib.py`. `sort_cmc` was a redundant wrapper that merely called `sorted` with a specific key and was used only once. This change simplifies the codebase and makes the sorting logic in `sort_cards` more consistent with other branches (like 'name' sorting) that already use inline logic. All tests passed, ensuring no change in external behavior.

---
*PR created automatically by Jules for task [10872164653411356010](https://jules.google.com/task/10872164653411356010) started by @RainRat*