### PR TITLE
[FEAT] Semantic ANSI colorization for mana and special symbols

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -689,9 +689,6 @@ class Card:
         # 4. Unary unpass
         mtext = utils.from_unary(mtext)
 
-        # 5. Symbols unpass (called BEFORE cardname to avoid Zombie {T}est bug)
-        mtext = utils.from_symbols(mtext, for_forum, for_html)
-
         # 6. Sentencecase
         mtext = sentencecase(mtext)
 
@@ -709,6 +706,9 @@ class Card:
         # 9. Unicode (MSE or Gatherer)
         if mse or gatherer:
             mtext = transforms.text_unpass_8_unicode(mtext)
+
+        # 9.5. Symbols unpass (called AFTER sentencecase to avoid color corruption)
+        mtext = utils.from_symbols(mtext, for_forum, for_html, ansi_color=ansi_color)
 
         # 10. Final formatting via Manatext
         newtext = Manatext('')

--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -109,9 +109,8 @@ class Manacost:
         
         else:
             s = utils.mana_untranslate(utils.mana_open_delimiter + ''.join(self.sequence)
-                                          + utils.mana_close_delimiter, for_forum, for_html)
-            if ansi_color:
-                return utils.colorize(s, utils.Ansi.CYAN)
+                                          + utils.mana_close_delimiter, for_forum, for_html,
+                                          ansi_color = ansi_color)
             return s
 
     def encode(self, randomize = False):
@@ -179,7 +178,9 @@ class Manatext:
     def format(self, for_forum = False, for_html = False, ansi_color = False):
         text = self.text
         for cost in self.costs:
-            text = text.replace(utils.reserved_mana_marker, cost.format(for_forum=for_forum, for_html=for_html, ansi_color=ansi_color), 1)
+            text = text.replace(utils.reserved_mana_marker,
+                                cost.format(for_forum=for_forum, for_html=for_html,
+                                            ansi_color=ansi_color), 1)
         if for_html:
             text = text.replace('\n', '<br>\n')
         # Unescape literal reserved_mana_marker characters

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -441,10 +441,32 @@ def mana_translate(jmanastr):
 # convert an encoded mana string back to json
 mana_symlen_min = min([len(sym) for sym in mana_symall_decode])
 mana_symlen_max = max([len(sym) for sym in mana_symall_decode])
-def mana_untranslate(manastr, for_forum = False, for_html = False):
+def mana_untranslate(manastr, for_forum = False, for_html = False, ansi_color = False):
     inner = manastr[1:-1]
     jmanastr = ''
     colorless_total = 0
+
+    def get_sym_color(sym):
+        # Individual symbol color mapping
+        if not ansi_color:
+            return None
+        sym_upper = sym.upper()
+        if sym_upper in ['W']:
+            return Ansi.WHITE
+        if sym_upper in ['U']:
+            return Ansi.CYAN
+        if sym_upper in ['B']:
+            return Ansi.MAGENTA
+        if sym_upper in ['R']:
+            return Ansi.RED
+        if sym_upper in ['G']:
+            return Ansi.GREEN
+        if any(c in sym_upper for c in 'WUBRG'):
+            # Hybrid or Phyrexian with colors
+            return Ansi.BOLD + Ansi.YELLOW
+        # Colorless, X, S, E, etc.
+        return Ansi.BOLD
+
     idx = 0
     while idx < len(inner):
         # taking this branch is an infinite loop if unary_marker is empty
@@ -468,7 +490,12 @@ def mana_untranslate(manastr, for_forum = False, for_html = False):
                     elif for_forum:
                         jmanastr = jmanastr + mana_decode_direct_forum(sym)
                     else:
-                        jmanastr = jmanastr + mana_decode_direct(sym)
+                        decoded = mana_decode_direct(sym)
+                        if ansi_color:
+                            color = get_sym_color(mana_symall_decode[sym])
+                            if color:
+                                decoded = colorize(decoded, color)
+                        jmanastr = jmanastr + decoded
                     break
             # otherwise we'll go into an infinite loop if we see a symbol we don't know
             if idx == old_idx:
@@ -490,12 +517,20 @@ def mana_untranslate(manastr, for_forum = False, for_html = False):
                                                  else str(colorless_total))
                     + jmanastr + mana_forum_close_delimiter)
     else:
+        colorless_str = ''
+        if colorless_total > 0 or jmanastr == '':
+            colorless_str = mana_json_open_delimiter + str(colorless_total) + mana_json_close_delimiter
+            if ansi_color:
+                colorless_str = colorize(colorless_str, Ansi.BOLD)
+
         if jmanastr == '':
-            return mana_json_open_delimiter + str(colorless_total) + mana_json_close_delimiter
+            return colorless_str
         else:
-            return (('' if colorless_total == 0 else 
-                     mana_json_open_delimiter + str(colorless_total) + mana_json_close_delimiter)
-                    + jmanastr)
+            # If jmanastr is not empty, we only include colorless if it's > 0
+            if colorless_total > 0:
+                return colorless_str + jmanastr
+            else:
+                return jmanastr
 
 # finally, replacing all instances in a string
 # notice the calls to .upper(), this way we recognize lowercase symbols as well just in case
