### PR TITLE
[TEST] Fix counter transformation bug and add verification test

### DIFF
--- a/lib/transforms.py
+++ b/lib/transforms.py
@@ -350,14 +350,16 @@ def text_pass_5_counters(s):
 
     s = counters_regex.sub(replace_counter, s)
 
-    # deduplicate usedcounters while preserving order of first appearance
-    unique_used = list(dict.fromkeys(usedcounters))
+    if usedcounters:
+        # If there's only one type of counter, we can deduplicate the headers.
+        # This keeps the output cleaner for the most common cases and is handled
+        # specially by the decoder.
+        if len(set(usedcounters)) == 1:
+            usedcounters = [usedcounters[0]]
 
-    # we haven't done newline replacement yet, so use actual newlines
-    if unique_used:
-        # prepend a countertype line for each unique counter used
+        # we haven't done newline replacement yet, so use actual newlines
         header = ''
-        for counter in unique_used:
+        for counter in usedcounters:
              header += 'countertype ' + counter_marker + ' ' + counter.split()[0] + '\n'
         s = header + s
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -155,6 +155,19 @@ def test_text_unpass_2_counters_multiple():
     expected = "put a charge counter on it. remove a charge counter."
     assert transforms.text_unpass_2_counters(input_text) == expected
 
+def test_text_pass_5_counters_mixed_types():
+    input_text = "put a charge counter, another charge counter, and a time counter."
+    encoded = transforms.text_pass_5_counters(input_text)
+
+    headers = [line for line in encoded.split('\n') if line.startswith('countertype')]
+    assert len(headers) == 3
+    assert headers[0] == "countertype % charge"
+    assert headers[1] == "countertype % charge"
+    assert headers[2] == "countertype % time"
+
+    decoded = transforms.text_unpass_2_counters(encoded)
+    assert decoded == input_text
+
 def test_text_unpass_3_uncast():
     # "uncast" -> "counter"
     assert transforms.text_unpass_3_uncast("uncast target.") == "counter target."


### PR DESCRIPTION
Fixed a bug in `lib/transforms.py` where mixed counter types were incorrectly deduplicated during encoding, leading to restoration errors during decoding. Updated `text_pass_5_counters` to preserve headers when multiple counter types are present. Added a corresponding test case in `tests/test_transforms.py` and verified it against the full test suite.

---
*PR created automatically by Jules for task [13301807126939676513](https://jules.google.com/task/13301807126939676513) started by @RainRat*