### PR TITLE
[FEAT] Direct ZIP Archive Support for Card Input

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -460,7 +460,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .jsonl, .csv, .md, .sum, .summary, .mse-set).')
 

--- a/encode.py
+++ b/encode.py
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console (stdout).')
 

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('--json', action='store_true',
                         help='Output statistics in JSON format.')
 

--- a/sortcards.py
+++ b/sortcards.py
@@ -198,7 +198,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, or MSE), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console (stdout).')
 


### PR DESCRIPTION
This PR adds support for reading Magic: The Gathering card data directly from `.zip` archives. 

Previously, users had to manually unzip files like MTGJSON's `AllPrintings.json` before processing them. Now, all CLI tools (`encode.py`, `decode.py`, `sortcards.py`, and `summarize.py`) can accept a `.zip` file as the `infile`.

Key changes:
1.  **ZIP Handling:** `mtg_open_file` now detects `.zip` extensions and iterates through the archive to find and process supported card data formats.
2.  **Nested MSE Support:** Correctly handles `.mse-set` files (which are themselves ZIP archives) when found inside a primary ZIP archive.
3.  **Refactoring:** Unified the logic for processing multiple files (from directories or ZIPs) using a `process_file_content` helper to ensure consistent behavior.
4.  **CLI Updates:** Updated help strings across all tools to inform users of the new ZIP support.
5.  **Bug Fix:** Resolved a `NameError` where a local `import io` was shadowing the global `io` module inside `mtg_open_file`.

Verified with existing test suite (267/267 passed) and manual verification with multi-format ZIP archives.

---
*PR created automatically by Jules for task [14936771383379438960](https://jules.google.com/task/14936771383379438960) started by @RainRat*