### PR TITLE
[FEAT] Add MTG decklist support for input filtering and multiplication

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -25,7 +25,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          gatherer = True, for_forum = False, for_mse = False,
          creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, summary_out = False, deck_out = False, quiet=False,
          report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None,
-         sets=None, rarities=None, shuffle=False, seed=None):
+         sets=None, rarities=None, shuffle=False, seed=None, decklist_file=None):
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
@@ -91,7 +91,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         raise ValueError('decode.py: unknown encoding: ' + encoding)
 
     cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep, vgrep=vgrep,
-                                  sets=sets, rarities=rarities, shuffle=shuffle, seed=seed)
+                                  sets=sets, rarities=rarities, shuffle=shuffle, seed=seed, decklist_file=decklist_file)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -579,6 +579,8 @@ if __name__ == '__main__':
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
                         help='Only include cards of these rarities (common, uncommon, rare, mythic).')
+    proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck_filter',
+                        help='Filter cards using a standard MTG decklist file. Also supports card multiplication based on counts in the decklist.')
 
     args = parser.parse_args()
 
@@ -597,6 +599,6 @@ if __name__ == '__main__':
          json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, summary_out = args.summary, deck_out = args.deck, quiet=args.quiet,
          report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep,
          sort=args.sort, vgrep=args.vgrep, sets=args.set, rarities=args.rarity,
-         shuffle=args.shuffle, seed=args.seed)
+         shuffle=args.shuffle, seed=args.seed, decklist_file=args.deck_filter)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, randomize = False, nolabel = False, stable = False,
          report_file=None, quiet=False, limit=0, grep=None, sort=None, vgrep=None,
-         sets=None, rarities=None, seed=None):
+         sets=None, rarities=None, seed=None, decklist_file=None):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
     fieldsep = utils.fieldsep
@@ -67,7 +67,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
     cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=line_transformations,
                                   report_file=report_file, grep=grep, vgrep=vgrep,
                                   sets=sets, rarities=rarities,
-                                  shuffle=not stable, seed=seed if seed is not None else 1371367)
+                                  shuffle=not stable, seed=seed if seed is not None else 1371367,
+                                  decklist_file=decklist_file)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -145,6 +146,8 @@ if __name__ == '__main__':
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
                         help='Only include cards of these rarities (common, uncommon, rare, mythic).')
+    proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
+                        help='Filter cards using a standard MTG decklist file. Also supports card multiplication based on counts in the decklist.')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -165,5 +168,5 @@ if __name__ == '__main__':
          nolinetrans = args.nolinetrans, randomize = args.randomize, nolabel = args.nolabel,
          stable = args.stable, report_file = args.report_unparsed, quiet=args.quiet,
          limit=args.limit, grep=args.grep, sort=args.sort, vgrep=args.vgrep,
-         sets=args.set, rarities=args.rarity, seed=args.seed)
+         sets=args.set, rarities=args.rarity, seed=args.seed, decklist_file=args.deck)
     exit(0)

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -203,6 +203,51 @@ def mtg_open_mse(fname, verbose = False):
 
     return mtg_open_mse_content(content, verbose=verbose)
 
