### PR TITLE
[FEAT] Enhanced card filtering with field-specific grep flags

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -25,6 +25,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          gatherer = True, for_forum = False, for_mse = False,
          creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, summary_out = False, deck_out = False, quiet=False,
          report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None,
+         grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
+         grep_text=None, vgrep_text=None,
          sets=None, rarities=None, shuffle=False, seed=None, decklist_file=None):
 
     # Set default format to text if no specific output format is selected.
@@ -91,6 +93,9 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         raise ValueError('decode.py: unknown encoding: ' + encoding)
 
     cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep, vgrep=vgrep,
+                                  grep_name=grep_name, vgrep_name=vgrep_name,
+                                  grep_types=grep_types, vgrep_types=vgrep_types,
+                                  grep_text=grep_text, vgrep_text=vgrep_text,
                                   sets=sets, rarities=rarities, shuffle=shuffle, seed=seed, decklist_file=decklist_file)
 
     if sort:
@@ -573,8 +578,20 @@ if __name__ == '__main__':
                         help='File path to save the text of cards that failed to parse/validate (useful for debugging).')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards that match a regex (matches name, type, or text). Use multiple times for AND logic.')
+    proc_group.add_argument('--grep-name', action='append',
+                        help='Only include cards whose name matches a regex.')
+    proc_group.add_argument('--grep-type', action='append',
+                        help='Only include cards whose typeline matches a regex.')
+    proc_group.add_argument('--grep-text', action='append',
+                        help='Only include cards whose rules text matches a regex.')
     proc_group.add_argument('--vgrep', '--exclude', action='append',
                         help='Exclude cards that match a regex (matches name, type, or text). Use multiple times for OR logic.')
+    proc_group.add_argument('--exclude-name', action='append',
+                        help='Exclude cards whose name matches a regex.')
+    proc_group.add_argument('--exclude-type', action='append',
+                        help='Exclude cards whose typeline matches a regex.')
+    proc_group.add_argument('--exclude-text', action='append',
+                        help='Exclude cards whose rules text matches a regex.')
     proc_group.add_argument('--set', action='append',
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
@@ -598,7 +615,11 @@ if __name__ == '__main__':
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text,
          json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, summary_out = args.summary, deck_out = args.deck, quiet=args.quiet,
          report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep,
-         sort=args.sort, vgrep=args.vgrep, sets=args.set, rarities=args.rarity,
+         sort=args.sort, vgrep=args.vgrep,
+         grep_name=args.grep_name, vgrep_name=args.exclude_name,
+         grep_types=args.grep_type, vgrep_types=args.exclude_type,
+         grep_text=args.grep_text, vgrep_text=args.exclude_text,
+         sets=args.set, rarities=args.rarity,
          shuffle=args.shuffle, seed=args.seed, decklist_file=args.deck_filter)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -15,6 +15,8 @@ from tqdm import tqdm
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, randomize = False, nolabel = False, stable = False,
          report_file=None, quiet=False, limit=0, grep=None, sort=None, vgrep=None,
+         grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
+         grep_text=None, vgrep_text=None,
          sets=None, rarities=None, seed=None, decklist_file=None):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
@@ -66,6 +68,9 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=line_transformations,
                                   report_file=report_file, grep=grep, vgrep=vgrep,
+                                  grep_name=grep_name, vgrep_name=vgrep_name,
+                                  grep_types=grep_types, vgrep_types=vgrep_types,
+                                  grep_text=grep_text, vgrep_text=vgrep_text,
                                   sets=sets, rarities=rarities,
                                   shuffle=not stable, seed=seed if seed is not None else 1371367,
                                   decklist_file=decklist_file)
@@ -140,8 +145,20 @@ if __name__ == '__main__':
                         help='Sort cards by the specified criterion (enables --stable).')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards that match a regex (matches name, type, or text). Use multiple times for AND logic.')
