### PR TITLE
[TEST] Add coverage for Card.summary() edge cases

### DIFF
--- a/tests/test_card_summary_gaps.py
+++ b/tests/test_card_summary_gaps.py
@@ -1,0 +1,42 @@
+import pytest
+from lib.cardlib import Card
+from lib import utils
+
+def test_summary_invalid_colored_status_indicator():
+    invalid_json = {"name": "Invalid Creature", "types": ["Creature"], "rarity": "Common"}
+    card = Card(invalid_json)
+    assert not card.valid
+
+    summary = card.summary(ansi_color=True)
+    expected_status = utils.colorize("[?] ", utils.Ansi.YELLOW)
+    assert summary.startswith(expected_status)
+
+def test_summary_planeswalker_loyalty_parentheses():
+    pw_json = {
+        "name": "Jace",
+        "manaCost": "{1}{U}{U}",
+        "types": ["Planeswalker"],
+        "rarity": "Rare",
+        "loyalty": 3
+    }
+    card = Card(pw_json)
+    assert card.loyalty == "&^^^"
+
+    summary = card.summary()
+    assert "(3)" in summary
+    assert "[[3]]" not in summary
+
+def test_summary_battle_defense_brackets():
+    battle_json = {
+        "name": "Invasion",
+        "manaCost": "{1}{G}",
+        "types": ["Battle"],
+        "rarity": "Uncommon",
+        "defense": 5
+    }
+    card = Card(battle_json)
+    assert card.loyalty == "&^^^^^"
+
+    summary = card.summary()
+    assert "[[5]]" in summary
+    assert "(5)" not in summary


### PR DESCRIPTION
Improved test coverage for `lib/cardlib.py` by adding targeted tests for the `Card.summary()` method. Specifically, covered the `ansi_color` branch for invalid cards and the different formatting logic for Planeswalker loyalty vs. Battle defense. Added `tests/test_card_summary_gaps.py` to house these tests. Verified that the new tests pass and improve coverage without regressions.

---
*PR created automatically by Jules for task [12839704814464566889](https://jules.google.com/task/12839704814464566889) started by @RainRat*