### PR TITLE
Remove redundant color_header wrapper in lib/datalib.py

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -53,11 +53,6 @@ def color_count(count, use_color, color_code=utils.Ansi.BOLD + utils.Ansi.GREEN)
         return utils.colorize(s, color_code)
     return s
 
-def color_header(text, use_color):
-    if use_color:
-        return utils.colorize(text, utils.Ansi.BOLD + utils.Ansi.CYAN)
-    return text
-
 def color_line(text, use_color, color_code=utils.Ansi.BOLD + utils.Ansi.CYAN):
     if use_color:
         return utils.colorize(text, color_code)
@@ -177,7 +172,7 @@ class Datamine:
     def summarize(self, hsize = 10, vsize = 10, cmcsize = 20, use_color = False):
 
         print(color_line('========================================', use_color))
-        print(color_header('             DATASET SUMMARY            ', use_color))
+        print(color_line('             DATASET SUMMARY            ', use_color))
         print(color_line('========================================', use_color))
         print(color_count(len(self.cards), use_color) + ' valid cards, ' +
               color_count(len(self.invalid_cards), use_color, utils.Ansi.BOLD + utils.Ansi.RED) + ' invalid cards.')
@@ -185,26 +180,26 @@ class Datamine:
               color_count(len(self.unparsed_cards), use_color, utils.Ansi.BOLD + utils.Ansi.RED) + ' failed to parse')
         print()
 
-        print(color_header(str(len(self.by_name)) + ' unique card names', use_color))
+        print(color_line(str(len(self.by_name)) + ' unique card names', use_color))
         print()
 