+    proc_group.add_argument('--grep-name', action='append',
+                        help='Only include cards whose name matches a regex.')
+    proc_group.add_argument('--grep-type', action='append',
+                        help='Only include cards whose typeline matches a regex.')
+    proc_group.add_argument('--grep-text', action='append',
+                        help='Only include cards whose rules text matches a regex.')
     proc_group.add_argument('--vgrep', '--exclude', action='append',
                         help='Exclude cards that match a regex (matches name, type, or text). Use multiple times for OR logic.')
+    proc_group.add_argument('--exclude-name', action='append',
+                        help='Exclude cards whose name matches a regex.')
+    proc_group.add_argument('--exclude-type', action='append',
+                        help='Exclude cards whose typeline matches a regex.')
+    proc_group.add_argument('--exclude-text', action='append',
+                        help='Exclude cards whose rules text matches a regex.')
     proc_group.add_argument('--set', action='append',
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
@@ -168,5 +185,8 @@ if __name__ == '__main__':
          nolinetrans = args.nolinetrans, randomize = args.randomize, nolabel = args.nolabel,
          stable = args.stable, report_file = args.report_unparsed, quiet=args.quiet,
          limit=args.limit, grep=args.grep, sort=args.sort, vgrep=args.vgrep,
+         grep_name=args.grep_name, vgrep_name=args.exclude_name,
+         grep_types=args.grep_type, vgrep_types=args.exclude_type,
+         grep_text=args.grep_text, vgrep_text=args.exclude_text,
          sets=args.set, rarities=args.rarity, seed=args.seed, decklist_file=args.deck)
     exit(0)

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -803,17 +803,31 @@ class Card:
 
     def search(self, pattern):
         """Returns True if the pattern matches any of the card's fields."""
-        if pattern.search(self.name):
+        if self.search_name(pattern):
+            return True
+        if self.search_types(pattern):
+            return True
+        if self.search_text(pattern):
+            return True
+        return False
+
+    def search_name(self, pattern):
+        """Returns True if the pattern matches the card's name."""
+        return bool(pattern.search(self.name))
+
+    def search_types(self, pattern):
+        """Returns True if the pattern matches any of the card's types (supertypes, types, or subtypes)."""
+        if any(pattern.search(t) for t in self.supertypes):
             return True
         if any(pattern.search(t) for t in self.types):
             return True
-        if any(pattern.search(t) for t in self.supertypes):
-            return True
         if any(pattern.search(t) for t in self.subtypes):
             return True
-        if pattern.search(self.text.text):
-            return True
         return False
+
+    def search_text(self, pattern):
+        """Returns True if the pattern matches the card's rules text."""
+        return bool(pattern.search(self.text.text))
 
     def summary(self, ansi_color=False):
         """Returns a compact, one-line summary of the card."""

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -556,6 +556,9 @@ def mtg_open_file(fname, verbose = False,
                   exclude_types = default_exclude_types,
                   exclude_layouts = default_exclude_layouts,
                   report_file=None, grep=None, vgrep=None,
+                  grep_name=None, vgrep_name=None,
+                  grep_types=None, vgrep_types=None,
+                  grep_text=None, vgrep_text=None,
                   sets=None, rarities=None,
                   shuffle=False, seed=None,
                   decklist_file=None):
@@ -793,9 +796,15 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
-    if grep or vgrep or sets or rarities:
+    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text:
         greps = [re.compile(p, re.IGNORECASE) for p in (grep if grep else [])]
         vgreps = [re.compile(p, re.IGNORECASE) for p in (vgrep if vgrep else [])]
+        greps_name = [re.compile(p, re.IGNORECASE) for p in (grep_name if grep_name else [])]
+        vgreps_name = [re.compile(p, re.IGNORECASE) for p in (vgrep_name if vgrep_name else [])]
+        greps_types = [re.compile(p, re.IGNORECASE) for p in (grep_types if grep_types else [])]
+        vgreps_types = [re.compile(p, re.IGNORECASE) for p in (vgrep_types if vgrep_types else [])]
+        greps_text = [re.compile(p, re.IGNORECASE) for p in (grep_text if grep_text else [])]
+        vgreps_text = [re.compile(p, re.IGNORECASE) for p in (vgrep_text if vgrep_text else [])]
 
         target_sets = [s.upper() for s in sets] if sets else None
         target_rarities = []
