### PR TITLE
[UI/UX] Improve scannability of decoded cards with dividers

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -194,8 +194,23 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
             writer.write(utils.html_append)
             return
 
+        first = True
         for card in tqdm(cards, disable=quiet, desc="Decoding"):
+            if not first and not (for_html or for_md or for_mse or for_summary):
+                # Add a divider between cards for console output
+                use_color = False
+                if color_arg is True:
+                    use_color = True
+                elif color_arg is None and writer == sys.stdout and sys.stdout.isatty():
+                    use_color = True
+
+                divider = '-' * 40
+                if use_color:
+                    divider = utils.colorize(divider, utils.Ansi.BOLD + utils.Ansi.CYAN)
+                writer.write(divider + '\n')
+
             writecard(writer, card, for_md=for_md, for_summary=for_summary)
+            first = False
 
         if for_mse:
             # more formatting info


### PR DESCRIPTION
**PR Title:** [UI/UX] [CLI] Improve scannability of decoded cards with dividers

**Description:**
* **Context:** CLI
* **Problem:** When decoding a large batch of cards to the console, the output lacks clear visual boundaries between cards. Since individual cards often contain internal blank lines and vary in length, it's difficult for users to quickly scan the list and identify the start of each card.
* **Solution:** Insert a horizontal dashed divider between cards when outputting in plain text or ANSI color format. The divider is colorized (Bold Cyan) to provide a clear but non-intrusive visual anchor. This divider is automatically omitted when exporting to structured formats (JSON, CSV, HTML, Markdown, MSE) or using the high-density summary mode.

**Changes:**
- Modified `decode.py` to insert a dashed divider between cards in the `writecards` loop.
- Logic detects whether color should be used for the divider based on `color_arg` and terminal TTY status.
- Divider is suppressed for HTML, Markdown, MSE, and summary formats to preserve their specific layouts.

---
*PR created automatically by Jules for task [8588770112064892510](https://jules.google.com/task/8588770112064892510) started by @RainRat*