### PR TITLE
Inline redundant index_size function in datalib.py

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -30,9 +30,6 @@ def printrows(l):
 # index management helpers
 
 
-def index_size(d):
-    return sum([len(d[k]) for k in d])
-
 def inc(d, k, obj):
     if k or k == 0:
         if k in d:
@@ -317,7 +314,7 @@ class Datamine:
         rows = [['Index Name', 'Keys', 'Total Members']]
         for index in self.indices:
             rows += [[index, color_count(len(self.indices[index]), use_color),
-                      color_count(index_size(self.indices[index]), use_color)]]
+                      color_count(sum(len(v) for v in self.indices[index].values()), use_color)]]
         printrows(padrows(rows))
         print()
 

--- a/tests/test_datalib.py
+++ b/tests/test_datalib.py
@@ -7,7 +7,7 @@ import io
 # Ensure lib is in path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib')))
 
-from datalib import Datamine, padrows, index_size, inc, plimit
+from datalib import Datamine, padrows, inc, plimit
 from cardlib import Card
 import utils
 
@@ -93,11 +93,6 @@ def test_padrows_with_color():
     assert padded[0].find('Count') == 14
     assert padded[1].find(color_text) == 14
     assert padded[2].find('10') == 14
-
-def test_index_size():
-    d = {'a': [1, 2], 'b': [3]}
-    assert index_size(d) == 3
-    assert index_size({}) == 0
 
 def test_inc():
     d = {}


### PR DESCRIPTION
Identified and resolved a case of **Premature Abstraction** by inlining the `index_size` function in `lib/datalib.py`. This function was a simple one-line utility used only once. The logic was replaced with a more efficient generator expression. Verified with existing tests and updated the test suite to reflect the change.

---
*PR created automatically by Jules for task [8513643864413705121](https://jules.google.com/task/8513643864413705121) started by @RainRat*