### PR TITLE
[TEST] Add B-side indexing support to Namediff and expand test coverage

### DIFF
--- a/lib/namediff.py
+++ b/lib/namediff.py
@@ -64,32 +64,39 @@ class Namediff:
             print('  Reading names from: ' + json_fname)
         json_srcs, _ = jdecode.mtg_open_json(json_fname, verbose)
         namecount = 0
+
+        def process_card(card, jcard):
+            nonlocal namecount
+            name = card.name
+            if name in self.names:
+                if self.verbose:
+                    print('  Duplicate name ' + name + ', ignoring.')
+            else:
+                self.names[name] = jcard['name']
+                self.cardstrings[name] = card.encode()
+                jcode = jcard.get(utils.json_field_info_code)
+                jnum = jcard.get('number', '')
+                if jcode and jnum:
+                    self.codes[name] = jcode + '/' + jnum + '.jpg'
+                else:
+                    self.codes[name] = ''
+                namecount += 1
+
+            if card.bside:
+                # For bsides in MTGJSON, they are often nested.
+                # card.bside is a Card object.
+                # We need the jcard for the bside too.
+                jbside = jcard.get(utils.json_field_bside)
+                if jbside:
+                    process_card(card.bside, jbside)
+
         for json_cardname in sorted(json_srcs.keys()):
             if len(json_srcs[json_cardname]) > 0:
                 jcards = json_srcs[json_cardname]
-
                 # just use the first one
                 idx = 0
                 card = cardlib.Card(jcards[idx])
-                name = card.name
-                jname = jcards[idx]['name']
-                jcode = jcards[idx].get(utils.json_field_info_code)
-                if 'number' in jcards[idx]:
-                    jnum = jcards[idx]['number']
-                else:
-                    jnum = ''
-                    
-                if name in self.names:
-                    if self.verbose:
-                        print('  Duplicate name ' + name + ', ignoring.')
-                else:
-                    self.names[name] = jname
-                    self.cardstrings[name] = card.encode()
-                    if jcode and jnum:
-                        self.codes[name] = jcode + '/' + jnum + '.jpg'
-                    else:
-                        self.codes[name] = ''
-                    namecount += 1
+                process_card(card, jcards[idx])
 
         if self.verbose:
             print('  Read ' + str(namecount) + ' unique cardnames')

--- a/tests/test_namediff.py
+++ b/tests/test_namediff.py
@@ -149,5 +149,48 @@ class TestNamediff(unittest.TestCase):
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
 
+    def test_namediff_split_cards(self):
+        test_data = {
+            "data": {
+                "TST": {
+                    "name": "Test Set",
+                    "code": "TST",
+                    "type": "core",
+                    "cards": [
+                        {
+                            "name": "Fire",
+                            "number": "1a",
+                            "types": ["Instant"],
+                            "manaCost": "{1}{R}",
+                            "text": "Fire deals 2 damage."
+                        },
+                        {
+                            "name": "Ice",
+                            "number": "1b",
+                            "types": ["Instant"],
+                            "manaCost": "{1}{U}",
+                            "text": "Tap target permanent."
+                        }
+                    ]
+                }
+            }
+        }
+
+        fd, tmp_path = tempfile.mkstemp(suffix='.json', text=True)
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(test_data, f)
+
+            nd = namediff.Namediff(verbose=False, json_fname=tmp_path)
+
+            # Fire should be in names
+            self.assertIn("fire", nd.names)
+            # Ice is the b-side. It should also be in names.
+            self.assertIn("ice", nd.names)
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change addresses a gap in the `Namediff` class where only the primary face of split or double-faced cards was being indexed. By refactoring the initialization logic to recursively process B-sides, we ensure that similarity matching (e.g., for finding the nearest card name or encoded string) works correctly for all card faces in the dataset.

A new test case was added to `tests/test_namediff.py` to verify that B-side names are correctly indexed from a sample MTGJSON-style input. All 331 tests in the suite are passing.

---
*PR created automatically by Jules for task [2554262302063851216](https://jules.google.com/task/2554262302063851216) started by @RainRat*