### PR TITLE
Consolidate average CMC calculation in Datamine class

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -171,6 +171,8 @@ class Datamine:
                 inc(self.by_textlines, len(card.text_lines), [card])
                 inc(self.by_textlen, len(card.text.encode()), [card])
 
+        self.avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
+
     # summarize the indices
     def summarize(self, hsize = 10, vsize = 10, cmcsize = 20, use_color = False):
 
@@ -246,8 +248,7 @@ class Datamine:
 
         print(color_header(str(len(self.by_cmc)) + ' different CMCs, ' +
               str(len(self.by_cost)) + ' unique mana costs', use_color))
-        avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
-        print('Average CMC: {:.2f}'.format(avg_cmc))
+        print('Average CMC: {:.2f}'.format(self.avg_cmc))
         print(color_header('Breakdown by CMC:', use_color))
         d = sorted(self.by_cmc, reverse=False)
         rows = []
@@ -465,6 +466,6 @@ class Datamine:
                 'textlen_max': max(self.by_textlen),
                 'textlines_min': min(self.by_textlines),
                 'textlines_max': max(self.by_textlines),
-                'avg_cmc': sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0,
+                'avg_cmc': self.avg_cmc,
             }
         return result


### PR DESCRIPTION
This PR resolves a logic duplication issue in the `Datamine` class within `lib/datalib.py`. The average CMC calculation was previously repeated in both the `summarize` and `to_dict` methods. I have consolidated this logic by calculating the average CMC once during initialization and storing it as a `self.avg_cmc` attribute.

Key Changes:
- Added `self.avg_cmc` calculation to `Datamine.__init__`.
- Replaced redundant calculations in `Datamine.summarize` and `Datamine.to_dict` with references to `self.avg_cmc`.

This change is non-breaking and preserves identical external behavior while improving code quality and maintainability. All tests passed.

---
*PR created automatically by Jules for task [2237143242175382086](https://jules.google.com/task/2237143242175382086) started by @RainRat*