### PR TITLE
[UI/UX] Standardize split card separators and improve colorization

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -908,11 +908,12 @@ class Card:
             }
             indicator = rarity_map.get(r.lower() if hasattr(r, 'lower') else r, r[0].upper() if r else '?')
 
+            indicator = f'[{indicator}]'
             if ansi_color:
                 color = self._get_rarity_ansi_color(r)
                 indicator = utils.colorize(indicator, color)
 
-            rarity_indicator = f'[{indicator}] '
+            rarity_indicator = f'{indicator} '
 
         # Name
         cardname = titlecase(self.name)
@@ -959,7 +960,7 @@ class Card:
             res += f' \u2022 {stats}'
 
         if self.bside:
-            res += utils.bsidesep + self.bside.summary(ansi_color=ansi_color)
+            res += ' // ' + self.bside.summary(ansi_color=ansi_color)
 
         return res
 
@@ -1074,16 +1075,18 @@ class Card:
         if gatherer:
             if self.__dict__[field_pt]:
                 pt = utils.from_unary(self.__dict__[field_pt])
-                if ansi_color: pt = utils.colorize(pt, utils.Ansi.RED)
-                outstr += ' (' + pt + ')'
+                pt_display = f'({pt})'
+                if ansi_color: pt_display = utils.colorize(pt_display, utils.Ansi.RED)
+                outstr += ' ' + pt_display
 
             if self.__dict__[field_loyalty]:
                 loyalty = utils.from_unary(self.__dict__[field_loyalty])
-                if ansi_color: loyalty = utils.colorize(loyalty, utils.Ansi.RED)
                 if 'battle' in self.types:
-                    outstr += ' [[' + loyalty + ']]'
+                    loy_display = f'[[{loyalty}]]'
                 else:
-                    outstr += ' ((' + loyalty + '))'
+                    loy_display = f'(({loyalty}))'
+                if ansi_color: loy_display = utils.colorize(loy_display, utils.Ansi.RED)
+                outstr += ' ' + loy_display
 
         if formatted_mtext:
             # Add a blank line before the rules text for better readability
@@ -1095,16 +1098,18 @@ class Card:
         if not gatherer:
             if self.__dict__[field_pt]:
                 pt = utils.from_unary(self.__dict__[field_pt])
-                if ansi_color: pt = utils.colorize(pt, utils.Ansi.RED)
-                outstr += linebreak + '(' + pt + ')'
+                pt_display = f'({pt})'
+                if ansi_color: pt_display = utils.colorize(pt_display, utils.Ansi.RED)
+                outstr += linebreak + pt_display
 
             if self.__dict__[field_loyalty]:
                 loyalty = utils.from_unary(self.__dict__[field_loyalty])
-                if ansi_color: loyalty = utils.colorize(loyalty, utils.Ansi.RED)
                 if 'battle' in self.types:
-                    outstr += linebreak + '[[' + loyalty + ']]'
+                    loy_display = f'[[{loyalty}]]'
                 else:
-                    outstr += linebreak + '((' + loyalty + '))'
+                    loy_display = f'(({loyalty}))'
+                if ansi_color: loy_display = utils.colorize(loy_display, utils.Ansi.RED)
+                outstr += linebreak + loy_display
 
         if vdump and self.__dict__[field_other]:
             outstr += linebreak
@@ -1135,7 +1140,12 @@ class Card:
 
         if self.bside:
             outstr += linebreak
-            if not for_html:
+            if not for_html and not for_forum and not for_md:
+                divider = "~~~~ (B-Side) " + "~" * 21
+                if ansi_color:
+                    divider = utils.colorize(divider, utils.Ansi.BOLD + utils.Ansi.CYAN)
+                outstr += divider + linebreak
+            elif not for_html:
                 outstr += utils.dash_marker * 8 + linebreak
             outstr += self.bside.format(gatherer=gatherer, for_forum=for_forum and not for_html, for_html=for_html, vdump=vdump, ansi_color=ansi_color, for_md=for_md)
 

--- a/sortcards.py
+++ b/sortcards.py
@@ -101,7 +101,7 @@ def sortcards(cards, verbose=False, use_summary=False, use_color=False, fmt_orde
             # But the original code did a replace to visualize the split.
             # Let's check if the raw string has the separator.
             if utils.bsidesep in card_str:
-                 card_str = card_str.replace(utils.bsidesep, '|\n~~~~~~~~~~~~~~~~\n|')
+                 card_str = card_str.replace(utils.bsidesep, ' // ')
             classes['multicards'].append(card_str)
             continue
         

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -112,7 +112,7 @@ def test_card_format(sample_card_json):
     expected_name = utils.colorize("Ornithopter", utils.Ansi.BOLD + utils.Ansi.CYAN)
     expected_cost = utils.colorize("{0}", utils.Ansi.BOLD)
     expected_type = utils.colorize("Artifact Creature ~ Thopter", utils.Ansi.GREEN)
-    expected_pt = utils.colorize("0/2", utils.Ansi.RED)
+    expected_pt = utils.colorize("(0/2)", utils.Ansi.RED)
     expected_rarity = utils.colorize("uncommon", utils.Ansi.BOLD + utils.Ansi.CYAN)
 
     # Construction of default format with colors
@@ -120,7 +120,7 @@ def test_card_format(sample_card_json):
         f"{expected_name} {expected_cost}\n"
         f"{expected_type} ({expected_rarity})\n\n"
         "Flying\n"
-        f"({expected_pt})"
+        f"{expected_pt}"
     )
     assert colored_output == expected_colored_output
 
@@ -137,9 +137,9 @@ def test_card_summary(sample_card_json):
     expected_cost = utils.colorize("{0}", utils.Ansi.BOLD)
     expected_type = utils.colorize("Artifact Creature — Thopter", utils.Ansi.GREEN)
     expected_pt = utils.colorize("(0/2)", utils.Ansi.RED)
-    expected_rarity_indicator = utils.colorize("U", utils.Ansi.BOLD + utils.Ansi.CYAN)
+    expected_rarity_indicator = utils.colorize("[U]", utils.Ansi.BOLD + utils.Ansi.CYAN)
 
-    expected_colored_summary = f"[{expected_rarity_indicator}] {expected_name} {expected_cost} • {expected_type} • {expected_pt}"
+    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt}"
     assert colored_output == expected_colored_summary
 
 def test_card_summary_status_indicators():


### PR DESCRIPTION
This PR improves the visual hierarchy and consistency of Magic card displays in the terminal. Key changes include standardizing split card separators to the industry-standard ` // ` format and ensuring that ANSI color codes encompass logical units (like rarity brackets and P/T parentheses) to reduce visual clutter and improve scannability. Additionally, full card displays for double-faced cards now feature a more prominent and informative B-Side divider.

---
*PR created automatically by Jules for task [782238824426284707](https://jules.google.com/task/782238824426284707) started by @RainRat*