### PR TITLE
Refactor MTG type splitting logic into centralized utility

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -32,15 +32,7 @@ def mtg_open_csv_reader(reader, verbose = False):
 
         # Split type into supertypes and types
         full_type = row.get('type', '')
-        supertypes = []
-        types = []
-        # Standard MTG supertypes
-        known_supertypes = {'Legendary', 'Basic', 'Snow', 'World', 'Ongoing'}
-        for t in full_type.split():
-            if t in known_supertypes:
-                supertypes.append(t)
-            else:
-                types.append(t)
+        supertypes, types = utils.split_types(full_type)
         card_dict['supertypes'] = supertypes
         card_dict['types'] = types
 
@@ -268,12 +260,7 @@ def mtg_open_mse_content(content, verbose=False):
 
         # Split types
         full_type = c.get('super type', '')
-        supertypes = []
-        types = []
-        known_supertypes = {'Legendary', 'Basic', 'Snow', 'World', 'Ongoing'}
-        for t in full_type.split():
-            if t in known_supertypes: supertypes.append(t)
-            else: types.append(t)
+        supertypes, types = utils.split_types(full_type)
         d['supertypes'] = supertypes
         d['types'] = types
 
@@ -312,11 +299,7 @@ def mtg_open_mse_content(content, verbose=False):
             if c.get('toughness 2'): b['toughness'] = c['toughness 2']
             if c.get('loyalty 2'): b['loyalty'] = c['loyalty 2']
             full_type_2 = c.get('super type 2', '')
-            supertypes_2 = []
-            types_2 = []
-            for t in full_type_2.split():
-                if t in known_supertypes: supertypes_2.append(t)
-                else: types_2.append(t)
+            supertypes_2, types_2 = utils.split_types(full_type_2)
             b['supertypes'] = supertypes_2
             b['types'] = types_2
             subtypes_2 = c.get('sub type 2', '')

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -557,6 +557,21 @@ def from_symbols(s, for_forum=False, for_html=False):
 
 unletters_regex = r"[^abcdefghijklmnopqrstuvwxyz']"
 
+# MTG Constants
+known_supertypes = {'Legendary', 'Basic', 'Snow', 'World', 'Ongoing'}
+
+def split_types(full_type):
+    """Splits a type line string into supertypes and types."""
+    supertypes = []
+    types = []
+    for t in full_type.split():
+        if t in known_supertypes:
+            supertypes.append(t)
+        else:
+            types.append(t)
+    return supertypes, types
+
+
 class Ansi:
     RESET = '\033[0m'
     BOLD = '\033[1m'

--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -1,6 +1,13 @@
 import csv
 import argparse
 import json
+import os
+import sys
+
+# Ensure lib is in path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+import utils
 
 #convert a CSV file (that follows a specific format) to JSON, If you want to have custom cards in whole or part of your training.
 
@@ -58,14 +65,7 @@ with open(args.csv_file) as csvfile, open(args.json_output, 'w') as jsonfile:
                 card["pt"] = row[5]
 
         # supertypes, types, subtypes
-        known_supertypes = {'Legendary', 'Basic', 'Snow', 'World', 'Ongoing'}
-        supertypes = []
-        types = []
-        for t in row[2].split():
-            if t in known_supertypes:
-                supertypes.append(t)
-            else:
-                types.append(t)
+        supertypes, types = utils.split_types(row[2])
         if supertypes:
             card["supertypes"] = supertypes
         card["types"] = types


### PR DESCRIPTION
Centralized the logic for identifying and splitting MTG supertypes (Legendary, Basic, Snow, World, Ongoing) from card types into a new utility function in lib/utils.py. Updated lib/jdecode.py and scripts/csv2json.py to use this centralized logic, reducing code duplication and improving maintainability.

---
*PR created automatically by Jules for task [4310602354403556903](https://jules.google.com/task/4310602354403556903) started by @RainRat*