-        print(color_header(str(len(self.by_color_inclusive)) + ' represented colors (including colorless as \'A\'), '
+        print(color_line(str(len(self.by_color_inclusive)) + ' represented colors (including colorless as \'A\'), '
                + str(len(self.by_color)) + ' combinations', use_color))
-        print(color_header('Breakdown by color:', use_color))
+        print(color_line('Breakdown by color:', use_color))
         rows = []
         for k in sorted(self.by_color_inclusive.keys()):
             rows += [[k, color_count(len(self.by_color_inclusive[k]), use_color)]]
         printrows(padrows(rows))
-        print(color_header('Breakdown by number of colors:', use_color))
+        print(color_line('Breakdown by number of colors:', use_color))
         rows = []
         for k in sorted(self.by_color_count.keys()):
             rows += [[str(k), color_count(len(self.by_color_count[k]), use_color)]]
         printrows(padrows(rows))
         print()
 
-        print(color_header(str(len(self.by_type_inclusive)) + ' unique card types, ' +
+        print(color_line(str(len(self.by_type_inclusive)) + ' unique card types, ' +
               str(len(self.by_type)) + ' combinations', use_color))
-        print(color_header('Breakdown by type:', use_color))
+        print(color_line('Breakdown by type:', use_color))
         d = sorted(self.by_type_inclusive,
                    key=lambda x: len(self.by_type_inclusive[x]),
                    reverse=True)
@@ -214,9 +209,9 @@ class Datamine:
         printrows(padrows(rows))
         print()
 
-        print(color_header(str(len(self.by_subtype_inclusive)) + ' unique subtypes, '
+        print(color_line(str(len(self.by_subtype_inclusive)) + ' unique subtypes, '
                + str(len(self.by_subtype)) + ' combinations', use_color))
-        print(color_header('Popular subtypes:', use_color))
+        print(color_line('Popular subtypes:', use_color))
         d = sorted(self.by_subtype_inclusive,
                    key=lambda x: len(self.by_subtype_inclusive[x]),
                    reverse=True)
@@ -224,7 +219,7 @@ class Datamine:
         for k in d[0:vsize]:
             rows += [[k, color_count(len(self.by_subtype_inclusive[k]), use_color)]]
         printrows(padrows(rows))
-        print(color_header('Top combinations:', use_color))
+        print(color_line('Top combinations:', use_color))
         d = sorted(self.by_subtype,
                    key=lambda x: len(self.by_subtype[x]),
                    reverse = True)
@@ -234,9 +229,9 @@ class Datamine:
         printrows(padrows(rows))
         print()
 
-        print(color_header(str(len(self.by_supertype_inclusive)) + ' unique supertypes, '
+        print(color_line(str(len(self.by_supertype_inclusive)) + ' unique supertypes, '
                + str(len(self.by_supertype)) + ' combinations', use_color))
-        print(color_header('Breakdown by supertype:', use_color))
+        print(color_line('Breakdown by supertype:', use_color))
         d = sorted(self.by_supertype_inclusive,
                    key=lambda x: len(self.by_supertype_inclusive[x]),
                    reverse=True)
@@ -246,16 +241,16 @@ class Datamine:
         printrows(padrows(rows))
         print()
 
-        print(color_header(str(len(self.by_cmc)) + ' different CMCs, ' +
+        print(color_line(str(len(self.by_cmc)) + ' different CMCs, ' +
               str(len(self.by_cost)) + ' unique mana costs', use_color))
         print('Average CMC: {:.2f}'.format(self.avg_cmc))
-        print(color_header('Breakdown by CMC:', use_color))
+        print(color_line('Breakdown by CMC:', use_color))
         d = sorted(self.by_cmc, reverse=False)
         rows = []
         for k in d[:vsize]:
             rows += [[str(k), color_count(len(self.by_cmc[k]), use_color)]]
         printrows(padrows(rows))
-        print(color_header('Popular mana costs:', use_color))
+        print(color_line('Popular mana costs:', use_color))
         d = sorted(self.by_cost,
                    key=lambda x: len(self.by_cost[x]),
                    reverse = True)
@@ -265,19 +260,19 @@ class Datamine:
         printrows(padrows(rows))
         print()
 
-        print(color_header(str(len(self.by_rarity)) + ' represented rarities', use_color))
-        print(color_header('Breakdown by rarity:', use_color))
+        print(color_line(str(len(self.by_rarity)) + ' represented rarities', use_color))
+        print(color_line('Breakdown by rarity:', use_color))
         rows = []
         for k in sorted(self.by_rarity.keys()):
             rows += [[k, color_count(len(self.by_rarity[k]), use_color)]]
         printrows(padrows(rows))
         print()
 
-        print(color_header(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
+        print(color_line(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
         if len(self.by_power) > 0 and len(self.by_toughness) > 0:
             print(('Largest power: ' + str(max(list(map(len, self.by_power))) - 1) +
                    ', largest toughness: ' + str(max(list(map(len, self.by_toughness))) - 1)))
-        print(color_header('Popular p/t values:', use_color))
+        print(color_line('Popular p/t values:', use_color))
         d = sorted(self.by_pt,
                    key=lambda x: len(self.by_pt[x]),
                    reverse = True)
@@ -287,7 +282,7 @@ class Datamine:
         printrows(padrows(rows))
         print()
 
-        print(color_header('Loyalty values:', use_color))
+        print(color_line('Loyalty values:', use_color))
         d = sorted(self.by_loyalty,
                    key=lambda x: len(self.by_loyalty[x]),
                    reverse = True)
@@ -298,11 +293,11 @@ class Datamine:
         print()
 
         if len(self.by_textlen) > 0 and len(self.by_textlines) > 0:
-            print(color_header('Card text ranges from ' + str(min(self.by_textlen)) + ' to '
+            print(color_line('Card text ranges from ' + str(min(self.by_textlen)) + ' to '
                    + str(max(self.by_textlen)) + ' characters in length', use_color))
-            print(color_header('Card text ranges from ' + str(min(self.by_textlines)) + ' to '
+            print(color_line('Card text ranges from ' + str(min(self.by_textlines)) + ' to '
                    + str(max(self.by_textlines)) + ' lines', use_color))
-        print(color_header('Line counts by frequency:', use_color))
+        print(color_line('Line counts by frequency:', use_color))
         d = sorted(self.by_textlines,
                    key=lambda x: len(self.by_textlines[x]),
                    reverse = True)
@@ -316,9 +311,9 @@ class Datamine:
     def outliers(self, hsize=10, vsize=10, dump_invalid=False, use_color = False):
 
         print(color_line('========================================', use_color))
-        print(color_header('            OUTLIER ANALYSIS            ', use_color))
+        print(color_line('            OUTLIER ANALYSIS            ', use_color))
         print(color_line('========================================', use_color))
-        print(color_header('Overview of indices:', use_color))
+        print(color_line('Overview of indices:', use_color))
         rows = [['Index Name', 'Keys', 'Total Members']]
         for index in self.indices:
             rows += [[index, color_count(len(self.indices[index]), use_color),
@@ -330,12 +325,12 @@ class Datamine:
             scardname = sorted(self.by_name,
                                key=len,
                                reverse=False)[0]
-            print(color_header('Shortest Cardname: (' + str(len(scardname)) + ')', use_color))
+            print(color_line('Shortest Cardname: (' + str(len(scardname)) + ')', use_color))
             print('  ' + scardname)
             lcardname = sorted(self.by_name,
                                key=len,
                                reverse=True)[0]
-            print(color_header('Longest Cardname: (' + str(len(lcardname)) + ')', use_color))
+            print(color_line('Longest Cardname: (' + str(len(lcardname)) + ')', use_color))
             print('  ' + lcardname)
             d = sorted(self.by_name,
                        key=lambda x: len(self.by_name[x]),
@@ -347,7 +342,7 @@ class Datamine:
             if rows == []:
                 print('No duplicated cardnames')
             else:
-                print(color_header('Most duplicated names:', use_color))
+                print(color_line('Most duplicated names:', use_color))
                 printrows(padrows(rows))
         else:
             print('No cards indexed by name?')
@@ -357,7 +352,7 @@ class Datamine:
             ltypes = sorted(self.by_type,
                             key=len,
                             reverse=True)[0]
-            print(color_header('Longest card type: (' + str(len(ltypes)) + ')', use_color))
+            print(color_line('Longest card type: (' + str(len(ltypes)) + ')', use_color))
             print('  ' + ltypes)
         else:
             print('No cards indexed by type?')
@@ -365,7 +360,7 @@ class Datamine:
             lsubtypes = sorted(self.by_subtype,
                                key=len,
                                reverse=True)[0]
-            print(color_header('Longest subtype: (' + str(len(lsubtypes)) + ')', use_color))
+            print(color_line('Longest subtype: (' + str(len(lsubtypes)) + ')', use_color))
             print('  ' + lsubtypes)
         else:
             print('No cards indexed by subtype?')
@@ -373,7 +368,7 @@ class Datamine:
             lsupertypes = sorted(self.by_supertype,
                                  key=len,
                                  reverse=True)[0]
-            print(color_header('Longest supertype: (' + str(len(lsupertypes)) + ')', use_color))
+            print(color_line('Longest supertype: (' + str(len(lsupertypes)) + ')', use_color))
             print('  ' + lsupertypes)
         else:
             print('No cards indexed by supertype?')
@@ -383,14 +378,14 @@ class Datamine:
             lcost = sorted(self.by_cost,
                            key=len,
                            reverse=True)[0]
-            print(color_header('Longest mana cost: (' + str(len(lcost)) + ')', use_color))
+            print(color_line('Longest mana cost: (' + str(len(lcost)) + ')', use_color))
             print('  ' + utils.from_mana(lcost))
             print('\n' + plimit(self.by_cost[lcost][0].encode()) + '\n')
         else:
             print('No cards indexed by cost?')
         if len(self.by_cmc) > 0:
             lcmc = sorted(self.by_cmc, reverse=True)[0]
-            print(color_header('Largest cmc: (' + str(lcmc) + ')', use_color))
+            print(color_line('Largest cmc: (' + str(lcmc) + ')', use_color))
             print('  ' + str(self.by_cmc[lcmc][0].cost))
             print('\n' + plimit(self.by_cmc[lcmc][0].encode()))
         else:
@@ -401,7 +396,7 @@ class Datamine:
             lpower = sorted(self.by_power,
                             key=len,
                             reverse=True)[0]
-            print(color_header('Largest creature power: ' + utils.from_unary(lpower), use_color))
+            print(color_line('Largest creature power: ' + utils.from_unary(lpower), use_color))
             print('\n' + plimit(self.by_power[lpower][0].encode()) + '\n')
         else:
             print('No cards indexed by power?')
@@ -409,7 +404,7 @@ class Datamine:
             ltoughness = sorted(self.by_toughness,
                                 key=len,
                                 reverse=True)[0]
-            print(color_header('Largest creature toughness: ' +
+            print(color_line('Largest creature toughness: ' +
                   utils.from_unary(ltoughness), use_color))
             print('\n' + plimit(self.by_toughness[ltoughness][0].encode()))
         else:
@@ -418,19 +413,19 @@ class Datamine:
 
         if len(self.by_textlines) > 0:
             llines = sorted(self.by_textlines, reverse=True)[0]
-            print(color_header('Most lines of text in a card: ' + str(llines), use_color))
+            print(color_line('Most lines of text in a card: ' + str(llines), use_color))
             print('\n' + plimit(self.by_textlines[llines][0].encode()) + '\n')
         else:
             print('No cards indexed by line count?')
         if len(self.by_textlen) > 0:
             ltext = sorted(self.by_textlen, reverse=True)[0]
-            print(color_header('Most chars in a card text: ' + str(ltext), use_color))
+            print(color_line('Most chars in a card text: ' + str(ltext), use_color))
             print('\n' + plimit(self.by_textlen[ltext][0].encode()))
         else:
             print('No cards indexed by char count?')
         print()
 
-        print(color_header('There were ' + color_count(len(self.invalid_cards), use_color, utils.Ansi.BOLD + utils.Ansi.RED) + ' invalid cards.', use_color))
+        print(color_line('There were ' + color_count(len(self.invalid_cards), use_color, utils.Ansi.BOLD + utils.Ansi.RED) + ' invalid cards.', use_color))
         if dump_invalid:
             for card in self.invalid_cards:
                 print('\n' + repr(card.fields))
@@ -438,7 +433,7 @@ class Datamine:
             print('Not summarizing.')
         print()
 
-        print(color_header('There were ' + color_count(len(self.unparsed_cards), use_color, utils.Ansi.BOLD + utils.Ansi.RED) + ' unparsed cards.', use_color))
+        print(color_line('There were ' + color_count(len(self.unparsed_cards), use_color, utils.Ansi.BOLD + utils.Ansi.RED) + ' unparsed cards.', use_color))
         if dump_invalid:
             for card in self.unparsed_cards:
                 print('\n' + repr(card.fields))


### PR DESCRIPTION
Identified and resolved a **Redundant Wrapper** issue in `lib/datalib.py`.

### Changes:
*   Removed `color_header(text, use_color)` function.
*   Replaced 40+ occurrences of `color_header` with `color_line` in `lib/datalib.py`.
*   Verified that `color_line` provides identical functionality via its default `color_code=utils.Ansi.BOLD + utils.Ansi.CYAN`.
*   Confirmed no syntax errors and verified that all 299 tests pass.

---
*PR created automatically by Jules for task [9793796555755254585](https://jules.google.com/task/9793796555755254585) started by @RainRat*