### PR TITLE
[FEAT] Add random sampling and shuffling to CLI tools

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -23,7 +23,8 @@ from namediff import Namediff
 def main(fname, oname = None, verbose = True, encoding = 'std',
          gatherer = True, for_forum = False, for_mse = False,
          creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, summary_out = False, quiet=False,
-         report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None):
+         report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None,
+         shuffle=False, seed=None):
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
@@ -86,7 +87,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
     else:
         raise ValueError('decode.py: unknown encoding: ' + encoding)
 
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep, vgrep=vgrep)
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep, vgrep=vgrep,
+                                  shuffle=shuffle, seed=seed)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -454,6 +456,12 @@ if __name__ == '__main__':
                         help="Calculate how unique these cards are compared to real Magic cards (requires Word2Vec).")
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Limit the number of cards to decode.')
+    proc_group.add_argument('--shuffle', action='store_true',
+                        help='Randomize the order of cards before decoding.')
+    proc_group.add_argument('--seed', type=int,
+                        help='Seed for the random number generator.')
+    proc_group.add_argument('--sample', type=int, default=0,
+                        help='Pick N random cards from the input (equivalent to --shuffle --limit N).')
     proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc'],
                         help='Sort cards by the specified criterion.')
     proc_group.add_argument('-d', '--dump', action='store_true',
@@ -475,11 +483,16 @@ if __name__ == '__main__':
     if args.mse and not args.outfile:
         parser.error("--mse requires an output filename.")
 
+    # Handle --sample
+    if args.sample > 0:
+        args.shuffle = True
+        args.limit = args.sample
+
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          gatherer = args.gatherer, for_forum = args.forum, for_mse = args.mse,
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text,
          json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, summary_out = args.summary, quiet=args.quiet,
          report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep,
-         sort=args.sort, vgrep=args.vgrep)
+         sort=args.sort, vgrep=args.vgrep, shuffle=args.shuffle, seed=args.seed)
 
     exit(0)

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -4,6 +4,7 @@ import os
 import re
 import csv
 import zipfile
+import random
 
 import utils
 import cardlib
@@ -448,7 +449,8 @@ def mtg_open_file(fname, verbose = False,
                   exclude_sets = default_exclude_sets,
                   exclude_types = default_exclude_types,
                   exclude_layouts = default_exclude_layouts,
-                  report_file=None, grep=None, vgrep=None):
+                  report_file=None, grep=None, vgrep=None,
+                  shuffle=False, seed=None):
 
     cards = []
     valid = 0
@@ -674,5 +676,10 @@ def mtg_open_file(fname, verbose = False,
 
             return True
         cards = [c for c in cards if match_card(c)]
+
+    if shuffle:
+        if seed is not None:
+            random.seed(seed)
+        random.shuffle(cards)
 
     return _check_parsing_quality(cards, report_fobj)

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -10,13 +10,14 @@ import utils
 import jdecode
 from datalib import Datamine
 
-def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = False, limit = 0, json_out = False, vgrep = None):
+def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = False, limit = 0, json_out = False, vgrep = None, shuffle = False, seed = None):
     # Use the robust mtg_open_file for all loading and filtering.
     # We disable default exclusions to match original summarize.py behavior.
     cards = jdecode.mtg_open_file(fname, verbose=verbose, grep=grep, vgrep=vgrep,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
-                                  exclude_layouts=lambda x: False)
+                                  exclude_layouts=lambda x: False,
+                                  shuffle=shuffle, seed=seed)
 
     if limit > 0:
         cards = cards[:limit]
@@ -55,6 +56,12 @@ if __name__ == '__main__':
                         help='show all information and dump invalid cards')
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Limit the number of cards to process.')
+    proc_group.add_argument('--shuffle', action='store_true',
+                        help='Randomize the order of cards before summarizing.')
+    proc_group.add_argument('--seed', type=int,
+                        help='Seed for the random number generator.')
+    proc_group.add_argument('--sample', type=int, default=0,
+                        help='Pick N random cards from the input (equivalent to --shuffle --limit N).')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
     proc_group.add_argument('--vgrep', '--exclude', action='append',
@@ -81,5 +88,10 @@ if __name__ == '__main__':
     elif args.color is None and sys.stdout.isatty():
         use_color = True
 
-    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = use_color, limit = args.limit, json_out = args.json, vgrep = args.vgrep)
+    # Handle --sample
+    if args.sample > 0:
+        args.shuffle = True
+        args.limit = args.sample
+
+    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = use_color, limit = args.limit, json_out = args.json, vgrep = args.vgrep, shuffle = args.shuffle, seed = args.seed)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -214,6 +214,12 @@ Supports any encoding format supported by encode.py/decode.py.""",
     proc_group = parser.add_argument_group('Processing Options')
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Limit the number of cards to sort.')
+    proc_group.add_argument('--shuffle', action='store_true',
+                        help='Randomize the order of cards before sorting.')
+    proc_group.add_argument('--seed', type=int,
+                        help='Seed for the random number generator.')
+    proc_group.add_argument('--sample', type=int, default=0,
+                        help='Pick N random cards from the input (equivalent to --shuffle --limit N).')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
     proc_group.add_argument('--vgrep', '--exclude', action='append',
@@ -248,13 +254,19 @@ Supports any encoding format supported by encode.py/decode.py.""",
 
     # We could support custom formats if needed, but this covers the main ones.
 
+    # Handle --sample
+    if args.sample > 0:
+        args.shuffle = True
+        args.limit = args.sample
+
     # Use the robust jdecode.mtg_open_file for loading and filtering.
     # We disable default exclusions (sets, types, layouts) to match the original sortcards.py behavior.
     # verbose=True enables jdecode diagnostic output (e.g. invalid cards).
     cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, fmt_ordered=fmt_ordered, grep=args.grep, vgrep=args.vgrep,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
-                                  exclude_layouts=lambda x: False)
+                                  exclude_layouts=lambda x: False,
+                                  shuffle=args.shuffle, seed=args.seed)
 
     if args.limit > 0:
         cards = cards[:args.limit]


### PR DESCRIPTION
Implemented random sampling and shuffling support across the Magic: The Gathering card processing toolset. This enables more efficient data exploration and testing by providing a consistent CLI interface for generating random subsets of cards.

---
*PR created automatically by Jules for task [4453388117638164983](https://jules.google.com/task/4453388117638164983) started by @RainRat*