### PR TITLE
[DOCS] Improve CLI help strings for core tools

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -422,7 +422,10 @@ if __name__ == '__main__':
     # Group: Content Formatting
     content_group = parser.add_argument_group('Content Formatting')
     content_group.add_argument('-e', '--encoding', default='std', choices=utils.formats,
-                        help="Format of the input data. Default is 'std' (standard).")
+                        help="Card data format: 'std' (name last, default), 'named' (name first), "
+                             "'noname' (no name), 'rfields' (random field order), "
+                             "'old' (legacy), 'norarity' (no rarity), 'vec' (vectorized), "
+                             "or 'custom' (user-defined).")
 
     # Gatherer formatting is on by default.
     parser.set_defaults(gatherer=True)

--- a/encode.py
+++ b/encode.py
@@ -109,7 +109,10 @@ if __name__ == '__main__':
     # Group: Encoding Options
     enc_group = parser.add_argument_group('Encoding Options')
     enc_group.add_argument('-e', '--encoding', default='std', choices=utils.formats,
-                        help="Format for the output data. 'std' (default) puts the name last. 'named' puts the name first. 'vec' produces a vectorized format for training.",
+                        help="Card data format: 'std' (name last, default), 'named' (name first), "
+                             "'noname' (no name), 'rfields' (random field order), "
+                             "'old' (legacy), 'norarity' (no rarity), 'vec' (vectorized), "
+                             "or 'custom' (user-defined).",
     )
     enc_group.add_argument('--nolabel', action='store_true',
                         help="Remove field labels (e.g., '|cost|') from the output.")

--- a/sortcards.py
+++ b/sortcards.py
@@ -205,7 +205,10 @@ Supports any encoding format supported by encode.py/decode.py.""",
     # Group: Encoding Options
     enc_group = parser.add_argument_group('Encoding Options')
     enc_group.add_argument('-e', '--encoding', default='std', choices=utils.formats,
-                        help="Format of the input data. 'std' (default) puts the name last. 'named' puts the name first. Must match the format of the input file.")
+                        help="Card data format: 'std' (name last, default), 'named' (name first), "
+                             "'noname' (no name), 'rfields' (random field order), "
+                             "'old' (legacy), 'norarity' (no rarity), 'vec' (vectorized), "
+                             "or 'custom' (user-defined).")
 
     # Group: Processing Options
     proc_group = parser.add_argument_group('Processing Options')


### PR DESCRIPTION
Improved the CLI help text for the `--encoding` flag across all main scripts to clearly explain the purpose of each available format (std, named, noname, rfields, old, norarity, vec, and custom). This change ensures consistency across the tools and helps users select the correct format for their needs.

---
*PR created automatically by Jules for task [125787047041609069](https://jules.google.com/task/125787047041609069) started by @RainRat*