### PR TITLE
Remove redundant delimiter checks in Manatext

### DIFF
--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -167,9 +167,7 @@ class Manatext:
             self.text = self.text.replace(manastr, utils.reserved_mana_marker, 1)
 
         if (utils.mana_open_delimiter in self.text 
-            or utils.mana_close_delimiter in self.text
-            or utils.mana_json_open_delimiter in self.text 
-            or utils.mana_json_close_delimiter in self.text):
+            or utils.mana_close_delimiter in self.text):
             self.valid = False
 
     def __str__(self):


### PR DESCRIPTION
The `Manatext` class in `lib/manalib.py` performed redundant checks for mana delimiters. Since `utils.mana_json_open_delimiter` and `utils.mana_json_close_delimiter` are defined as identical to `utils.mana_open_delimiter` and `utils.mana_close_delimiter` in `lib/utils.py`, checking for both is unnecessary. This PR removes the redundant checks to improve code clarity.

---
*PR created automatically by Jules for task [14255535734550501469](https://jules.google.com/task/14255535734550501469) started by @RainRat*