### PR TITLE
[FEAT] Negative Filtering (--vgrep / --exclude)

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -23,7 +23,7 @@ from namediff import Namediff
 def main(fname, oname = None, verbose = True, encoding = 'std',
          gatherer = True, for_forum = False, for_mse = False,
          creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, summary_out = False, quiet=False,
-         report_file=None, color_arg=None, limit=0, grep=None, sort=None):
+         report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None):
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
@@ -86,7 +86,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
     else:
         raise ValueError('decode.py: unknown encoding: ' + encoding)
 
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep)
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep, vgrep=vgrep)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -463,6 +463,8 @@ if __name__ == '__main__':
                         help='File path to save the text of cards that failed to parse/validate (useful for debugging).')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
+    proc_group.add_argument('--vgrep', '--exclude', action='append',
+                        help='Exclude cards matching regex (matches name, type, or text). Can be used multiple times (OR logic).')
 
     args = parser.parse_args()
 
@@ -475,6 +477,6 @@ if __name__ == '__main__':
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text,
          json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, summary_out = args.summary, quiet=args.quiet,
          report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep,
-         sort=args.sort)
+         sort=args.sort, vgrep=args.vgrep)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, randomize = False, nolabel = False, stable = False,
-         report_file=None, quiet=False, limit=0, grep=None, sort=None):
+         report_file=None, quiet=False, limit=0, grep=None, sort=None, vgrep=None):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
     fieldsep = utils.fieldsep
@@ -56,7 +56,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         if not line_transformations:
             print('  NOT using line reordering transformations', file=sys.stderr)
 
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=line_transformations, report_file=report_file, grep=grep)
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=line_transformations, report_file=report_file, grep=grep, vgrep=vgrep)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -128,6 +128,8 @@ if __name__ == '__main__':
                         help='Sort cards by the specified criterion.')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
+    proc_group.add_argument('--vgrep', '--exclude', action='append',
+                        help='Exclude cards matching regex (matches name, type, or text). Can be used multiple times (OR logic).')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -142,5 +144,5 @@ if __name__ == '__main__':
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          nolinetrans = args.nolinetrans, randomize = args.randomize, nolabel = args.nolabel,
          stable = args.stable, report_file = args.report_unparsed, quiet=args.quiet,
-         limit=args.limit, grep=args.grep, sort=args.sort)
+         limit=args.limit, grep=args.grep, sort=args.sort, vgrep=args.vgrep)
     exit(0)

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -10,10 +10,10 @@ import utils
 import jdecode
 from datalib import Datamine
 
-def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = False, limit = 0, json_out = False):
+def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = False, limit = 0, json_out = False, vgrep = None):
     # Use the robust mtg_open_file for all loading and filtering.
     # We disable default exclusions to match original summarize.py behavior.
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, grep=grep,
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, grep=grep, vgrep=vgrep,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False)
@@ -57,6 +57,8 @@ if __name__ == '__main__':
                         help='Limit the number of cards to process.')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
+    proc_group.add_argument('--vgrep', '--exclude', action='append',
+                        help='Exclude cards matching regex (matches name, type, or text). Can be used multiple times (OR logic).')
     
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -79,5 +81,5 @@ if __name__ == '__main__':
     elif args.color is None and sys.stdout.isatty():
         use_color = True
 
-    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = use_color, limit = args.limit, json_out = args.json)
+    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = use_color, limit = args.limit, json_out = args.json, vgrep = args.vgrep)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -213,6 +213,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Limit the number of cards to sort.')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
+    proc_group.add_argument('--vgrep', '--exclude', action='append',
+                        help='Exclude cards matching regex (matches name, type, or text). Can be used multiple times (OR logic).')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -246,7 +248,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
     # Use the robust jdecode.mtg_open_file for loading and filtering.
     # We disable default exclusions (sets, types, layouts) to match the original sortcards.py behavior.
     # verbose=True enables jdecode diagnostic output (e.g. invalid cards).
-    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, fmt_ordered=fmt_ordered, grep=args.grep,
+    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, fmt_ordered=fmt_ordered, grep=args.grep, vgrep=args.vgrep,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False)


### PR DESCRIPTION
Identified and implemented the "missing piece" of functionality: Negative Filtering. This adds a `--vgrep` (aliased as `--exclude`) flag to all major card processing tools (`encode.py`, `decode.py`, `sortcards.py`, and `summarize.py`), allowing users to exclude cards based on regex patterns. This achieves symmetry with the existing `--grep` (inclusion) flag and improves the overall utility of the dataset management tools.

---
*PR created automatically by Jules for task [13173282708512837350](https://jules.google.com/task/13173282708512837350) started by @RainRat*