### PR TITLE
[TEST] Improve sentencecase capitalization for choice options

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -31,13 +31,17 @@ def sentencecase(s):
     clines = []
     for line in lines:
         if line:
-            # First, split by ": " to handle activated abilities
-            parts = line.split(': ')
+            # Split by ": " to handle activated abilities
+            # and by " =" to handle choice options
+            parts = re.split(r'(: | =)', line)
             cparts = []
             for part in parts:
-                sentences = sent_tokenizer.tokenize(part)
-                cparts += [' '.join([cap(sent) for sent in sentences])]
-            clines += [': '.join(cparts)]
+                if part in [': ', ' =']:
+                    cparts += [part]
+                else:
+                    sentences = sent_tokenizer.tokenize(part)
+                    cparts += [' '.join([cap(sent) for sent in sentences])]
+            clines += [''.join(cparts)]
         else:
             clines += ['']
     return utils.newline.join(clines).replace(utils.reserved_marker, utils.x_marker)

--- a/tests/test_sentencecase.py
+++ b/tests/test_sentencecase.py
@@ -48,3 +48,10 @@ def test_sentencecase_with_x_marker():
     input_text = f"{utils.x_marker} is the number of cards in your hand."
     result = sentencecase(input_text)
     assert result == f"{utils.x_marker} is the number of cards in your hand."
+
+def test_sentencecase_choice_options():
+    # Options in choice blocks should be capitalized.
+    # Choice format: [&^ =option 1 =option 2]
+    input_text = "[&^ =deal 3 damage =draw a card]"
+    expected = "[&^ =Deal 3 damage =Draw a card]"
+    assert sentencecase(input_text) == expected


### PR DESCRIPTION
This PR addresses a gap in the `sentencecase` function where options within choice blocks (e.g., `[&^ =deal 3 damage =draw a card]`) were not being capitalized during decoding. 

The fix involves:
1.  Updating `sentencecase` to split text using `re.split(r'(: | =)', line)`.
2.  Ensuring both the activated ability colon and the choice option marker are treated as boundaries for sentence-style capitalization.
3.  Adding a comprehensive test case to `tests/test_sentencecase.py` covering this scenario.

All existing tests pass, and the new test correctly validates the improvement.

---
*PR created automatically by Jules for task [7529817988383580799](https://jules.google.com/task/7529817988383580799) started by @RainRat*