### PR TITLE
[FEAT] Extended Sorting and Summary View for sortcards.py

### DIFF
--- a/sortcards.py
+++ b/sortcards.py
@@ -19,7 +19,7 @@ except ImportError:
     def tqdm(iterable, **kwargs):
         return iterable
 
-def sortcards(cards, verbose=False):
+def sortcards(cards, verbose=False, use_summary=False, use_color=False):
     """
     Sorts a list of Card objects into various categories.
     """
@@ -62,6 +62,23 @@ def sortcards(cards, verbose=False):
         ('four colors', []),
         ('five colors', []),
         ('6+ colors', []),
+        ('By rarity:', None),
+        ('common', []),
+        ('uncommon', []),
+        ('rare', []),
+        ('mythic', []),
+        ('special', []),
+        ('basic land', []),
+        ('unknown rarity', []),
+        ('By CMC:', None),
+        ('CMC 0', []),
+        ('CMC 1', []),
+        ('CMC 2', []),
+        ('CMC 3', []),
+        ('CMC 4', []),
+        ('CMC 5', []),
+        ('CMC 6', []),
+        ('CMC 7+', []),
     ])
 
     iterator = cards
@@ -69,9 +86,13 @@ def sortcards(cards, verbose=False):
         iterator = tqdm(cards, desc="Sorting cards", unit="card")
 
     for card in iterator:
-        # Use card.raw for the original string representation
-        # Ensure we have a string to write out
-        card_str = card.raw if card.raw else card.encode()
+        # Determine the string representation to use
+        if use_summary:
+            card_str = card.summary(ansi_color=use_color)
+        else:
+            # Use card.raw for the original string representation
+            # Ensure we have a string to write out
+            card_str = card.raw if card.raw else card.encode()
 
         # special classes
         # Check if it's a split card (has a bside)
@@ -183,6 +204,42 @@ def sortcards(cards, verbose=False):
             classes['five colors'].append(card_str)
         else:
             classes['6+ colors'].append(card_str)
+
+        # rarity classes
+        rarity = card.rarity
+        if rarity in [utils.rarity_common_marker, 'common']:
+            classes['common'].append(card_str)
+        elif rarity in [utils.rarity_uncommon_marker, 'uncommon']:
+            classes['uncommon'].append(card_str)
+        elif rarity in [utils.rarity_rare_marker, 'rare']:
+            classes['rare'].append(card_str)
+        elif rarity in [utils.rarity_mythic_marker, 'mythic', 'mythic rare']:
+            classes['mythic'].append(card_str)
+        elif rarity in [utils.rarity_special_marker, 'special']:
+            classes['special'].append(card_str)
+        elif rarity in [utils.rarity_basic_land_marker, 'basic land']:
+            classes['basic land'].append(card_str)
+        else:
+            classes['unknown rarity'].append(card_str)
+
+        # CMC classes
+        cmc = card.cost.cmc
+        if cmc == 0:
+            classes['CMC 0'].append(card_str)
+        elif cmc == 1:
+            classes['CMC 1'].append(card_str)
+        elif cmc == 2:
+            classes['CMC 2'].append(card_str)
+        elif cmc == 3:
+            classes['CMC 3'].append(card_str)
+        elif cmc == 4:
+            classes['CMC 4'].append(card_str)
+        elif cmc == 5:
+            classes['CMC 5'].append(card_str)
+        elif cmc == 6:
+            classes['CMC 6'].append(card_str)
+        elif cmc >= 7:
+            classes['CMC 7+'].append(card_str)
         
     return classes
 
@@ -242,6 +299,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Only include cards of these rarities (common, uncommon, rare, mythic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also supports card multiplication based on counts in the decklist.')
+    proc_group.add_argument('--summary', action='store_true',
+                        help='Output compact card summaries instead of full encoded text.')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -295,8 +354,15 @@ Supports any encoding format supported by encode.py/decode.py.""",
     if args.limit > 0:
         cards = cards[:args.limit]
 
+    # Determine if we should use color for the summary
+    use_color = False
+    if args.color is True:
+        use_color = True
+    elif args.color is None and sys.stderr.isatty():
+        use_color = True
+
     # Progress bar is shown unless --quiet is specified
-    classes = sortcards(cards, verbose=not args.quiet)
+    classes = sortcards(cards, verbose=not args.quiet, use_summary=args.summary, use_color=use_color)
 
     outputter = sys.stdout
     ofile = None

--- a/tests/test_sortcards.py
+++ b/tests/test_sortcards.py
@@ -45,5 +45,38 @@ class TestSortCards(unittest.TestCase):
         self.assertIn(encoded, classes['planeswalkers'])
         self.assertNotIn(encoded, classes['other'])
 
+    def test_sort_rarity_and_cmc(self):
+        rare_data = {
+            "name": "Test Rare",
+            "manaCost": "{1}{R}",
+            "types": ["Creature"],
+            "rarity": "Rare",
+            "power": "2",
+            "toughness": "2"
+        }
+        card = Card(rare_data)
+        classes = sortcards.sortcards([card])
+        encoded = card.encode()
+
+        self.assertIn(encoded, classes['rare'])
+        self.assertIn(encoded, classes['CMC 2'])
+        self.assertNotIn(encoded, classes['common'])
+
+    def test_sort_summary(self):
+        card_data = {
+            "name": "Summary Card",
+            "manaCost": "{1}{W}",
+            "types": ["Instant"],
+            "rarity": "Uncommon"
+        }
+        card = Card(card_data)
+        # Testing the summary output mode
+        classes = sortcards.sortcards([card], use_summary=True)
+        summary_str = card.summary()
+
+        self.assertIn(summary_str, classes['instants'])
+        self.assertIn(summary_str, classes['uncommon'])
+        self.assertIn(summary_str, classes['CMC 2'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR introduces several enhancements to the `sortcards.py` utility to improve its data organization and visualization capabilities.

### New Features:
1.  **Extended Categorization:** Added "By Rarity" and "By CMC" sections to the `sortcards.py` output. Cards are now automatically grouped into rarity levels (common, uncommon, rare, mythic, etc.) and CMC buckets (CMC 0 through CMC 7+).
2.  **Summary Mode:** Introduced a new `--summary` flag. When enabled, `sortcards.py` outputs compact, one-line summaries (using `Card.summary()`) for each card instead of the full encoded text. This is ideal for quickly reviewing a sorted dataset.
3.  **Color Support:** Added support for the `--color` flag in `sortcards.py`, allowing for ANSI-colorized summaries and section headers in the terminal.

### Changes:
- Modified `sortcards.py` to include new categories in its `OrderedDict`.
- Updated `sortcards()` function to implement the logic for rarity and CMC categorization.
- Updated the main loop in `sortcards.py` to respect the `--summary` and `--color` flags.
- Added new test cases to `tests/test_sortcards.py` covering the new sorting logic and summary output mode.

These changes are fully additive and non-breaking, as the existing categorization logic and output format remain the default behavior.

---
*PR created automatically by Jules for task [6675828023976504716](https://jules.google.com/task/6675828023976504716) started by @RainRat*