### PR TITLE
Refactor Manatext.__str__ to eliminate duplication

### DIFF
--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -174,11 +174,7 @@ class Manatext:
             self.valid = False
 
     def __str__(self):
-        text = self.text
-        for cost in self.costs:
-            text = text.replace(utils.reserved_mana_marker, str(cost), 1)
-        # Unescape literal reserved_mana_marker characters
-        return text.replace('\u001e', utils.reserved_mana_marker)
+        return self.format()
 
     def format(self, for_forum = False, for_html = False, ansi_color = False):
         text = self.text


### PR DESCRIPTION
This PR refactors the `Manatext.__str__` method in `lib/manalib.py` to use the existing `self.format()` method. This change eliminates duplicated logic for mana marker replacement and character unescaping, improving maintainability while remaining a non-breaking, atomic improvement. All 248 tests passed.

---
*PR created automatically by Jules for task [2167338462765596302](https://jules.google.com/task/2167338462765596302) started by @RainRat*