### PR TITLE
[DOCS] Add .jsonl to automatic format detection in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Options for formatting the output:
 The tool automatically selects the format based on the file extension of your output file:
 *   `.html` -> Webpage
 *   `.json` -> JSON data
+*   `.jsonl` -> JSON Lines data
 *   `.csv`  -> Spreadsheet
 *   `.md`   -> Markdown document
 *   `.sum`, `.summary` -> One-line summary


### PR DESCRIPTION
Updated README.md to include .jsonl in the "Automatic Format Detection" section. This format is supported by decode.py but was missing from the documentation. verified that all tests pass and the change adheres to style guidelines.

---
*PR created automatically by Jules for task [16311435001726836841](https://jules.google.com/task/16311435001726836841) started by @RainRat*