@@ -809,14 +818,36 @@ def mtg_open_file(fname, verbose = False,
                     target_rarities.append(r)
 
         def match_card(card):
-            # Positive filtering (AND logic): card must match ALL grep patterns
+            # Generic filtering (AND logic for greps, OR logic for vgreps)
             for pattern in greps:
                 if not card.search(pattern):
                     return False
-
-            # Negative filtering (OR logic): card must match NONE of the vgrep patterns
             for pattern in vgreps:
                 if card.search(pattern):
+                    return False
+
+            # Name filtering
+            for pattern in greps_name:
+                if not card.search_name(pattern):
+                    return False
+            for pattern in vgreps_name:
+                if card.search_name(pattern):
+                    return False
+
+            # Type filtering
+            for pattern in greps_types:
+                if not card.search_types(pattern):
+                    return False
+            for pattern in vgreps_types:
+                if card.search_types(pattern):
+                    return False
+
+            # Text filtering
+            for pattern in greps_text:
+                if not card.search_text(pattern):
+                    return False
+            for pattern in vgreps_text:
+                if card.search_text(pattern):
                     return False
 
             # Set filtering

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -20,7 +20,10 @@ except ImportError:
     def tqdm(iterable, **kwargs):
         return iterable
 
-def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = None, limit = 0, json_out = False, vgrep = None, sets = None, rarities = None, shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None):
+def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = None, limit = 0, json_out = False, vgrep = None,
+         grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
+         grep_text=None, vgrep_text=None,
+         sets = None, rarities = None, shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None):
 
     # Set default format to JSON if no specific output format is selected and outfile is .json
     if not json_out and oname and oname.endswith('.json'):
