### PR TITLE
Inline redundant Manacost.check_colors wrapper

### DIFF
--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -21,9 +21,6 @@ class Manacost:
         # sort so the order is always consistent
         return ''.join(sorted(colors))
 
-    def check_colors(self, symbolstring):
-        return all(sym in self.colors for sym in symbolstring)
-
     def __init__(self, src, fmt = ''):
         # source fields, exactly one will be set
         self.raw = None

--- a/scripts/pairing.py
+++ b/scripts/pairing.py
@@ -45,7 +45,7 @@ def select_card(cards, stats, i):
 def compare_to_real(card, realcard):
     ctypes = ' '.join(sorted(card.types))
     rtypes = ' '.join(sorted(realcard.types))
-    return ctypes == rtypes and realcard.cost.check_colors(card.cost.colors)
+    return ctypes == rtypes and all(c in realcard.cost.colors for c in card.cost.colors)
 
 def writecard(card, name, writer):
     gatherer = False

--- a/tests/test_manalib.py
+++ b/tests/test_manalib.py
@@ -92,18 +92,6 @@ class TestManacost:
         assert Manacost("{2W}").colors == "W"
         assert Manacost("{WP}").colors == "W"
 
-    def test_check_colors(self):
-        m = Manacost("{WWUUBBRRGG}") # WUBRG
-        assert m.check_colors("W")
-        assert m.check_colors("U")
-        assert m.check_colors("WU")
-        assert m.check_colors("BGRUW")
-
-        # Not subset
-        m2 = Manacost("{WW}") # W
-        assert m2.check_colors("W")
-        assert not m2.check_colors("U")
-
     def test_format(self):
         m = Manacost("{WWUUBBRRGG}")
         assert m.format() == "{W}{U}{B}{R}{G}"


### PR DESCRIPTION
**What:** Inlined the `check_colors` method of the `Manacost` class in `lib/manalib.py` into its sole call site in `scripts/pairing.py`.

**Why:** The `check_colors` method was a thin wrapper around an `all()` generator expression. Inlining it reduces the complexity of the `Manacost` class and makes the logic at the call site in `scripts/pairing.py` more explicit. This change is non-breaking as the external behavior of the script remains identical. All 336 tests in the suite passed.

---
*PR created automatically by Jules for task [10339260018729873951](https://jules.google.com/task/10339260018729873951) started by @RainRat*