### PR TITLE
Consolidate loyalty and defense parsing in lib/cardlib.py

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -301,10 +301,11 @@ def fields_from_json(src_json, linetrans = True):
     else:
         parsed = False
 
-    if 'loyalty' in src_json:
-        fields[field_loyalty] = [(-1, utils.to_unary(str(src_json['loyalty'])))]
-    elif 'defense' in src_json:
-        fields[field_loyalty] = [(-1, utils.to_unary(str(src_json['defense'])))]
+    loyalty_val = src_json.get('loyalty')
+    if loyalty_val is None:
+        loyalty_val = src_json.get('defense')
+    if loyalty_val is not None:
+        fields[field_loyalty] = [(-1, utils.to_unary(str(loyalty_val)))]
 
     p_t = ''
     parsed_pt = True


### PR DESCRIPTION
This PR improves code quality in `lib/cardlib.py` by addressing logic duplication in the `fields_from_json` function. 

### Changes:
- Replaced separate `if/elif` blocks for `loyalty` and `defense` with a consolidated parsing sequence.
- Utilized `.get()` and explicit `is not None` checks to safely handle missing or null values from the source JSON.

### Why:
- **Reduces Duplication:** Identical logic for converting values to unary and assigning them to `field_loyalty` was previously repeated for both keys.
- **Improved Robustness:** The new implementation correctly prioritizes `loyalty` over `defense` while avoiding potential issues with `if 'key' in src_json` evaluating to true for null values.
- **Safety:** External behavior remains identical for all valid inputs, as confirmed by existing tests.

No breaking changes were introduced.

---
*PR created automatically by Jules for task [1177799005916944244](https://jules.google.com/task/1177799005916944244) started by @RainRat*