### PR TITLE
[TEST] Fix Planeswalker 'X' loyalty costs in MSE export

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -711,6 +711,14 @@ class Card:
         # 9.5. Symbols unpass (called AFTER sentencecase to avoid color corruption)
         mtext = utils.from_symbols(mtext, for_forum, for_html, ansi_color=ansi_color)
 
+        if mse:
+            # Handle the +X / -X loyalty cost case where X becomes + / - during unary unpass
+            # if X was misinterpreted as 0 by Manacost/Manatext.
+            # This is a bit of a hack but ensures loyalty costs are correctly formatted for MSE.
+            mtext = re.sub(r'^\+\s*:', '+X:', mtext, flags=re.MULTILINE)
+            mtext = re.sub(r'^−\s*:', '−X:', mtext, flags=re.MULTILINE)
+            mtext = re.sub(r'^-\s*:', '-X:', mtext, flags=re.MULTILINE)
+
         # 10. Final formatting via Manatext
         newtext = Manatext('')
         newtext.text = mtext
@@ -1302,17 +1310,18 @@ class Card:
 
             # set up the loyalty cost fields using regex to find how many there are.
             i = 0
-            lcost_regex = r'([-−+−]?\d+): (.*)' # 1+ figures, might be 0.
+            lcost_regex = r'([-−+−]?[\dxX]+): (.*)' # 1+ figures or X, might be 0.
 
             abilities = []
             for line in newtext.split('\n'):
-                match = re.match(lcost_regex, line)
+                # Handle leading spaces that might be present in text_unpass_7_newlines result
+                match = re.match(r'\s*' + lcost_regex, line)
                 if match:
                     i += 1
                     outstr += '\tloyalty cost ' + str(i) + ': ' + match.group(1) + '\n'
                     abilities.append(match.group(2))
                 elif line:
-                    abilities.append(line)
+                    abilities.append(line.strip())
 
             # We need to uppercase again, because MSE won't magically capitalize for us
             # like it does after semicolons.

--- a/tests/test_planeswalker_x_mse.py
+++ b/tests/test_planeswalker_x_mse.py
@@ -1,0 +1,33 @@
+import pytest
+from lib.cardlib import Card
+
+def test_planeswalker_x_loyalty_to_mse():
+    pw_json = {
+        "name": "Nissa, Steward of Elements",
+        "manaCost": "{X}{G}{U}",
+        "types": ["Planeswalker"],
+        "rarity": "Mythic",
+        "text": "+X: Scry X.\n-10: You win.",
+        "loyalty": "X"
+    }
+    card = Card(pw_json)
+    mse_output = card.to_mse()
+
+    assert "loyalty cost 1: +X" in mse_output
+    assert "loyalty cost 2: -10" in mse_output
+    assert "\trule text:\n\t\tScry X.\n\t\tYou win." in mse_output
+
+def test_planeswalker_lowercase_x_loyalty_to_mse():
+    pw_json = {
+        "name": "Test Walker",
+        "manaCost": "{1}{R}",
+        "types": ["Planeswalker"],
+        "rarity": "Rare",
+        "text": "+x: Damage.\n-1: Draw.",
+        "loyalty": 2
+    }
+    card = Card(pw_json)
+    mse_output = card.to_mse()
+
+    assert "loyalty cost 1: +X" in mse_output
+    assert "\trule text:\n\t\tDamage.\n\t\tDraw." in mse_output


### PR DESCRIPTION
This change fixes a bug where Planeswalker loyalty abilities starting with "+X:" or "-X:" were not correctly identified as loyalty abilities when exporting to Magic Set Editor (MSE) format. 

The fix involves:
1. Updating the regex in `Card.to_mse()` to include 'X' and 'x' as valid characters in a loyalty cost.
2. Adding a specific restoration pass in `Card.get_text(mse=True)` to handle cases where the unary decoder misinterprets 'X' in a loyalty cost as '0' and strips it, leaving only '+:'.

A new test suite `tests/test_planeswalker_x_mse.py` has been added to verify these changes and prevent regressions.

---
*PR created automatically by Jules for task [16261562874165615382](https://jules.google.com/task/16261562874165615382) started by @RainRat*