### PR TITLE
[FEAT] Add Markdown Table output format to decode.py

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -23,7 +23,7 @@ from namediff import Namediff
 
 def main(fname, oname = None, verbose = True, encoding = 'std',
          gatherer = True, for_forum = False, for_mse = False,
-         creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, summary_out = False, deck_out = False, quiet=False,
+         creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, md_table_out = False, summary_out = False, deck_out = False, quiet=False,
          report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None,
          grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
          grep_text=None, vgrep_text=None,
@@ -34,7 +34,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
-    if not (html or text or for_mse or json_out or jsonl_out or csv_out or md_out or summary_out or deck_out):
+    if not (html or text or for_mse or json_out or jsonl_out or csv_out or md_out or md_table_out or summary_out or deck_out):
         if oname:
             if oname.endswith('.html'):
                 html = True
@@ -46,6 +46,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 csv_out = True
             elif oname.endswith('.md'):
                 md_out = True
+            elif oname.endswith('.mdt'):
+                md_table_out = True
             elif oname.endswith('.sum') or oname.endswith('.summary'):
                 summary_out = True
             elif oname.endswith('.mse-set'):
@@ -59,7 +61,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     # Mutually exclusive output formats are now enforced by argparse in main block,
     # but we keep this check for programmatic access safety.
-    if sum([bool(html), bool(for_mse), bool(json_out), bool(jsonl_out), bool(text), bool(csv_out), bool(md_out), bool(summary_out), bool(deck_out)]) > 1:
+    if sum([bool(html), bool(for_mse), bool(json_out), bool(jsonl_out), bool(text), bool(csv_out), bool(md_out), bool(md_table_out), bool(summary_out), bool(deck_out)]) > 1:
         # If user explicitly requested multiple formats programmatically, we warn or error.
         # However, argparse logic below ensures text defaults to True only if others are False.
         # But if someone calls main() directly with multiple True, we should respect that or fail.
@@ -165,9 +167,12 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
             namestr = truename + ': ' + str(dist) + '\n'
         return namestr
 
-    def writecards(writer, for_html=False, for_md=False, for_summary=False, for_mse=False):
+    def writecards(writer, for_html=False, for_md=False, for_md_table=False, for_summary=False, for_mse=False):
         success_count = 0
         fail_count = 0
+        if for_md_table:
+            writer.write("| Name | Cost | Type | Stats | Rules Text | Rarity |\n")
+            writer.write("| :--- | :--- | :--- | :--- | :--- | :--- |\n")
         if for_mse:
             # have to prepend a massive chunk of formatting info
             writer.write(utils.mse_prepend)
@@ -211,7 +216,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                         divider = utils.colorize(divider, utils.Ansi.BOLD + utils.Ansi.CYAN)
                     writer.write(divider + '\n')
 
-                writecard(writer, card, for_md=for_md, for_summary=for_summary, for_mse=for_mse)
+                writecard(writer, card, for_md=for_md, for_md_table=for_md_table, for_summary=for_summary, for_mse=for_mse)
                 success_count += 1
                 first = False
             except Exception:
@@ -223,8 +228,11 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
         return success_count, fail_count
 
-    def writecard(writer, card, for_html=False, for_md=False, for_summary=False, for_mse=False):
+    def writecard(writer, card, for_html=False, for_md=False, for_md_table=False, for_summary=False, for_mse=False):
         try:
+            if for_md_table:
+                writer.write(card.to_markdown_row() + '\n')
+                return
             if for_mse:
                 writer.write(card.to_mse())
                 fstring = ''
@@ -360,6 +368,13 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 s, f = writecards(ofile, for_md=True, for_mse=for_mse)
                 total_success += s
                 total_fail += f
+        if md_table_out:
+            if verbose:
+                print('Writing markdown table output to: ' + oname, file=sys.stderr)
+            with open(oname, 'w', encoding='utf8') as ofile:
+                s, f = writecards(ofile, for_md_table=True, for_mse=for_mse)
+                total_success += s
+                total_fail += f
         if html:
             fname = oname
             if not fname.endswith('.html'):
@@ -493,8 +508,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                     total_fail += 1
             sys.stdout.flush()
         else:
-            # Correctly propagate for_html=html, for_md=md_out, for_summary=summary_out
-            s, f = writecards(sys.stdout, for_html=html, for_md=md_out, for_summary=summary_out, for_mse=for_mse)
+            # Correctly propagate for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out
+            s, f = writecards(sys.stdout, for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_mse=for_mse)
             total_success += s
             total_fail += f
         sys.stdout.flush()
@@ -529,6 +544,8 @@ if __name__ == '__main__':
                            help='Generate a CSV file (Auto-detected for .csv).')
     fmt_group.add_argument('--md', action='store_true',
                            help='Generate a Markdown file (Auto-detected for .md).')
