### PR TITLE
[UI/UX] Improve CLI table alignment for colorized output

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -11,16 +11,16 @@ def padrows(l):
     for ll in l:
         for i, field in enumerate(ll):
             if i < len(lens):
-                lens[i] = max(len(str(field)), lens[i])
+                lens[i] = max(utils.visible_len(str(field)), lens[i])
             else:
-                lens += [len(str(field))]
+                lens += [utils.visible_len(str(field))]
     # now pad out to that length
     padded = []
     for ll in l:
         padded += ['']
         for i, field in enumerate(ll):
             s = str(field)
-            pad = ' ' * (lens[i] - len(s))
+            pad = ' ' * (lens[i] - utils.visible_len(s))
             padded[-1] += (s + pad + ' ')
     return padded
 def printrows(l):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -587,3 +587,10 @@ def colorize(text, color_code):
     if not text:
         return text
     return f"{color_code}{text}{Ansi.RESET}"
+
+# Regular expression for matching ANSI escape sequences
+_ansi_escape_re = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
+def visible_len(s):
+    """Returns the length of a string without ANSI escape sequences."""
+    return len(_ansi_escape_re.sub('', s))

--- a/tests/test_datalib.py
+++ b/tests/test_datalib.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..',
 
 from datalib import Datamine, padrows, index_size, inc, plimit
 from cardlib import Card
+import utils
 
 # Sample Data Fixture
 @pytest.fixture
@@ -67,6 +68,31 @@ def test_padrows():
     assert len(padded) == 2
     assert padded[0].strip() == 'A   BB'
     assert padded[1].strip() == 'CCC D'
+
+def test_padrows_with_color():
+    color_text = utils.colorize("1", utils.Ansi.BOLD + utils.Ansi.GREEN)
+    data = [
+        ['Index', 'Count'],
+        ['A', color_text],
+        ['LongIndexName', '10']
+    ]
+    padded = padrows(data)
+
+    # Column 0: Index(5), A(1), LongIndexName(13) -> lens[0] = 13
+    # Column 1: Count(5), color_text(visible 1), 10(2) -> lens[1] = 5
+
+    # Row 0: 'Index' + 8 spaces + 1 space + 'Count' + 0 spaces + 1 space = 20 chars
+    # Row 1: 'A' + 12 spaces + 1 space + color_text + 4 spaces + 1 space = 20 chars (visible)
+    # Row 2: 'LongIndexName' + 0 spaces + 1 space + '10' + 3 spaces + 1 space = 20 chars
+
+    assert utils.visible_len(padded[0]) == 13 + 1 + 5 + 1
+    assert utils.visible_len(padded[1]) == 13 + 1 + 5 + 1
+    assert utils.visible_len(padded[2]) == 13 + 1 + 5 + 1
+
+    # Check that they start at the same position
+    assert padded[0].find('Count') == 14
+    assert padded[1].find(color_text) == 14
+    assert padded[2].find('10') == 14
 
 def test_index_size():
     d = {'a': [1, 2], 'b': [3]}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -248,3 +248,16 @@ def test_colorize_combined():
     color = utils.Ansi.BOLD + utils.Ansi.RED
     expected = f"\033[1m\033[91mBold Red\033[0m"
     assert utils.colorize(text, color) == expected
+
+def test_visible_len():
+    # Plain text
+    assert utils.visible_len("hello") == 5
+    # Colorized text
+    assert utils.visible_len(utils.colorize("hello", utils.Ansi.RED)) == 5
+    # Combined styles
+    assert utils.visible_len(utils.colorize("world", utils.Ansi.BOLD + utils.Ansi.CYAN)) == 5
+    # Empty string
+    assert utils.visible_len("") == 0
+    # Text with embedded codes
+    text = f"Part 1 {utils.Ansi.RED}Part 2{utils.Ansi.RESET} Part 3"
+    assert utils.visible_len(text) == len("Part 1 Part 2 Part 3")


### PR DESCRIPTION
This PR improves the visual hierarchy and clarity of CLI statistical reports by fixing a table alignment bug.

### Problem
The `padrows` function was incorrectly calculating column widths when ANSI escape sequences (colors) were present. This caused multi-column reports (like the index overview in `summarize.py`) to appear jagged and misaligned when run with the `--color` flag.

### Solution
- Implemented `utils.visible_len(s)` which uses a robust regex to strip ANSI codes before measuring length.
- Refactored `datalib.padrows` to consistently use `visible_len` for both finding the maximum column width and calculating the required padding for each cell.
- Added comprehensive test cases in `tests/test_utils.py` and `tests/test_datalib.py` to ensure alignment is preserved even with complex ANSI styling.

### Verification
- Verified manually using `scripts/summarize.py --color -x` on sample data.
- All 249 project tests passed successfully.

---
*PR created automatically by Jules for task [11357841903402663014](https://jules.google.com/task/11357841903402663014) started by @RainRat*