@@ -503,8 +538,8 @@ def to_mana(s):
     return re.sub(mana_json_regex, lambda m: mana_translate(m.group(0).upper()), s)
 
 
-def from_mana(s, for_forum=False, for_html=False):
-    return re.sub(mana_regex, lambda m: mana_untranslate(m.group(0).upper(), for_forum=for_forum, for_html=for_html), s)
+def from_mana(s, for_forum=False, for_html=False, ansi_color=False):
+    return re.sub(mana_regex, lambda m: mana_untranslate(m.group(0).upper(), for_forum=for_forum, for_html=for_html, ansi_color=ansi_color), s)
     
 # Translation could also be accomplished using the datamine.Manacost object's
 # display methods, but these direct string transformations are retained for
@@ -544,7 +579,7 @@ def to_symbols(s):
     return re.sub(json_symbol_regex, lambda m: json_symbol_trans[m.group(0)], s)
 
 
-def from_symbols(s, for_forum=False, for_html=False):
+def from_symbols(s, for_forum=False, for_html=False, ansi_color=False):
     def replace(match):
         sym = match.group(0)
         if for_html:
@@ -552,7 +587,10 @@ def from_symbols(s, for_forum=False, for_html=False):
         elif for_forum:
             return symbol_forum_trans[sym]
         else:
-            return symbol_trans[sym]
+            res = symbol_trans[sym]
+            if ansi_color:
+                res = colorize(res, Ansi.BOLD + Ansi.YELLOW)
+            return res
     return re.sub(symbol_regex, replace, s)
 
 unletters_regex = r"[^abcdefghijklmnopqrstuvwxyz']"

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -110,7 +110,7 @@ def test_card_format(sample_card_json):
     # P/T: Red
     # Rarity: Cyan (Uncommon)
     expected_name = utils.colorize("Ornithopter", utils.Ansi.BOLD + utils.Ansi.CYAN)
-    expected_cost = utils.colorize("{0}", utils.Ansi.CYAN)
+    expected_cost = utils.colorize("{0}", utils.Ansi.BOLD)
     expected_type = utils.colorize("Artifact Creature ~ Thopter", utils.Ansi.GREEN)
     expected_pt = utils.colorize("0/2", utils.Ansi.RED)
     expected_rarity = utils.colorize("uncommon", utils.Ansi.BOLD + utils.Ansi.CYAN)
@@ -134,7 +134,7 @@ def test_card_summary(sample_card_json):
     # Test colored summary
     colored_output = card.summary(ansi_color=True)
     expected_name = utils.colorize("Ornithopter", utils.Ansi.BOLD + utils.Ansi.CYAN)
-    expected_cost = utils.colorize("{0}", utils.Ansi.CYAN)
+    expected_cost = utils.colorize("{0}", utils.Ansi.BOLD)
     expected_type = utils.colorize("Artifact Creature — Thopter", utils.Ansi.GREEN)
     expected_pt = utils.colorize("0/2", utils.Ansi.RED)
     expected_rarity_indicator = utils.colorize("U", utils.Ansi.BOLD + utils.Ansi.CYAN)

--- a/tests/test_manalib.py
+++ b/tests/test_manalib.py
@@ -113,7 +113,12 @@ class TestManacost:
 
         # ANSI Color
         colored = m.format(ansi_color=True)
-        assert colored == utils.colorize("{W}{U}{B}{R}{G}", utils.Ansi.CYAN)
+        expected = (utils.colorize("{W}", utils.Ansi.WHITE) +
+                    utils.colorize("{U}", utils.Ansi.CYAN) +
+                    utils.colorize("{B}", utils.Ansi.MAGENTA) +
+                    utils.colorize("{R}", utils.Ansi.RED) +
+                    utils.colorize("{G}", utils.Ansi.GREEN))
+        assert colored == expected
 
         # None
         assert Manacost("").format() == "_NOCOST_"
@@ -179,7 +184,7 @@ class TestManatext:
         # {X} -> {XX} -> format() -> {X}
         # In Manatext, cost.format(ansi_color=True) is called
         colored = mt.format(ansi_color=True)
-        expected_cost = utils.colorize("{X}", utils.Ansi.CYAN)
+        expected_cost = utils.colorize("{X}", utils.Ansi.BOLD)
         assert colored == f"Pay {expected_cost}."
 
     def test_encode(self):


### PR DESCRIPTION
Implemented semantic ANSI colorization for mana symbols (W, U, B, R, G) and utility symbols (T, Q) in terminal output. This improves readability by providing visual cues consistent with Magic: The Gathering identity. The implementation includes logic to prevent ANSI code corruption during text capitalization and ensures backward compatibility for non-ANSI outputs. All tests passed.

---
*PR created automatically by Jules for task [11274595390940936027](https://jules.google.com/task/11274595390940936027) started by @RainRat*