### PR TITLE
[TEST] Fix P/T Ranking Bug and Enhance Datamine Coverage

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -270,8 +270,8 @@ class Datamine:
 
         print(color_line(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
         if len(self.by_power) > 0 and len(self.by_toughness) > 0:
-            print(('Largest power: ' + str(max(list(map(len, self.by_power))) - 1) +
-                   ', largest toughness: ' + str(max(list(map(len, self.by_toughness))) - 1)))
+            print(('Largest power: ' + str(max(map(utils.from_unary_single, self.by_power))) +
+                   ', largest toughness: ' + str(max(map(utils.from_unary_single, self.by_toughness)))))
         print(color_line('Popular p/t values:', use_color))
         d = sorted(self.by_pt,
                    key=lambda x: len(self.by_pt[x]),
@@ -394,7 +394,7 @@ class Datamine:
 
         if len(self.by_power) > 0:
             lpower = sorted(self.by_power,
-                            key=len,
+                            key=utils.from_unary_single,
                             reverse=True)[0]
             print(color_line('Largest creature power: ' + utils.from_unary(lpower), use_color))
             print('\n' + plimit(self.by_power[lpower][0].encode()) + '\n')
@@ -402,7 +402,7 @@ class Datamine:
             print('No cards indexed by power?')
         if len(self.by_toughness) > 0:
             ltoughness = sorted(self.by_toughness,
-                                key=len,
+                                key=utils.from_unary_single,
                                 reverse=True)[0]
             print(color_line('Largest creature toughness: ' +
                   utils.from_unary(ltoughness), use_color))

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -122,6 +122,7 @@ unary_marker = config.unary_marker
 unary_counter = config.unary_counter
 unary_max = config.unary_max
 unary_exceptions = config.unary_exceptions
+_unary_exceptions_inv = {v: k for k, v in unary_exceptions.items()}
 
 def to_unary(s, warn = False):
     def replace_number(match):
@@ -145,6 +146,20 @@ def from_unary(s):
         return str(i)
 
     return _number_unary_re.sub(replace_unary, s)
+
+def from_unary_single(s):
+    """Converts a single unary string (possibly with exceptions) back to a numerical value."""
+    if not s:
+        return 0
+    if s in _unary_exceptions_inv:
+        return _unary_exceptions_inv[s]
+    try:
+        res = from_unary(s)
+        if '.' in res:
+            return float(res)
+        return int(res)
+    except (ValueError, TypeError):
+        return 0
 
 # mana syntax
 mana_open_delimiter = '{'

--- a/tests/test_datalib.py
+++ b/tests/test_datalib.py
@@ -195,6 +195,53 @@ def test_datamine_with_invalid_card():
     finally:
         sys.stdout = old_stdout
 
+def test_pt_ranking_outliers(capsys):
+    # Create cards with power 20 and 25
+    # Power 20 -> & + 20 ^ -> len 21
+    # Power 25 -> twenty~five -> len 11 (mapped via exceptions)
+    # Power 2.5 -> &^^.&^^^^^ (decimal)
+    cards = [
+        {
+            "name": "Giant 20",
+            "types": ["Creature"],
+            "power": "20",
+            "toughness": "20",
+            "rarity": "Common"
+        },
+        {
+            "name": "Giant 25",
+            "types": ["Creature"],
+            "power": "25",
+            "toughness": "25",
+            "rarity": "Common"
+        },
+        {
+            "name": "Giant 2.5",
+            "types": ["Creature"],
+            "power": "2.5",
+            "toughness": "2.5",
+            "rarity": "Common"
+        }
+    ]
+
+    dm = Datamine(cards)
+    dm.summarize()
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Correct ranking should find 25 as largest, and 2.5 should not break anything
+    assert "Largest power: 25" in output
+    assert "largest toughness: 25" in output
+
+    # Check outliers specifically
+    dm.outliers()
+    captured = capsys.readouterr()
+    output = captured.out
+    # Note: outliers use utils.from_unary for display, which returns the exception label (e.g. "twenty~five")
+    assert "Largest creature power: twenty~five" in output
+    assert "Largest creature toughness: twenty~five" in output
+
 def test_datamine_to_dict(datamine_instance):
     result = datamine_instance.to_dict()
 


### PR DESCRIPTION
The `Datamine` class was incorrectly calculating the largest power and toughness in a dataset by relying on the length of the unary representation string. Because certain large values (e.g., 25, 50, 100) are mapped to words (e.g., 'twenty~five'), their string length is actually shorter than smaller values like 20 which are represented as long sequences of carats. 

I implemented a new utility function `utils.from_unary_single` that correctly handles these exceptions and decimal values. I then refactored `lib/datalib.py` to use this function for all P/T comparisons and summaries. Finally, I added a robust test suite to `tests/test_datalib.py` that verifies the correct ranking of these edge cases.

---
*PR created automatically by Jules for task [4202913243294719392](https://jules.google.com/task/4202913243294719392) started by @RainRat*