### PR TITLE
[UI/UX] Improve card summary format and feedback

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -817,6 +817,17 @@ class Card:
 
     def summary(self, ansi_color=False):
         """Returns a compact, one-line summary of the card."""
+        # Status indicator
+        status = ''
+        if not self.parsed:
+            status = '[!] '
+            if ansi_color:
+                status = utils.colorize(status, utils.Ansi.BOLD + utils.Ansi.RED)
+        elif not self.valid:
+            status = '[?] '
+            if ansi_color:
+                status = utils.colorize(status, utils.Ansi.YELLOW)
+
         # Rarity indicator
         rarity_indicator = ''
         if self.rarity:
@@ -876,16 +887,20 @@ class Card:
         if self.pt:
             pt = utils.from_unary(self.pt)
             if ansi_color: pt = utils.colorize(pt, utils.Ansi.RED)
-            stats = f' - {pt}'
+            stats = pt
         elif self.loyalty:
             loyalty = utils.from_unary(self.loyalty)
             if ansi_color: loyalty = utils.colorize(loyalty, utils.Ansi.RED)
             if any('battle' in t.lower() for t in self.types):
-                stats = f' - [[{loyalty}]]'
+                stats = f'[[{loyalty}]]'
             else:
-                stats = f' - ({loyalty})'
+                stats = f'({loyalty})'
 
-        return f'{rarity_indicator}{cardname}{coststr} - {typeline}{stats}'
+        # Construct final summary string with consistent bullet separators
+        res = f'{status}{rarity_indicator}{cardname}{coststr} \u2022 {typeline}'
+        if stats:
+            res += f' \u2022 {stats}'
+        return res
 
     def format(self, gatherer=False, for_forum=False, vdump=False, for_html=False, ansi_color=False, for_md=False):
         """Formats the card data into a human-readable string.

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -129,7 +129,7 @@ def test_card_summary(sample_card_json):
 
     # Test plain summary
     output = card.summary()
-    assert output == "[U] Ornithopter {0} - Artifact Creature — Thopter - 0/2"
+    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • 0/2"
 
     # Test colored summary
     colored_output = card.summary(ansi_color=True)
@@ -139,8 +139,27 @@ def test_card_summary(sample_card_json):
     expected_pt = utils.colorize("0/2", utils.Ansi.RED)
     expected_rarity_indicator = utils.colorize("U", utils.Ansi.BOLD + utils.Ansi.CYAN)
 
-    expected_colored_summary = f"[{expected_rarity_indicator}] {expected_name} {expected_cost} - {expected_type} - {expected_pt}"
+    expected_colored_summary = f"[{expected_rarity_indicator}] {expected_name} {expected_cost} • {expected_type} • {expected_pt}"
     assert colored_output == expected_colored_summary
+
+def test_card_summary_status_indicators():
+    # Invalid card (Creature missing P/T)
+    invalid_json = {"name": "Invalid", "types": ["Creature"], "rarity": "Common"}
+    card_inv = Card(invalid_json)
+    assert not card_inv.valid
+    assert card_inv.parsed
+    assert card_inv.summary().startswith("[?] ")
+
+    # Unparsed card
+    unparsed_text = "type|name|extra" # too many fields for custom order
+    card_unp = Card(unparsed_text, fmt_ordered=["types", "name"], fmt_labeled={})
+    assert not card_unp.parsed
+    assert card_unp.summary().startswith("[!] ")
+
+    # Colored unparsed
+    colored_summary = card_unp.summary(ansi_color=True)
+    expected_indicator = utils.colorize("[!] ", utils.Ansi.BOLD + utils.Ansi.RED)
+    assert colored_summary.startswith(expected_indicator)
 
 def test_planeswalker_to_mse_formatting():
     planeswalker_json = {

--- a/tests/test_decode_autoformat.py
+++ b/tests/test_decode_autoformat.py
@@ -49,9 +49,9 @@ def test_auto_format_summary(encoded_file, tmp_path):
 
     assert outfile.exists()
     content = outfile.read_text()
-    # Summary format: [?] Test Card - Creature
+    # Summary format: [?] Test Card • Creature
     assert 'Test Card' in content
-    assert '-' in content
+    assert '\u2022' in content
 
 def test_explicit_flag_overrides_extension(encoded_file, tmp_path):
     # Extension is .json but we force --text


### PR DESCRIPTION
Improved the card summary output format in `lib/cardlib.py` to use bullet separators and add status indicators for invalid/unparsed cards. Updated tests to match the new format.

---
*PR created automatically by Jules for task [17450802555246592913](https://jules.google.com/task/17450802555246592913) started by @RainRat*