### PR TITLE
[DOCS] Improve CLI help strings for decode.py

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -366,7 +366,7 @@ if __name__ == '__main__':
     io_group.add_argument('infile', nargs='?', default='-',
                         help='Input file containing encoded cards (or a JSON/CSV corpus) to decode. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
-                        help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .csv, .mse-set).')
+                        help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .csv, .md, .sum, .summary, .mse-set).')
 
     # Group: Output Format (Mutually Exclusive)
     # We use a mutually exclusive group to enforce one output format.
@@ -399,9 +399,9 @@ if __name__ == '__main__':
     # We provide a --raw flag to disable it.
     # We also keep -g for backward compatibility but make it a no-op that ensures True.
     content_group.add_argument('-g', '--gatherer', action='store_true', default=True,
-                        help='Explicitly enable Gatherer formatting (Default).')
+                        help='Format text like the official Gatherer website (Default).')
     content_group.add_argument('--raw', '--no-gatherer', dest='gatherer', action='store_false',
-                        help='Output raw text without Gatherer formatting.')
+                        help='Output raw text without any special formatting.')
 
     content_group.add_argument('-f', '--forum', action='store_true',
                         help='Use pretty formatting for mana symbols (compatible with MTG Salvation forums).')
@@ -417,13 +417,13 @@ if __name__ == '__main__':
     # Group: Processing & Debugging
     proc_group = parser.add_argument_group('Processing & Debugging')
     proc_group.add_argument('-c', '--creativity', action='store_true',
-                        help="Enable 'creativity' mode: calculate similarity to existing cards using CBOW (slow).")
+                        help="Calculate how unique these cards are compared to real Magic cards (requires Word2Vec).")
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Limit the number of cards to decode.')
     proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc'],
                         help='Sort cards by the specified criterion.')
     proc_group.add_argument('-d', '--dump', action='store_true',
-                        help='Debug mode: print detailed information about cards that failed to validate.')
+                        help='Show detailed debug information for cards that were not processed correctly.')
     proc_group.add_argument('-v', '--verbose', action='store_true',
                         help='Enable verbose output.')
     proc_group.add_argument('-q', '--quiet', action='store_true',


### PR DESCRIPTION
This submission improves the internal CLI help strings for `decode.py` to make the tool more accessible and user-friendly for a global audience. 

Key improvements:
*   **Accurate Format Detection:** Updated the `outfile` help text to include previously unlisted but supported file extensions (`.md`, `.sum`, `.summary`).
*   **Reduced Technical Jargon:** Simplified the description of the `--creativity` flag to focus on its function (measuring card uniqueness) rather than the underlying algorithm (CBOW).
*   **Clarified Formatting Options:** Provided clearer explanations for the `--gatherer` and `--raw` flags, explaining their impact on the output appearance.
*   **Better Debugging Guidance:** Refined the `--dump` flag description to better explain its purpose in troubleshooting card processing issues.

These changes follow the project's documentation guidelines for simplicity, Plain English, and active voice. All tests passed, ensuring no regressions were introduced.

---
*PR created automatically by Jules for task [4666958028566701443](https://jules.google.com/task/4666958028566701443) started by @RainRat*