### PR TITLE
[FEAT] Add dataset splitting utility scripts/splitcards.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ Extracts a single card from the massive `AllPrintings.json` file. This is useful
 python3 scripts/extract_one.py data/AllPrintings.json SET_CODE "Card Name"
 ```
 
+### `splitcards.py`
+Splits a card dataset into multiple files, which is essential for creating training and validation sets for AI models.
+```bash
+python3 scripts/splitcards.py encoded_output.txt --outputs train.txt val.txt --ratios 0.9 0.1
+```
+
 ---
 
 ## Troubleshooting

--- a/scripts/splitcards.py
+++ b/scripts/splitcards.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import sys
+import os
+import argparse
+import json
+import csv
+
+# Ensure lib is in path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+import jdecode
+import utils
+import cardlib
+
+def main():
+    parser = argparse.ArgumentParser(description="Splits a card dataset into multiple files (e.g., train, validation, test).")
+
+    # Input
+    io_group = parser.add_argument_group('Input / Output')
+    io_group.add_argument('infile', help='Input card data (JSON, JSONL, CSV, MSE, or encoded text).')
+    io_group.add_argument('--outputs', nargs='+', required=True,
+                        help='Output filenames for each split (e.g., train.txt val.txt).')
+    io_group.add_argument('--ratios', type=float, nargs='+', required=True,
+                        help='Ratios for each split (e.g., 0.9 0.1). Must match the number of outputs and sum to 1.0.')
+
+    # Options
+    proc_group = parser.add_argument_group('Processing Options')
+    proc_group.add_argument('-f', '--format', choices=['text', 'json', 'jsonl', 'csv'], default='text',
+                        help='Output format for the splits (default: text).')
+    proc_group.add_argument('--shuffle', action='store_true', default=True,
+                        help='Shuffle cards before splitting (default: True).')
+    proc_group.add_argument('--no-shuffle', dest='shuffle', action='store_false',
+                        help='Do not shuffle cards before splitting.')
+    proc_group.add_argument('--seed', type=int, help='Seed for the random number generator.')
+    proc_group.add_argument('-e', '--encoding', default='std', choices=utils.formats,
+                        help="Encoding format if output is text (default: std).")
+
+    # Logging
+    log_group = parser.add_argument_group('Logging')
+    log_group.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output.')
+    log_group.add_argument('-q', '--quiet', action='store_true', help='Suppress status messages.')
+
+    args = parser.parse_args()
+
+    if len(args.outputs) != len(args.ratios):
+        print("Error: The number of outputs must match the number of ratios.", file=sys.stderr)
+        sys.exit(1)
+
+    if abs(sum(args.ratios) - 1.0) > 1e-6:
+        if not args.quiet:
+            print(f"Warning: Ratios sum to {sum(args.ratios):.4f}, normalizing to 1.0.", file=sys.stderr)
+        total = sum(args.ratios)
+        args.ratios = [r / total for r in args.ratios]
+
+    # Load cards
+    if not args.quiet:
+        print(f"Loading cards from {args.infile}...", file=sys.stderr)
+
+    # mtg_open_file handles format detection and basic filtering
+    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose,
+                                  shuffle=args.shuffle, seed=args.seed)
+
+    total_cards = len(cards)
+    if not args.quiet:
+        print(f"Total cards loaded: {total_cards}", file=sys.stderr)
+
+    if total_cards == 0:
+        print("Error: No cards loaded.", file=sys.stderr)
+        sys.exit(1)
+
+    # Calculate split indices
+    indices = []
+    current = 0
+    for i, ratio in enumerate(args.ratios):
+        if i == len(args.ratios) - 1:
+            # Last split gets the remainder to ensure we use all cards
+            indices.append((current, total_cards))
+        else:
+            count = int(round(ratio * total_cards))
+            indices.append((current, current + count))
+            current += count
+
+    # Write splits
+    for i, (start, end) in enumerate(indices):
+        outfile = args.outputs[i]
+        split_cards = cards[start:end]
+
+        if not args.quiet:
+            print(f"Writing {len(split_cards)} cards to {outfile} (format: {args.format})...", file=sys.stderr)
+
+        with open(outfile, 'w', encoding='utf8') as f:
+            if args.format == 'json':
+                json_data = [c.to_dict() for c in split_cards]
+                json.dump(json_data, f, indent=2)
+            elif args.format == 'jsonl':
+                for c in split_cards:
+                    f.write(json.dumps(c.to_dict()) + '\n')
+            elif args.format == 'csv':
+                fieldnames = ['name', 'mana_cost', 'type', 'subtypes', 'text', 'power', 'toughness', 'loyalty', 'rarity']
+                writer = csv.DictWriter(f, fieldnames=fieldnames, lineterminator='\n')
+                writer.writeheader()
+                for c in split_cards:
+                    d = c.to_dict()
+                    row = {
+                        'name': d.get('name', ''),
+                        'mana_cost': d.get('manaCost', ''),
+                        'type': ' '.join(d.get('supertypes', []) + d.get('types', [])),
+                        'subtypes': ' '.join(d.get('subtypes', [])),
+                        'text': d.get('text', ''),
+                        'power': d.get('power', ''),
+                        'toughness': d.get('toughness', ''),
+                        'loyalty': d.get('loyalty', d.get('defense', '')),
+                        'rarity': d.get('rarity', ''),
+                    }
+                    writer.writerow(row)
+            else: # text (encoded)
+                # determine the encoding parameters
+                # ENCODING_CONFIG from encode.py
+                fmt_ordered = cardlib.fmt_ordered_default
+                if args.encoding == 'named': fmt_ordered = cardlib.fmt_ordered_named
+                elif args.encoding == 'noname': fmt_ordered = cardlib.fmt_ordered_noname
+                elif args.encoding == 'old': fmt_ordered = cardlib.fmt_ordered_old
+                elif args.encoding == 'norarity': fmt_ordered = cardlib.fmt_ordered_norarity
+
+                for c in split_cards:
+                    f.write(c.encode(fmt_ordered=fmt_ordered) + utils.cardsep)
+
+    if not args.quiet:
+        print("Dataset split successfully.", file=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_splitcards.py
+++ b/tests/test_splitcards.py
@@ -1,0 +1,137 @@
+import pytest
+import os
+import subprocess
+import json
+import csv
+
+def test_splitcards_basic(tmp_path):
+    # Create a dummy input file
+    infile = tmp_path / "input.txt"
+    # Using labeled format to ensure jdecode handles it correctly
+    cards = [
+        "|1Card A|7common|5Creature\n\n",
+        "|1Card B|7common|5Creature\n\n",
+        "|1Card C|7common|5Creature\n\n",
+        "|1Card D|7common|5Creature\n\n"
+    ]
+    infile.write_text("".join(cards))
+
+    out1 = tmp_path / "out1.txt"
+    out2 = tmp_path / "out2.txt"
+
+    # Run splitcards.py
+    cmd = [
+        "python3", "scripts/splitcards.py",
+        str(infile),
+        "--outputs", str(out1), str(out2),
+        "--ratios", "0.75", "0.25",
+        "--no-shuffle"
+    ]
+    subprocess.run(cmd, check=True)
+
+    # Check that outputs exist
+    assert out1.exists()
+    assert out2.exists()
+
+    # Check content counts
+    content1 = out1.read_text()
+    content2 = out2.read_text()
+
+    # Since we have 4 cards and 0.75 ratio, out1 should have 3 cards, out2 should have 1.
+    # jdecode.mtg_open_file will have correctly parsed these.
+    # Re-encoded output will have labels because default is labeled.
+    assert content1.count("|1") == 3
+    assert content2.count("|1") == 1
+
+def test_splitcards_json(tmp_path):
+    # Create a dummy input JSON file
+    infile = tmp_path / "input.json"
+    data = {
+        "data": {
+            "TEST": {
+                "name": "Test Set",
+                "code": "TEST",
+                "type": "expansion",
+                "cards": [
+                    {"name": "Card 1", "types": ["Creature"], "rarity": "common", "power": "1", "toughness": "1"},
+                    {"name": "Card 2", "types": ["Instant"], "rarity": "uncommon"},
+                    {"name": "Card 3", "types": ["Sorcery"], "rarity": "rare"}
+                ]
+            }
+        }
+    }
+    infile.write_text(json.dumps(data))
+
+    out1 = tmp_path / "out1.json"
+    out2 = tmp_path / "out2.json"
+
+    cmd = [
+        "python3", "scripts/splitcards.py",
+        str(infile),
+        "--outputs", str(out1), str(out2),
+        "--ratios", "0.7", "0.3",
+        "--format", "json",
+        "--no-shuffle"
+    ]
+    subprocess.run(cmd, check=True)
+
+    # Verify JSON output
+    with open(out1) as f:
+        data1 = json.load(f)
+    with open(out2) as f:
+        data2 = json.load(f)
+
+    assert len(data1) == 2
+    assert len(data2) == 1
+    assert data1[0]['name'] == "Card 1"
+    assert data2[0]['name'] == "Card 3"
+
+def test_splitcards_csv(tmp_path):
+     # Create dummy input
+    infile = tmp_path / "input.jsonl"
+    # Card objects need a type to be valid
+    infile.write_text('{"name": "C1", "types": ["T1"]}\n{"name": "C2", "types": ["T2"]}\n')
+
+    out1 = tmp_path / "out1.csv"
+    out2 = tmp_path / "out2.csv"
+
+    cmd = [
+        "python3", "scripts/splitcards.py",
+        str(infile),
+        "--outputs", str(out1), str(out2),
+        "--ratios", "0.5", "0.5",
+        "--format", "csv",
+        "--no-shuffle"
+    ]
+    subprocess.run(cmd, check=True)
+
+    # Verify CSV output
+    with open(out1, newline='') as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]['name'] == "C1"
+
+def test_splitcards_three_way(tmp_path):
+    infile = tmp_path / "input.txt"
+    cards = ["|1C{:d}|7common|5Type\n\n".format(i) for i in range(10)]
+    infile.write_text("".join(cards))
+
+    outputs = [str(tmp_path / "f{:d}.txt".format(i)) for i in range(3)]
+
+    cmd = [
+        "python3", "scripts/splitcards.py",
+        str(infile),
+        "--outputs", outputs[0], outputs[1], outputs[2],
+        "--ratios", "0.7", "0.2", "0.1",
+        "--no-shuffle"
+    ]
+    subprocess.run(cmd, check=True)
+
+    assert os.path.getsize(outputs[0]) > 0
+    assert os.path.getsize(outputs[1]) > 0
+    assert os.path.getsize(outputs[2]) > 0
+
+    with open(outputs[0]) as f: assert f.read().count("|1") == 7
+    with open(outputs[1]) as f: assert f.read().count("|1") == 2
+    with open(outputs[2]) as f: assert f.read().count("|1") == 1


### PR DESCRIPTION
This PR introduces `scripts/splitcards.py`, a new utility that facilitates the common task of splitting card datasets into training, validation, and test sets. It integrates seamlessly with the existing `jdecode` and `cardlib` libraries, supporting all project input formats and providing flexible output options. Documentation and tests are included to ensure ease of use and reliability.

---
*PR created automatically by Jules for task [8610300281448940512](https://jules.google.com/task/8610300281448940512) started by @RainRat*