### PR TITLE
Fix logic bug in Card.encode where randomize_lines was not passed to B-side

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -752,6 +752,7 @@ class Card:
                                           fieldsep = fieldsep,
                                           randomize_fields = randomize_fields, 
                                           randomize_mana = randomize_mana,
+                                          randomize_lines = randomize_lines,
                                           initial_sep = initial_sep, final_sep = final_sep))
 
         return outstr


### PR DESCRIPTION
Identified and fixed a logic bug in the `Card.encode` method in `lib/cardlib.py`. The `randomize_lines` parameter, which controls the randomization of card rules text lines, was not being passed to the recursive `self.bside.encode()` call. This resulted in the B-sides of split cards always retaining their original line order, even when randomization was enabled.

Verified the fix with a reproduction script that confirms B-side lines are now correctly randomized. All existing tests passed without regressions.

---
*PR created automatically by Jules for task [13987869848160468563](https://jules.google.com/task/13987869848160468563) started by @RainRat*