+def parse_decklist(fpath):
+    """
+    Parses a standard MTG decklist file.
+    Returns a dictionary mapping lowercase card names to counts.
+    """
+    name_counts = {}
+    if not os.path.exists(fpath):
+        return name_counts
+
+    # Standard MTG decklist line: [Count] Name [(Set)] [Number]
+    # Example: 4 Grizzly Bears (LEA) 201
+    # We want to be lenient and capture the name primarily.
+    # Note: Some names can contain dashes or other symbols.
+    with open(fpath, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            # Skip empty lines, comments, and standard decklist separators
+            if not line or line.startswith(('#', '//', 'Sideboard', 'Deck')):
+                continue
+
+            # Match count and name
+            # Optional count at start (digits followed by space or 'x' and space)
+            # followed by name. Name ends before a '(' or '[' or '#' (comment).
+            match = re.match(r'^(\d+[xX]?\s+)?([^(\[\n#]+)', line)
+            if match:
+                count_str = match.group(1)
+                name = match.group(2).strip()
+
+                count = 1
+                if count_str:
+                    # Clean up the count string
+                    count_str = count_str.strip().lower().replace('x', '')
+                    try:
+                        count = int(count_str)
+                    except ValueError:
+                        count = 1
+
+                name_lower = name.lower()
+                # Exclude common non-card words that might slip through
+                if name_lower in ['sideboard', 'deck', 'maybeboard']:
+                    continue
+
+                name_counts[name_lower] = name_counts.get(name_lower, 0) + count
+    return name_counts
+
 def mtg_open_mse_content(content, verbose=False):
     """
     Parses the 'set' file content from an MSE archive.
@@ -390,16 +435,26 @@ def _check_parsing_quality(cards, report_fobj):
 
 def _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
                        exclude_sets, exclude_types, exclude_layouts,
-                       report_fobj):
+                       report_fobj, decklist_names=None):
     cards = []
     valid = 0
     skipped = 0
     invalid = 0
     unparsed = 0
 
+    # If decklist is provided, we use it as our primary list of names to process
+    if decklist_names:
+        target_names = sorted(decklist_names.keys())
+        if verbose:
+            missing = [name for name in target_names if name not in json_srcs]
+            if missing:
+                print(f"Warning: {len(missing)} cards from decklist not found in source: {', '.join(missing[:5])}{'...' if len(missing) > 5 else ''}", file=sys.stderr)
+    else:
+        target_names = sorted(json_srcs)
+
     # sorted for stability
-    for json_cardname in sorted(json_srcs):
-        if len(json_srcs[json_cardname]) > 0:
+    for json_cardname in target_names:
+        if json_cardname in json_srcs and len(json_srcs[json_cardname]) > 0:
             jcards = json_srcs[json_cardname]
 
             idx, card = _find_best_candidate(jcards, exclude_sets, linetrans)
@@ -424,7 +479,10 @@ def _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
 
             if card.valid:
                 valid += 1
-                cards += [card]
+                # Handle multiplication from decklist
+                count = decklist_names[json_cardname] if decklist_names else 1
+                for _ in range(count):
+                    cards += [card]
             elif card.parsed:
                 invalid += 1
                 if verbose:
@@ -445,6 +503,53 @@ def _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
 
     return cards
 
+def _process_text_cards(txt_cards, decklist_names, verbose, report_fobj=None):
+    """
+    Processes a list of Card objects from encoded text, applying decklist filters/multipliers.
+    """
+    cards = []
+    valid = 0
+    invalid = 0
+    unparsed = 0
+
+    def handle_card(card, count):
+        nonlocal valid, invalid, unparsed
+        for _ in range(count):
+            cards.append(card)
+            if card.valid:
+                valid += 1
+            elif card.parsed:
+                invalid += 1
+                if verbose:
+                    print ('Invalid card: ' + (card.raw if card.raw else card.encode()), file=sys.stderr)
+                if report_fobj:
+                    report_fobj.write((card.raw if card.raw else card.encode()) + utils.cardsep)
+            else:
+                unparsed += 1
+                if verbose:
+                    print ('Failed to parse card: ' + (card.raw if card.raw else card.encode()), file=sys.stderr)
+                if report_fobj:
+                    report_fobj.write((card.raw if card.raw else card.encode()) + utils.cardsep)
+
+    if decklist_names:
+        name_to_txt_card = {}
+        for c in txt_cards:
+            name_l = c.name.lower()
+            if name_l in decklist_names and name_l not in name_to_txt_card:
+                name_to_txt_card[name_l] = c
+
+        # Iterating over decklist names ensures we get the right counts and multiplication
+        for name in sorted(decklist_names.keys()):
+            if name in name_to_txt_card:
+                card = name_to_txt_card[name]
+                count = decklist_names[name]
+                handle_card(card, count)
+    else:
+        for card in txt_cards:
+            handle_card(card, 1)
+
+    return cards, valid, invalid, unparsed
+
 def mtg_open_file(fname, verbose = False,
                   linetrans = True, fmt_ordered = cardlib.fmt_ordered_default,
                   exclude_sets = default_exclude_sets,
@@ -452,7 +557,8 @@ def mtg_open_file(fname, verbose = False,
                   exclude_layouts = default_exclude_layouts,
                   report_file=None, grep=None, vgrep=None,
                   sets=None, rarities=None,
-                  shuffle=False, seed=None):
+                  shuffle=False, seed=None,
+                  decklist_file=None):
 
     cards = []
     valid = 0
@@ -463,6 +569,12 @@ def mtg_open_file(fname, verbose = False,
     report_fobj = None
     if report_file:
         report_fobj = open(report_file, 'w', encoding='utf-8')
+
+    decklist_names = None
+    if decklist_file:
+        decklist_names = parse_decklist(decklist_file)
+        if verbose:
+            print(f"Loaded decklist from {decklist_file} with {len(decklist_names)} unique cards.", file=sys.stderr)
 
     # Directory Handling
     if fname != '-' and (os.path.isdir(fname) or fname.endswith('.zip')):
@@ -564,9 +676,11 @@ def mtg_open_file(fname, verbose = False,
                      print('Opened ' + str(len(txt_cards)) + ' cards from encoded text files.', file=sys.stderr)
 
         cards = _process_json_srcs(aggregated_srcs, aggregated_bad_sets, verbose, linetrans,
-                                   exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                   decklist_names=decklist_names)
         # Combine with cards from encoded text files
-        cards.extend(txt_cards)
+        processed_txt, _, _, _ = _process_text_cards(txt_cards, decklist_names, verbose, report_fobj=report_fobj)
+        cards.extend(processed_txt)
 
     # Single CSV File Handling
     elif fname.endswith('.csv'):
@@ -575,7 +689,8 @@ def mtg_open_file(fname, verbose = False,
         csv_srcs, bad_sets = mtg_open_csv(fname, verbose)
 
         cards = _process_json_srcs(csv_srcs, bad_sets, verbose, linetrans,
-                                   exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                   decklist_names=decklist_names)
 
     # Single JSONL File Handling
     elif fname.endswith('.jsonl'):
@@ -584,7 +699,8 @@ def mtg_open_file(fname, verbose = False,
         jsonl_srcs, bad_sets = mtg_open_jsonl(fname, verbose)
 
         cards = _process_json_srcs(jsonl_srcs, bad_sets, verbose, linetrans,
-                                   exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                   decklist_names=decklist_names)
 
     # Single MSE File Handling
     elif fname.endswith('.mse-set'):
@@ -593,7 +709,8 @@ def mtg_open_file(fname, verbose = False,
         mse_srcs, bad_sets = mtg_open_mse(fname, verbose)
 
         cards = _process_json_srcs(mse_srcs, bad_sets, verbose, linetrans,
-                                   exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                   decklist_names=decklist_names)
 
     # Encoded Text File Handling
     elif fname == '-' or (not fname.endswith('.json') and not fname.endswith('.mse-set')):
@@ -610,7 +727,8 @@ def mtg_open_file(fname, verbose = False,
                         print('Detected JSON input from stdin.', file=sys.stderr)
                     json_srcs, bad_sets = mtg_open_json_obj(jobj, verbose)
                     cards = _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
-                                               exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                               exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                               decklist_names=decklist_names)
                 except json.JSONDecodeError:
                     # Try JSONL
                     jsonl_srcs, bad_sets = mtg_open_jsonl_content(text, verbose)
@@ -618,7 +736,8 @@ def mtg_open_file(fname, verbose = False,
                         if verbose:
                             print('Detected JSONL input from stdin.', file=sys.stderr)
                         cards = _process_json_srcs(jsonl_srcs, bad_sets, verbose, linetrans,
-                                                   exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                                   decklist_names=decklist_names)
             # 2. CSV Detection
             if not cards and stripped.startswith('name,'):
                 try:
@@ -627,7 +746,8 @@ def mtg_open_file(fname, verbose = False,
                         print('Detected CSV input from stdin.', file=sys.stderr)
                     csv_srcs, bad_sets = mtg_open_csv_reader(reader, verbose)
                     cards = _process_json_srcs(csv_srcs, bad_sets, verbose, linetrans,
-                                               exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                               exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                               decklist_names=decklist_names)
                 except Exception:
                     pass
         else:
@@ -653,23 +773,11 @@ def mtg_open_file(fname, verbose = False,
                     else:
                         skipped += 1
 
-            for card in txt_cards:
-                # unlike opening from json, we still want to return invalid cards
-                cards += [card]
-                if card.valid:
-                    valid += 1
-                elif card.parsed:
-                    invalid += 1
-                    if verbose:
-                        print ('Invalid card: ' + (card.raw if card.raw else card.encode()), file=sys.stderr)
-                    if report_fobj:
-                        report_fobj.write((card.raw if card.raw else card.encode()) + utils.cardsep)
-                else:
-                    unparsed += 1
-                    if verbose:
-                        print ('Failed to parse card: ' + (card.raw if card.raw else card.encode()), file=sys.stderr)
-                    if report_fobj:
-                        report_fobj.write((card.raw if card.raw else card.encode()) + utils.cardsep)
+            processed_txt, valid_txt, invalid_txt, unparsed_txt = _process_text_cards(txt_cards, decklist_names, verbose, report_fobj=report_fobj)
+            cards.extend(processed_txt)
+            valid += valid_txt
+            invalid += invalid_txt
+            unparsed += unparsed_txt
 
             if verbose:
                  print((str(valid) + ' valid, ' + str(skipped) + ' skipped, '
@@ -682,7 +790,8 @@ def mtg_open_file(fname, verbose = False,
         json_srcs, bad_sets = mtg_open_json(fname, verbose)
 
         cards = _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
-                                   exclude_sets, exclude_types, exclude_layouts, report_fobj)
+                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                   decklist_names=decklist_names)
 
     if grep or vgrep or sets or rarities:
         greps = [re.compile(p, re.IGNORECASE) for p in (grep if grep else [])]

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -20,7 +20,7 @@ except ImportError:
     def tqdm(iterable, **kwargs):
         return iterable
 
-def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = None, limit = 0, json_out = False, vgrep = None, sets = None, rarities = None, shuffle = False, seed = None, quiet = False, oname = None):
+def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = None, limit = 0, json_out = False, vgrep = None, sets = None, rarities = None, shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None):
 
     # Set default format to JSON if no specific output format is selected and outfile is .json
     if not json_out and oname and oname.endswith('.json'):
@@ -33,7 +33,8 @@ def main(fname, verbose = True, outliers = False, dump_all = False, grep = None,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
-                                  shuffle=shuffle, seed=seed)
+                                  shuffle=shuffle, seed=seed,
+                                  decklist_file=decklist_file)
 
     if limit > 0:
         cards = cards[:limit]
@@ -107,6 +108,8 @@ if __name__ == '__main__':
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
                         help='Only include cards of these rarities (common, uncommon, rare, mythic).')
+    proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
+                        help='Filter cards using a standard MTG decklist file. Also supports card multiplication based on counts in the decklist.')
     
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -129,5 +132,5 @@ if __name__ == '__main__':
         args.shuffle = True
         args.limit = args.sample
 
-    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = args.color, limit = args.limit, json_out = args.json, vgrep = args.vgrep, sets = args.set, rarities = args.rarity, shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile)
+    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = args.color, limit = args.limit, json_out = args.json, vgrep = args.vgrep, sets = args.set, rarities = args.rarity, shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -228,6 +228,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
                         help='Only include cards of these rarities (common, uncommon, rare, mythic).')
+    proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
+                        help='Filter cards using a standard MTG decklist file. Also supports card multiplication based on counts in the decklist.')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -271,7 +273,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
-                                  shuffle=args.shuffle, seed=args.seed)
+                                  shuffle=args.shuffle, seed=args.seed,
+                                  decklist_file=args.deck)
 
     if args.limit > 0:
         cards = cards[:args.limit]

--- a/tests/test_decklist_input.py
+++ b/tests/test_decklist_input.py
@@ -1,0 +1,105 @@
+import pytest
+import os
+import sys
+import tempfile
+
+# Add lib to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+import jdecode
+import cardlib
+import utils
+
+@pytest.fixture
+def sample_json_data():
+    return {
+        "data": {
+            "SET1": {
+                "name": "Set 1",
+                "code": "SET1",
+                "type": "expansion",
+                "cards": [
+                    {"name": "Grizzly Bears", "rarity": "Common", "types": ["Creature"], "power": "2", "toughness": "2"},
+                    {"name": "Black Lotus", "rarity": "Rare", "types": ["Artifact"]},
+                    {"name": "Giant Growth", "rarity": "Common", "types": ["Instant"]}
+                ]
+            }
+        }
+    }
+
+def test_parse_decklist(tmp_path):
+    decklist_content = """
+    4 Grizzly Bears
+    1 Black Lotus (LEA) 232
+    // A comment
+    2 Giant Growth
+    """
+    deck_file = tmp_path / "deck.txt"
+    deck_file.write_text(decklist_content)
+
+    name_counts = jdecode.parse_decklist(str(deck_file))
+
+    assert name_counts["grizzly bears"] == 4
+    assert name_counts["black lotus"] == 1
+    assert name_counts["giant growth"] == 2
+    assert len(name_counts) == 3
+
+def test_decklist_filtering(sample_json_data, tmp_path):
+    # Create a decklist with only some cards
+    decklist_content = "1 Grizzly Bears\n2 Giant Growth"
+    deck_file = tmp_path / "deck.txt"
+    deck_file.write_text(decklist_content)
+
+    # Mock mtg_open_json to return our sample data
+    import json
+    json_file = tmp_path / "data.json"
+    json_file.write_text(json.dumps(sample_json_data))
+
+    # Load with decklist filter
+    cards = jdecode.mtg_open_file(str(json_file), decklist_file=str(deck_file))
+
+    # Grizzly Bears (1) + Giant Growth (2) = 3 cards
+    assert len(cards) == 3
+    names = [c.name.lower() for c in cards]
+    assert names.count("grizzly bears") == 1
+    assert names.count("giant growth") == 2
+    assert "black lotus" not in names
+
+def test_decklist_non_existent_cards(sample_json_data, tmp_path):
+    # Card not in database
+    decklist_content = "4 Spectral Bears"
+    deck_file = tmp_path / "deck.txt"
+    deck_file.write_text(decklist_content)
+
+    import json
+    json_file = tmp_path / "data.json"
+    json_file.write_text(json.dumps(sample_json_data))
+
+    # Load with decklist filter
+    cards = jdecode.mtg_open_file(str(json_file), decklist_file=str(deck_file))
+
+    assert len(cards) == 0
+
+def test_decklist_with_encoded_text(tmp_path):
+    # Create encoded text cards using 'named' encoding for simplicity in test
+    # fmt_ordered_named = [field_name, field_types, field_supertypes, field_subtypes, field_loyalty, field_pt, field_text, field_cost, field_rarity]
+    encoded_cards = (
+        "|Grizzly Bears|creature||||2/2||{1}{G}|common|" + utils.cardsep +
+        "|Black Lotus|artifact||||||{0}|rare|"
+    )
+    text_file = tmp_path / "cards.txt"
+    text_file.write_text(encoded_cards)
+
+    # Create decklist filter (only Grizzly Bears, but 4 of them)
+    decklist_content = "4 Grizzly Bears"
+    deck_file = tmp_path / "deck.txt"
+    deck_file.write_text(decklist_content)
+
+    # Load with decklist filter
+    # We specify encoding='named' to match our test data
+    cards = jdecode.mtg_open_file(str(text_file), decklist_file=str(deck_file), fmt_ordered=cardlib.fmt_ordered_named)
+
+    assert len(cards) == 4
+    for card in cards:
+        assert card.name.lower() == "grizzly bears"


### PR DESCRIPTION
Implemented support for MTG decklists as input filters, allowing users to specify a set of cards and counts to process from larger datasets. This improves symmetry with the existing decklist export feature and adds significant convenience for batching operations.

---
*PR created automatically by Jules for task [2953577342416462883](https://jules.google.com/task/2953577342416462883) started by @RainRat*