### PR TITLE
[FEAT] Enhanced Dataset Summary with Visual Analytics and P/T Statistics

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -55,6 +55,40 @@ def color_line(text, use_color, color_code=utils.Ansi.BOLD + utils.Ansi.CYAN):
         return utils.colorize(text, color_code)
     return text
 
+def _print_breakdown(title, index, total, use_color, vsize=None, sort_key=None, reverse=True, key_formatter=None):
+    if not index:
+        return
+    print(color_line(title, use_color))
+
+    if sort_key:
+        keys = sorted(index.keys(), key=sort_key, reverse=reverse)
+    else:
+        # default alphabetical
+        keys = sorted(index.keys())
+
+    if vsize:
+        keys = keys[:vsize]
+
+    rows = []
+    for k in keys:
+        count = len(index[k])
+        percent = (count / total * 100) if total > 0 else 0
+
+        display_key = key_formatter(k) if key_formatter else str(k)
+
+        # Bar chart
+        bar_width = 10
+        filled = int(round(percent / 100 * bar_width))
+        bar = '[' + '#' * filled + ' ' * (bar_width - filled) + ']'
+
+        rows.append([
+            display_key,
+            color_count(count, use_color),
+            f"{percent:5.1f}%",
+            bar
+        ])
+    printrows(padrows(rows))
+
 class Datamine:
     # build the global indices
     def __init__(self, card_srcs):
@@ -165,6 +199,12 @@ class Datamine:
 
         self.avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
 
+        # Calculate average P/T
+        p_vals = [utils.from_unary_single(c.pt_p) for c in self.cards if c.pt_p is not None]
+        t_vals = [utils.from_unary_single(c.pt_t) for c in self.cards if c.pt_t is not None]
+        self.avg_power = sum(p_vals) / len(p_vals) if p_vals else 0
+        self.avg_toughness = sum(t_vals) / len(t_vals) if t_vals else 0
+
     # summarize the indices
     def summarize(self, hsize = 10, vsize = 10, cmcsize = 20, use_color = False):
 
@@ -180,111 +220,54 @@ class Datamine:
 
         print(color_line(str(len(self.by_color_inclusive)) + ' represented colors (including colorless as \'A\'), '
                + str(len(self.by_color)) + ' combinations', use_color))