+    fmt_group.add_argument('--md-table', '--mdt', action='store_true',
+                           help='Generate a Markdown table file (Auto-detected for .mdt).')
     fmt_group.add_argument('--summary', action='store_true',
                            help='Generate a compact one-line summary for each card (Auto-detected for .sum or .summary).')
     fmt_group.add_argument('--deck', '--decklist', action='store_true',
@@ -640,7 +657,7 @@ if __name__ == '__main__':
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          gatherer = args.gatherer, for_forum = args.forum, for_mse = args.mse,
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text,
-         json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, summary_out = args.summary, deck_out = args.deck, quiet=args.quiet,
+         json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, md_table_out = args.md_table, summary_out = args.summary, deck_out = args.deck, quiet=args.quiet,
          report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep,
          sort=args.sort, vgrep=args.vgrep,
          grep_name=args.grep_name, vgrep_name=args.exclude_name,

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1336,6 +1336,64 @@ class Card:
 
         return outstr
 
+    def to_markdown_row(self):
+        """Returns a Markdown table row representation of the card."""
+
+        def get_fields(card):
+            # Name
+            name = titlecase(card.name)
+
+            # Cost
+            cost = card.cost.format()
+            if cost == '_NOCOST_':
+                cost = ''
+
+            # Type
+            supertypes = [titlecase(s) for s in card.supertypes]
+            types = [titlecase(t) for t in card.types]
+            typeline = ' '.join(supertypes + types)
+            if card.subtypes:
+                typeline += f' \u2014 ' + ' '.join([titlecase(s) for s in card.subtypes])
+
+            # Stats (P/T or Loyalty/Defense)
+            stats = ''
+            if card.pt:
+                stats = utils.from_unary(card.pt)
+            elif card.loyalty:
+                loyalty = utils.from_unary(card.loyalty)
+                if any('battle' in t.lower() for t in card.types):
+                    stats = f'[[{loyalty}]]'
+                else:
+                    stats = f'({loyalty})'
+
+            # Text
+            text = card.get_text(force_unpass=True).replace('\n', '<br>')
+
+            # Rarity
+            rarity = card.rarity
+            if rarity in utils.json_rarity_unmap:
+                rarity = utils.json_rarity_unmap[rarity]
+
+            return name, cost, typeline, stats, text, rarity
+
+        name, cost, typeline, stats, text, rarity = get_fields(self)
+
+        if self.bside:
+            b_name, b_cost, b_typeline, b_stats, b_text, b_rarity = get_fields(self.bside)
+            name = f"{name} // {b_name}"
+            cost = f"{cost} // {b_cost}"
+            typeline = f"{typeline} // {b_typeline}"
+            stats = f"{stats} // {b_stats}" if stats or b_stats else ""
+            text = f"{text}<br>---<br>{b_text}"
+            if b_rarity and b_rarity != rarity:
+                rarity = f"{rarity} // {b_rarity}"
+
+        # Escape pipe characters and ensure no actual newlines break the row
+        fields = [name, cost, typeline, stats, text, rarity]
+        fields = [f.replace('|', '\\|').replace('\n', ' ') for f in fields]
+
+        return f"| {' | '.join(fields)} |"
+
     def vectorize(self):
         """Vectorizes the card data into a string format suitable for machine learning.
 

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -41,3 +41,39 @@ def test_decode_markdown_auto_extension(tmp_path):
 
     content = outfile.read_text(encoding="utf-8")
     assert "**Auto Card**" in content
+
+def test_markdown_table_format():
+    src = "|1Table Card|5Creature|6Human|3{WW}|8&^/&^|9Lifelink|0O"
+    card = cardlib.Card(src)
+    row = card.to_markdown_row()
+    assert "| Table Card | {W} | Creature — Human | 1/1 | Lifelink | common |" in row
+
+def test_markdown_table_split_card():
+    src = "|1Fire|5Sorcery|3{RR}|9Fire deals &^^ damage to any target.\n|1Ice|5Sorcery|3{^}{UU}|9Draw a card."
+    card = cardlib.Card(src)
+    row = card.to_markdown_row()
+    assert "| Fire // Ice | {R} // {1}{U} | Sorcery // Sorcery |  | Fire deals 2 damage to any target.<br>---<br>Draw a card. |  |" in row
+
+def test_decode_markdown_table_cli(tmp_path):
+    infile = tmp_path / "input.txt"
+    infile.write_text("|1Table Card|5Creature|6Human|3{WW}|8&^/&^|9Lifelink|0O", encoding="utf-8")
+    outfile = tmp_path / "output.mdt"
+
+    # Run main via programmatic call, should detect .mdt extension
+    decode.main(str(infile), str(outfile), quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert "| Name | Cost | Type | Stats | Rules Text | Rarity |" in content
+    assert "| Table Card | {W} | Creature — Human | 1/1 | Lifelink | common |" in content
+
+def test_decode_markdown_table_flag(tmp_path):
+    infile = tmp_path / "input.txt"
+    infile.write_text("|1Flag Card|5Sorcery|3{GG}|9Add {GG}.|0A", encoding="utf-8")
+    outfile = tmp_path / "output.txt" # Not .mdt
+
+    # Force md_table_out
+    decode.main(str(infile), str(outfile), md_table_out=True, quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert "| Name | Cost | Type | Stats | Rules Text | Rarity |" in content
+    assert "| Flag Card | {G} | Sorcery |  | Add {G}. | rare |" in content


### PR DESCRIPTION
Added a new output format for decoding Magic cards: Markdown Tables. This can be triggered by the `--md-table` (or `--mdt`) flag, or by using a `.mdt` file extension for the output file. The implementation includes a new `to_markdown_row` method in the `Card` class to handle formatting, which correctly manages stats (P/T, Loyalty, Defense) and multi-face cards. New tests were added to ensure correctness and prevent regressions.

---
*PR created automatically by Jules for task [12348838298528606632](https://jules.google.com/task/12348838298528606632) started by @RainRat*