### PR TITLE
[FEAT] Add support for MTG decklist export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Options for formatting the output:
 *   `--gatherer`: Formats text like the official Gatherer website (Default).
 *   `--raw`: Shows raw text without special formatting.
 *   `--html`: Creates a webpage with card images.
+*   `--deck`: Creates a standard MTG decklist.
 *   `--mse`: Creates a file for Magic Set Editor.
 *   `--json`: Creates a structured JSON file.
 *   `--csv`: Creates a spreadsheet file.
@@ -136,6 +137,7 @@ The tool automatically selects the format based on the file extension of your ou
 *   `.csv`  -> Spreadsheet
 *   `.md`   -> Markdown document
 *   `.sum`, `.summary` -> One-line summary
+*   `.deck`, `.dek` -> MTG Decklist
 *   `.mse-set` -> Magic Set Editor file
 
 ### Using Pipes

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -457,6 +457,8 @@ class Card:
         # looks like a json object
         if isinstance(src, dict):
             self.json = src
+            self.set_code = src.get('setCode')
+            self.number = src.get('number')
             if utils.json_field_bside in src:
                 self.bside = Card(src[utils.json_field_bside],
                                   fmt_ordered = fmt_ordered,
@@ -521,6 +523,9 @@ class Card:
         setattr(self, field_text + '_words', [])
         setattr(self, field_text + '_lines_words', [])
         setattr(self, field_other, [])
+        # metadata for interoperability
+        self.set_code = None
+        self.number = None
 
     def _get_ansi_color(self):
         """Returns the ANSI color code for the card based on its colors and types."""
@@ -1089,6 +1094,12 @@ class Card:
         # Text
         if self.text.text:
             d['text'] = self.get_text(force_unpass=True)
+
+        # Metadata
+        if self.set_code:
+            d['setCode'] = self.set_code
+        if self.number:
+            d['number'] = self.number
 
         # B-Side (Recursive)
         if self.bside:

--- a/tests/test_decklist_output.py
+++ b/tests/test_decklist_output.py
@@ -1,0 +1,75 @@
+import pytest
+import os
+import sys
+import json
+from io import StringIO
+
+# Add lib to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/..')
+
+import decode
+import cardlib
+
+def test_decklist_aggregation():
+    # Setup some test cards with duplicates
+    card_data = [
+        {"name": "Black Lotus", "setCode": "LEA", "number": "232"},
+        {"name": "Black Lotus", "setCode": "LEA", "number": "232"},
+        {"name": "Island", "setCode": "ZEN", "number": "234"},
+        {"name": "Island", "setCode": "ZEN", "number": "235"}, # Different number
+        {"name": "Mox Emerald", "setCode": "LEA"}, # No number
+        {"name": "Custom Card"}, # No set or number
+    ]
+
+    cards = [cardlib.Card(c) for c in card_data]
+
+    # Capture stdout
+    old_stdout = sys.stdout
+    sys.stdout = mystdout = StringIO()
+
+    try:
+        # We need to mock jdecode.mtg_open_file or just call decode.main with pre-loaded cards
+        # But decode.main calls mtg_open_file internally.
+        # So let's mock jdecode.mtg_open_file.
+        import jdecode
+        original_mtg_open_file = jdecode.mtg_open_file
+        jdecode.mtg_open_file = lambda *args, **kwargs: cards
+
+        decode.main("-", deck_out=True, verbose=False, quiet=True)
+
+        jdecode.mtg_open_file = original_mtg_open_file
+    finally:
+        sys.stdout = old_stdout
+
+    output = mystdout.getvalue()
+    lines = output.strip().split('\n')
+
+    assert "2 Black Lotus (LEA) 232" in lines
+    assert "1 Island (ZEN) 234" in lines
+    assert "1 Island (ZEN) 235" in lines
+    assert "1 Mox Emerald (LEA)" in lines
+    assert "1 Custom Card" in lines
+    assert len(lines) == 5
+
+def test_decklist_autoformat(tmp_path):
+    # Test extension detection
+    d = tmp_path / "subdir"
+    d.mkdir()
+    deck_file = d / "test.deck"
+
+    # We'll use a real file but mock the loading to be fast
+    import jdecode
+    original_mtg_open_file = jdecode.mtg_open_file
+    jdecode.mtg_open_file = lambda *args, **kwargs: [cardlib.Card({"name": "Black Lotus", "setCode": "LEA"})]
+
+    try:
+        # Pass oname so it detects .deck
+        decode.main("-", oname=str(deck_file), verbose=False, quiet=True)
+    finally:
+        jdecode.mtg_open_file = original_mtg_open_file
+
+    assert deck_file.exists()
+    content = deck_file.read_text()
+    assert "1 Black Lotus (LEA)" in content


### PR DESCRIPTION
This PR introduces a new output format for `decode.py`: standard MTG decklists. 

**What:**
- `decode.py` now supports a `--deck` (or `--decklist`) flag that aggregates cards by name, set code, and collector number.
- The output follows the standard format: `Count Card Name (SET) Number`.
- Automatic format detection is enabled for files ending in `.deck` or `.dek`.
- The `Card` class now preserves `setCode` and `number` fields from the source JSON, which are also included in the `to_dict()` output.

**Why:**
MTG decklists are a universal format for sharing card lists between different software tools (Arena, Cockatrice, Untap.in, etc.). By adding decklist support, users can now easily take a subset of real cards or AI-generated cards and import them into their favorite playtest or deck-building tool. This bridges a gap in the tool's interoperability with the wider MTG ecosystem.

---
*PR created automatically by Jules for task [13033839912658852522](https://jules.google.com/task/13033839912658852522) started by @RainRat*