### PR TITLE
[DOCS] Standardize and improve CLI help strings

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -393,9 +393,9 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input file containing encoded cards (or a JSON/CSV corpus) to decode. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
-                        help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .csv, .md, .sum, .summary, .mse-set).')
+                        help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .jsonl, .csv, .md, .sum, .summary, .mse-set).')
 
     # Group: Output Format (Mutually Exclusive)
     # We use a mutually exclusive group to enforce one output format.

--- a/encode.py
+++ b/encode.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input JSON file containing card data (e.g., AllPrintings.json), a CSV/JSONL file, or an already encoded file. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console (stdout).')
 

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='encoded card file or JSON/JSONL corpus to process. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('--json', action='store_true',
                         help='Output statistics in JSON format.')
 

--- a/sortcards.py
+++ b/sortcards.py
@@ -198,7 +198,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Path to the encoded card file to sort. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console (stdout).')
 


### PR DESCRIPTION
This PR improves the project's internal help strings for better accuracy, consistency, and accessibility.

Key changes:
- Unified the description of the `infile` positional argument across all main scripts (`encode.py`, `decode.py`, `sortcards.py`, and `summarize.py`).
- Clarified that these tools support multiple card data formats (JSON, JSONL, CSV, and MSE archives) as well as directory input.
- Added `.jsonl` to the list of auto-detected file extensions for the `outfile` argument in `decode.py`.
- Followed style guidelines by using plain English and removing jargon.

All changes were verified by running the `--help` command for each script and passing the full test suite.

---
*PR created automatically by Jules for task [16922553881661892454](https://jules.google.com/task/16922553881661892454) started by @RainRat*