@@ -29,6 +32,9 @@ def main(fname, verbose = True, outliers = False, dump_all = False, grep = None,
     # Use the robust mtg_open_file for all loading and filtering.
     # We disable default exclusions to match original summarize.py behavior.
     cards = jdecode.mtg_open_file(fname, verbose=verbose, grep=grep, vgrep=vgrep,
+                                  grep_name=grep_name, vgrep_name=vgrep_name,
+                                  grep_types=grep_types, vgrep_types=vgrep_types,
+                                  grep_text=grep_text, vgrep_text=vgrep_text,
                                   sets=sets, rarities=rarities,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
@@ -102,8 +108,20 @@ if __name__ == '__main__':
                         help='Pick N random cards from the input (shorthand for --shuffle --limit N).')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards that match a regex (matches name, type, or text). Use multiple times for AND logic.')
+    proc_group.add_argument('--grep-name', action='append',
+                        help='Only include cards whose name matches a regex.')
+    proc_group.add_argument('--grep-type', action='append',
+                        help='Only include cards whose typeline matches a regex.')
+    proc_group.add_argument('--grep-text', action='append',
+                        help='Only include cards whose rules text matches a regex.')
     proc_group.add_argument('--vgrep', '--exclude', action='append',
                         help='Exclude cards that match a regex (matches name, type, or text). Use multiple times for OR logic.')
+    proc_group.add_argument('--exclude-name', action='append',
+                        help='Exclude cards whose name matches a regex.')
+    proc_group.add_argument('--exclude-type', action='append',
+                        help='Exclude cards whose typeline matches a regex.')
+    proc_group.add_argument('--exclude-text', action='append',
+                        help='Exclude cards whose rules text matches a regex.')
     proc_group.add_argument('--set', action='append',
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
@@ -132,5 +150,9 @@ if __name__ == '__main__':
         args.shuffle = True
         args.limit = args.sample
 
-    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = args.color, limit = args.limit, json_out = args.json, vgrep = args.vgrep, sets = args.set, rarities = args.rarity, shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck)
+    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = args.color, limit = args.limit, json_out = args.json, vgrep = args.vgrep,
+         grep_name=args.grep_name, vgrep_name=args.exclude_name,
+         grep_types=args.grep_type, vgrep_types=args.exclude_type,
+         grep_text=args.grep_text, vgrep_text=args.exclude_text,
+         sets = args.set, rarities = args.rarity, shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -222,8 +222,20 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Pick N random cards from the input (equivalent to --shuffle --limit N).')
     proc_group.add_argument('--grep', action='append',
                         help='Filter cards by regex (matches name, type, or text). Can be used multiple times (AND logic).')
+    proc_group.add_argument('--grep-name', action='append',
+                        help='Only include cards whose name matches a regex.')
+    proc_group.add_argument('--grep-type', action='append',
+                        help='Only include cards whose typeline matches a regex.')
+    proc_group.add_argument('--grep-text', action='append',
+                        help='Only include cards whose rules text matches a regex.')
     proc_group.add_argument('--vgrep', '--exclude', action='append',
                         help='Exclude cards matching regex (matches name, type, or text). Can be used multiple times (OR logic).')
+    proc_group.add_argument('--exclude-name', action='append',
+                        help='Exclude cards whose name matches a regex.')
+    proc_group.add_argument('--exclude-type', action='append',
+                        help='Exclude cards whose typeline matches a regex.')
+    proc_group.add_argument('--exclude-text', action='append',
+                        help='Exclude cards whose rules text matches a regex.')
     proc_group.add_argument('--set', action='append',
                         help='Only include cards from these sets (e.g., MOM, MRD).')
     proc_group.add_argument('--rarity', action='append',
@@ -268,7 +280,11 @@ Supports any encoding format supported by encode.py/decode.py.""",
     # Use the robust jdecode.mtg_open_file for loading and filtering.
     # We disable default exclusions (sets, types, layouts) to match the original sortcards.py behavior.
     # verbose=True enables jdecode diagnostic output (e.g. invalid cards).
-    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, fmt_ordered=fmt_ordered, grep=args.grep, vgrep=args.vgrep,
+    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, fmt_ordered=fmt_ordered,
+                                  grep=args.grep, vgrep=args.vgrep,
+                                  grep_name=args.grep_name, vgrep_name=args.exclude_name,
+                                  grep_types=args.grep_type, vgrep_types=args.exclude_type,
+                                  grep_text=args.grep_text, vgrep_text=args.exclude_text,
                                   sets=args.set, rarities=args.rarity,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,

--- a/tests/test_grep_refined.py
+++ b/tests/test_grep_refined.py
@@ -1,0 +1,126 @@
+import os
+import sys
+import pytest
+import tempfile
+import json
+
+# Ensure lib is in path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from lib import jdecode, cardlib
+
+@pytest.fixture
+def sample_cards_file():
+    cards_data = [
+        {
+            "name": "Fire Dragon",
+            "types": ["Creature"],
+            "subtypes": ["Dragon"],
+            "text": "Flying\n{R}: Fire Dragon deals 1 damage.",
+            "manaCost": "{4}{R}{R}",
+            "power": "5",
+            "toughness": "5",
+            "rarity": "rare"
+        },
+        {
+            "name": "Water Elemental",
+            "types": ["Creature"],
+            "subtypes": ["Elemental"],
+            "text": "Islandwalk",
+            "manaCost": "{3}{U}{U}",
+            "power": "5",
+            "toughness": "4",
+            "rarity": "uncommon"
+        },
+        {
+            "name": "Fireball",
+            "types": ["Sorcery"],
+            "text": "Fireball deals X damage.",
+            "manaCost": "{X}{R}",
+            "rarity": "uncommon"
+        },
+        {
+            "name": "Island",
+            "types": ["Land"],
+            "text": "{T}: Add {U}.",
+            "rarity": "common"
+        }
+    ]
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.json', delete=False, encoding='utf-8') as tmp:
+        json.dump(cards_data, tmp)
+        tmp_path = tmp.name
+    yield tmp_path
+    if os.path.exists(tmp_path):
+        os.remove(tmp_path)
+
+def test_grep_name(sample_cards_file):
+    # Should only match Fire Dragon and Fireball, NOT Water Elemental (which might match if we searched everything)
+    cards = jdecode.mtg_open_file(sample_cards_file, grep_name=["Fire"])
+    assert len(cards) == 2
+    names = [c.name for c in cards]
+    assert "fire dragon" in names
+    assert "fireball" in names
+    assert "water elemental" not in names
+
+def test_grep_type(sample_cards_file):
+    # Should match Fire Dragon and Water Elemental
+    cards = jdecode.mtg_open_file(sample_cards_file, grep_types=["Creature"])
+    assert len(cards) == 2
+    names = [c.name for c in cards]
+    assert "fire dragon" in names
+    assert "water elemental" in names
+
+    # Should match Fire Dragon (Dragon subtype)
+    cards = jdecode.mtg_open_file(sample_cards_file, grep_types=["Dragon"])
+    assert len(cards) == 1
+    assert cards[0].name == "fire dragon"
+
+def test_grep_text(sample_cards_file):
+    # Should match Water Elemental (Islandwalk)
+    cards = jdecode.mtg_open_file(sample_cards_file, grep_text=["Islandwalk"])
+    assert len(cards) == 1
+    assert cards[0].name == "water elemental"
+
+    # Should match Fire Dragon and Fireball (deals damage)
+    cards = jdecode.mtg_open_file(sample_cards_file, grep_text=["deals"])
+    assert len(cards) == 2
+    names = [c.name for c in cards]
+    assert "fire dragon" in names
+    assert "fireball" in names
+
+def test_exclude_name(sample_cards_file):
+    # Exclude cards with "Fire" in name
+    cards = jdecode.mtg_open_file(sample_cards_file, vgrep_name=["Fire"])
+    assert len(cards) == 2
+    names = [c.name for c in cards]
+    assert "water elemental" in names
+    assert "island" in names
+    assert "fire dragon" not in names
+    assert "fireball" not in names
+
+def test_exclude_type(sample_cards_file):
+    # Exclude Creatures
+    cards = jdecode.mtg_open_file(sample_cards_file, vgrep_types=["Creature"])
+    assert len(cards) == 2
+    names = [c.name for c in cards]
+    assert "fireball" in names
+    assert "island" in names
+    assert "fire dragon" not in names
+
+def test_exclude_text(sample_cards_file):
+    # Exclude cards that deal damage
+    cards = jdecode.mtg_open_file(sample_cards_file, vgrep_text=["deals"])
+    assert len(cards) == 2
+    names = [c.name for c in cards]
+    assert "water elemental" in names
+    assert "island" in names
+
+def test_combined_filters(sample_cards_file):
+    # Name contains "Fire" AND type is "Sorcery"
+    cards = jdecode.mtg_open_file(sample_cards_file, grep_name=["Fire"], grep_types=["Sorcery"])
+    assert len(cards) == 1
+    assert cards[0].name == "fireball"
+
+    # Type is "Creature" AND text DOES NOT contain "Flying"
+    cards = jdecode.mtg_open_file(sample_cards_file, grep_types=["Creature"], vgrep_text=["Flying"])
+    assert len(cards) == 1
+    assert cards[0].name == "water elemental"


### PR DESCRIPTION
This PR introduces granular filtering capabilities to the MTG card processing tools. Users can now target their search patterns to specific fields using flags like `--grep-name`, `--grep-type`, and `--grep-text`, as well as their exclusion counterparts. This follows the project's logic of providing powerful and precise tools for preparing and analyzing Magic: The Gathering card data for AI training and other purposes.

### Changes:
- **Core Library:** Added `search_name`, `search_types`, and `search_text` to the `Card` class.
- **Loading Logic:** Refactored `jdecode.mtg_open_file` to support the new filtering parameters.
- **CLI Tools:** Updated `encode.py`, `decode.py`, `sortcards.py`, and `summarize.py` with the new flags.
- **Testing:** Added `tests/test_grep_refined.py` and ensured full suite compliance.

---
*PR created automatically by Jules for task [9794863175867180259](https://jules.google.com/task/9794863175867180259) started by @RainRat*