### PR TITLE
[DOCS] Clarify unary number encoding limits and exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ When you run `encode.py`, the output is converted into a specialized text format
 To help the AI count, numbers are represented as a sequence of symbols instead of digits.
 *   **Marker (`&`)**: Indicates the start of a number.
 *   **Counter (`^`)**: Each `^` represents 1.
+*   **Limits**: Standard unary sequences are capped at 20 (`&^^^^^^^^^^^^^^^^^^^^`).
+*   **Large Numbers**: Specific large values are represented by words to save space:
+    *   25 = `twenty~five`
+    *   30 = `thirty`
+    *   40 = `forty`
+    *   50 = `fifty`
+    *   100 = `one hundred`
+    *   200 = `two hundred`
 *   **Examples**:
     *   `&^` = 1
     *   `&^^` = 2


### PR DESCRIPTION
Improved the project documentation by adding technical details about how numbers are encoded in the specialized text format.

Changes:
* Added a note to the "Unary Numbers" section in `README.md` about the 20-unit cap for unary sequences.
* Listed the specific large numbers (25, 30, 40, 50, 100, 200) that are encoded as words instead of sequences.
* Provided examples of how these numbers are represented (e.g., `twenty~five`).

These updates ensure that the documentation accurately reflects the logic implemented in the codebase (specifically in `lib/utils.py` and `lib/config.py`).

---
*PR created automatically by Jules for task [17767973668680002462](https://jules.google.com/task/17767973668680002462) started by @RainRat*