-        print(color_line('Breakdown by color:', use_color))
-        rows = []
-        for k in sorted(self.by_color_inclusive.keys()):
-            rows += [[k, color_count(len(self.by_color_inclusive[k]), use_color)]]
-        printrows(padrows(rows))
-        print(color_line('Breakdown by number of colors:', use_color))
-        rows = []
-        for k in sorted(self.by_color_count.keys()):
-            rows += [[str(k), color_count(len(self.by_color_count[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Breakdown by color:', self.by_color_inclusive, len(self.allcards), use_color)
+        _print_breakdown('Breakdown by number of colors:', self.by_color_count, len(self.allcards), use_color)
         print()
 
         print(color_line(str(len(self.by_type_inclusive)) + ' unique card types, ' +
               str(len(self.by_type)) + ' combinations', use_color))
-        print(color_line('Breakdown by type:', use_color))
-        d = sorted(self.by_type_inclusive,
-                   key=lambda x: len(self.by_type_inclusive[x]),
-                   reverse=True)
-        rows = []
-        for k in d[:vsize]:
-            rows += [[k, color_count(len(self.by_type_inclusive[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Breakdown by type:', self.by_type_inclusive, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_type_inclusive[x]))
         print()
 
         print(color_line(str(len(self.by_subtype_inclusive)) + ' unique subtypes, '
                + str(len(self.by_subtype)) + ' combinations', use_color))
-        print(color_line('Popular subtypes:', use_color))
-        d = sorted(self.by_subtype_inclusive,
-                   key=lambda x: len(self.by_subtype_inclusive[x]),
-                   reverse=True)
-        rows = []
-        for k in d[0:vsize]:
-            rows += [[k, color_count(len(self.by_subtype_inclusive[k]), use_color)]]
-        printrows(padrows(rows))
-        print(color_line('Top combinations:', use_color))
-        d = sorted(self.by_subtype,
-                   key=lambda x: len(self.by_subtype[x]),
-                   reverse = True)
-        rows = []
-        for k in d[0:vsize]:
-            rows += [[k, color_count(len(self.by_subtype[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Popular subtypes:', self.by_subtype_inclusive, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_subtype_inclusive[x]))
+        _print_breakdown('Top combinations:', self.by_subtype, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_subtype[x]))
         print()
 
         print(color_line(str(len(self.by_supertype_inclusive)) + ' unique supertypes, '
                + str(len(self.by_supertype)) + ' combinations', use_color))
-        print(color_line('Breakdown by supertype:', use_color))
-        d = sorted(self.by_supertype_inclusive,
-                   key=lambda x: len(self.by_supertype_inclusive[x]),
-                   reverse=True)
-        rows = []
-        for k in d[:vsize]:
-            rows += [[k, color_count(len(self.by_supertype_inclusive[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Breakdown by supertype:', self.by_supertype_inclusive, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_supertype_inclusive[x]))
         print()
 
         print(color_line(str(len(self.by_cmc)) + ' different CMCs, ' +
               str(len(self.by_cost)) + ' unique mana costs', use_color))
         print('Average CMC: {:.2f}'.format(self.avg_cmc))
-        print(color_line('Breakdown by CMC:', use_color))
-        d = sorted(self.by_cmc, reverse=False)
-        rows = []
-        for k in d[:vsize]:
-            rows += [[str(k), color_count(len(self.by_cmc[k]), use_color)]]
-        printrows(padrows(rows))
-        print(color_line('Popular mana costs:', use_color))
-        d = sorted(self.by_cost,
-                   key=lambda x: len(self.by_cost[x]),
-                   reverse = True)
-        rows = []
-        for k in d[0:vsize]:
-            rows += [[utils.from_mana(k), color_count(len(self.by_cost[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Breakdown by CMC:', self.by_cmc, len(self.allcards), use_color,
+                         vsize=vsize, reverse=False, sort_key=lambda x: float(x))
+        _print_breakdown('Popular mana costs:', self.by_cost, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_cost[x]), key_formatter=utils.from_mana)
         print()
 
         print(color_line(str(len(self.by_rarity)) + ' represented rarities', use_color))
-        print(color_line('Breakdown by rarity:', use_color))
-        rows = []
-        for k in sorted(self.by_rarity.keys()):
-            rows += [[k, color_count(len(self.by_rarity[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Breakdown by rarity:', self.by_rarity, len(self.allcards), use_color)
         print()
 
         print(color_line(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
         if len(self.by_power) > 0 and len(self.by_toughness) > 0:
             print(('Largest power: ' + str(max(map(utils.from_unary_single, self.by_power))) +
                    ', largest toughness: ' + str(max(map(utils.from_unary_single, self.by_toughness)))))
-        print(color_line('Popular p/t values:', use_color))
-        d = sorted(self.by_pt,
-                   key=lambda x: len(self.by_pt[x]),
-                   reverse = True)
-        rows = []
-        for k in d[0:vsize]:
-            rows += [[utils.from_unary(k), color_count(len(self.by_pt[k]), use_color)]]
-        printrows(padrows(rows))
+            print(f'Average power: {self.avg_power:.2f}, Average toughness: {self.avg_toughness:.2f}')
+        _print_breakdown('Popular p/t values:', self.by_pt, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_pt[x]), key_formatter=utils.from_unary)
         print()
 
-        print(color_line('Loyalty values:', use_color))
-        d = sorted(self.by_loyalty,
-                   key=lambda x: len(self.by_loyalty[x]),
-                   reverse = True)
-        rows = []
-        for k in d[0:vsize]:
-            rows += [[utils.from_unary(k), color_count(len(self.by_loyalty[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Loyalty values:', self.by_loyalty, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_loyalty[x]), key_formatter=utils.from_unary)
         print()
 
         if len(self.by_textlen) > 0 and len(self.by_textlines) > 0:
@@ -292,14 +275,8 @@ class Datamine:
                    + str(max(self.by_textlen)) + ' characters in length', use_color))
             print(color_line('Card text ranges from ' + str(min(self.by_textlines)) + ' to '
                    + str(max(self.by_textlines)) + ' lines', use_color))
-        print(color_line('Line counts by frequency:', use_color))
-        d = sorted(self.by_textlines,
-                   key=lambda x: len(self.by_textlines[x]),
-                   reverse = True)
-        rows = []
-        for k in d[0:vsize]:
-            rows += [[k, color_count(len(self.by_textlines[k]), use_color)]]
-        printrows(padrows(rows))
+        _print_breakdown('Line counts by frequency:', self.by_textlines, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_textlines[x]))
         print()
 
     # describe outliers in the indices
@@ -455,5 +432,7 @@ class Datamine:
                 'textlines_min': min(self.by_textlines),
                 'textlines_max': max(self.by_textlines),
                 'avg_cmc': self.avg_cmc,
+                'avg_power': self.avg_power,
+                'avg_toughness': self.avg_toughness,
             }
         return result

--- a/tests/test_datalib.py
+++ b/tests/test_datalib.py
@@ -44,6 +44,16 @@ def sample_cards_data():
             "colors": [],
             "text": "Text C",
             "rarity": "Rare"
+        },
+        {
+            "name": "Planeswalker D",
+            "types": ["Planeswalker"],
+            "manaCost": "{2}{W}{W}",
+            "cmc": 4,
+            "colors": ["W"],
+            "text": "Text D",
+            "rarity": "Mythic",
+            "loyalty": 3
         }
     ]
 
@@ -115,7 +125,7 @@ def test_plimit():
 
 # Test Datamine Class
 def test_datamine_init(datamine_instance):
-    assert len(datamine_instance.cards) == 3
+    assert len(datamine_instance.cards) == 4
     assert len(datamine_instance.invalid_cards) == 0
     assert len(datamine_instance.unparsed_cards) == 0
 
@@ -155,8 +165,8 @@ def test_datamine_summarize(datamine_instance, capsys):
     captured = capsys.readouterr()
     output = captured.out
 
-    assert "3 valid cards" in output
-    assert "3 unique card names" in output
+    assert "4 valid cards" in output
+    assert "4 unique card names" in output
     assert "Breakdown by color:" in output
     assert "Breakdown by CMC:" in output
     assert "Loyalty values:" in output
@@ -246,9 +256,9 @@ def test_datamine_to_dict(datamine_instance):
     assert 'stats' in result
 
     # Check counts
-    assert result['counts']['valid'] == 3
+    assert result['counts']['valid'] == 4
     assert result['counts']['invalid'] == 0
-    assert result['counts']['parsed'] == 3
+    assert result['counts']['parsed'] == 4
     assert result['counts']['unparsed'] == 0
 
     # Check indices
@@ -260,13 +270,18 @@ def test_datamine_to_dict(datamine_instance):
     assert result['indices']['by_color']['A'] == 1
 
     # Check stats
-    # Text lengths in sample data: "Text A" (6), "Text B" (6), "Text C" (6)
+    # Text lengths in sample data: "Text A" (6), "Text B" (6), "Text C" (6), "Text D" (6)
     # Note: text.encode() might add newlines or markers.
     # Manatext("Text A").encode() -> "Text A"
     assert result['stats']['textlen_min'] == 6
     assert result['stats']['textlen_max'] == 6
     assert result['stats']['textlines_min'] == 1
     assert result['stats']['textlines_max'] == 1
+
+    # Check avg power/toughness
+    # Card A: 1/1, Card C: 2/2. Total power = 3, Total count = 2. Avg = 1.5
+    assert result['stats']['avg_power'] == 1.5
+    assert result['stats']['avg_toughness'] == 1.5
 
 def test_datamine_with_parsed_but_invalid_card():
     # Card that parses (has name/types/etc in roughly correct format)


### PR DESCRIPTION
Enhanced the `Datamine.summarize` functionality in `lib/datalib.py` to provide a more detailed and visual overview of card datasets. This includes standardized breakdown tables for colors, types, rarity, and CMC that now feature percentage distributions and ASCII bar charts. Additionally, the tool now calculates and reports average Power and Toughness for applicable cards (creatures/vehicles), and these new metrics are included in both terminal output and JSON exports (`to_dict`).

I noticed that while the codebase calculated average CMC, it lacked similar basic statistical averages for Power and Toughness, which are critical metrics for Magic: The Gathering dataset analysis. Furthermore, the previous terminal output was a simple list of counts; adding percentages and visual bar charts significantly improves the immediate scannability and professional utility of the data mining tools.

---
*PR created automatically by Jules for task [7335511678693650138](https://jules.google.com/task/7335511678693650138) started by @RainRat*