### PR TITLE
[FEAT] Add Rarity and Average CMC to Dataset Summary

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -89,6 +89,7 @@ class Datamine:
         self.by_toughness = {}
         self.by_pt = {}
         self.by_loyalty = {}
+        self.by_rarity = {}
         self.by_textlines = {}
         self.by_textlen = {}
 
@@ -109,6 +110,7 @@ class Datamine:
             'by_toughness' : self.by_toughness,
             'by_pt' : self.by_pt,
             'by_loyalty' : self.by_loyalty,
+            'by_rarity' : self.by_rarity,
             'by_textlines' : self.by_textlines,
             'by_textlen' : self.by_textlen,
         }
@@ -159,6 +161,12 @@ class Datamine:
                 inc(self.by_pt, card.pt, [card])
 
                 inc(self.by_loyalty, card.loyalty, [card])
+
+                # normalize rarity
+                rarity = card.rarity
+                if rarity in utils.json_rarity_unmap:
+                    rarity = utils.json_rarity_unmap[rarity]
+                inc(self.by_rarity, rarity, [card])
 
                 inc(self.by_textlines, len(card.text_lines), [card])
                 inc(self.by_textlen, len(card.text.encode()), [card])
@@ -231,6 +239,8 @@ class Datamine:
         print(color_line('--------------------', use_color))
         print(color_header(str(len(self.by_cmc)) + ' different CMCs, ' +
               str(len(self.by_cost)) + ' unique mana costs', use_color))
+        avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
+        print('Average CMC: {:.2f}'.format(avg_cmc))
         print('-- Breakdown by CMC: --')
         d = sorted(self.by_cmc, reverse=False)
         rows = []
@@ -244,6 +254,13 @@ class Datamine:
         rows = []
         for k in d[0:vsize]:
             rows += [[utils.from_mana(k), color_count(len(self.by_cost[k]), use_color)]]
+        printrows(padrows(rows))
+        print(color_line('--------------------', use_color))
+        print(color_header(str(len(self.by_rarity)) + ' represented rarities', use_color))
+        print('-- Breakdown by rarity: --')
+        rows = []
+        for k in sorted(self.by_rarity.keys()):
+            rows += [[k, color_count(len(self.by_rarity[k]), use_color)]]
         printrows(padrows(rows))
         print(color_line('--------------------', use_color))
         print(color_header(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
@@ -428,5 +445,6 @@ class Datamine:
                 'textlen_max': max(self.by_textlen),
                 'textlines_min': min(self.by_textlines),
                 'textlines_max': max(self.by_textlines),
+                'avg_cmc': sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0,
             }
         return result

--- a/tests/test_datamine_rarity.py
+++ b/tests/test_datamine_rarity.py
@@ -1,0 +1,104 @@
+
+import pytest
+import sys
+import os
+import io
+
+# Ensure lib is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib')))
+
+from datalib import Datamine
+import utils
+
+# Sample Data Fixture
+@pytest.fixture
+def sample_cards_data():
+    return [
+        {
+            "name": "Card A",
+            "types": ["Creature"],
+            "pt": "1/1",
+            "manaCost": "{R}",
+            "cmc": 1,
+            "colors": ["R"],
+            "text": "Text A",
+            "rarity": "Common"
+        },
+        {
+            "name": "Card B",
+            "types": ["Instant"],
+            "manaCost": "{U}",
+            "cmc": 1,
+            "colors": ["U"],
+            "text": "Text B",
+            "rarity": "Uncommon"
+        },
+        {
+            "name": "Card C",
+            "types": ["Creature", "Artifact"],
+            "subtypes": ["Construct"],
+            "pt": "2/2",
+            "manaCost": "{2}",
+            "cmc": 2,
+            "colors": [],
+            "text": "Text C",
+            "rarity": "Rare"
+        },
+        {
+            "name": "Card D",
+            "types": ["Planeswalker"],
+            "manaCost": "{3}{W}{B}",
+            "cmc": 5,
+            "colors": ["W", "B"],
+            "text": "Text D",
+            "rarity": "Mythic Rare",
+            "loyalty": "3"
+        }
+    ]
+
+@pytest.fixture
+def datamine_instance(sample_cards_data):
+    return Datamine(sample_cards_data)
+
+def test_rarity_indexing(datamine_instance):
+    dm = datamine_instance
+
+    assert 'by_rarity' in dm.indices
+    assert len(dm.by_rarity) == 4
+    # json_rarity_unmap results in these keys based on the last-entry-wins in utils.py
+    assert 'common' in dm.by_rarity
+    assert 'uncommon' in dm.by_rarity
+    assert 'rare' in dm.by_rarity
+    assert 'mythic' in dm.by_rarity
+
+def test_average_cmc(datamine_instance):
+    dm = datamine_instance
+
+    # CMCs: 1, 1, 2, 5 -> Sum = 9. Count = 4. Avg = 2.25
+    expected_avg = 2.25
+
+    # Calculate from dm.cards
+    avg_cmc = sum(c.cost.cmc for c in dm.cards) / len(dm.cards)
+    assert avg_cmc == expected_avg
+
+def test_summarize_output(datamine_instance, capsys):
+    datamine_instance.summarize()
+    captured = capsys.readouterr()
+    output = captured.out
+
+    assert "Average CMC: 2.25" in output
+    assert "4 represented rarities" in output
+    assert "-- Breakdown by rarity: --" in output
+    assert "common" in output
+    assert "uncommon" in output
+    assert "rare" in output
+    assert "mythic" in output
+
+def test_to_dict_avg_cmc(datamine_instance):
+    result = datamine_instance.to_dict()
+    assert 'avg_cmc' in result['stats']
+    assert result['stats']['avg_cmc'] == 2.25
+
+    assert 'by_rarity' in result['indices']
+    assert result['indices']['by_rarity']['common'] == 1
+    assert result['indices']['by_rarity']['mythic'] == 1


### PR DESCRIPTION
This PR enhances the dataset analysis capabilities of the project by adding rarity distribution tracking and average converted mana cost (CMC) calculation to the `summarize.py` tool.

### Changes:
*   **Rarity Indexing:** The `Datamine` class now automatically indexes cards by their rarity. It uses the project's existing normalization logic to ensure consistent naming (e.g., converting internal markers back to human-readable strings like 'common').
*   **Average CMC:** The summary output now includes the average CMC of all valid cards in the dataset, providing a quick metric for set "speed".
*   **Detailed Breakdown:** A new "Breakdown by rarity" section has been added to the CLI output of `summarize.py`.
*   **Programmatic Access:** The `avg_cmc` and rarity counts are included in the JSON output produced by the `--json` flag.
*   **Verification:** New unit tests in `tests/test_datamine_rarity.py` verify the accuracy of the new statistics across sample datasets.

These additions provide immediate value for users analyzing both official MTG datasets and AI-generated card sets, following the "Symmetry" and "Convenience" heuristics by filling a noticeable gap in the existing analytical suite.

---
*PR created automatically by Jules for task [10452195846059897632](https://jules.google.com/task/10452195846059897632) started by @RainRat*