### PR TITLE
[FEAT] Support MTG Decklists as a primary input source

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -523,7 +523,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .jsonl, .csv, .md, .sum, .summary, .deck, .dek, .mse-set).')
 

--- a/encode.py
+++ b/encode.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console (stdout).')
 

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -503,6 +503,21 @@ def _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
 
     return cards
 
+def _hydrate_decklist(decklist_names, verbose, linetrans,
+                       exclude_sets, exclude_types, exclude_layouts, report_fobj):
+    """
+    Attempts to resolve card names in a decklist against data/AllPrintings.json.
+    """
+    default_data = os.path.join(os.path.dirname(__file__), '../data/AllPrintings.json')
+    if os.path.exists(default_data):
+        if verbose:
+            print(f'Auto-hydrating decklist using {default_data}', file=sys.stderr)
+        json_srcs, bad_sets = mtg_open_json(default_data, verbose=False)
+        return _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
+                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                   decklist_names=decklist_names)
+    return []
+
 def _process_text_cards(txt_cards, decklist_names, verbose, report_fobj=None):
     """
     Processes a list of Card objects from encoded text, applying decklist filters/multipliers.
@@ -566,6 +581,17 @@ def mtg_open_file(fname, verbose = False,
                   colors=None, cmcs=None,
                   shuffle=False, seed=None,
                   decklist_file=None):
+    """
+    High-level entry point for loading card data from various formats.
+    Supported formats: JSON, JSONL, CSV, Magic Set Editor (.mse-set),
+    and standard MTG decklists (.txt, .deck, .dek).
+
+    Decklist support includes "auto-hydration": if a decklist is provided as
+    the primary input and data/AllPrintings.json exists, the tool will
+    automatically resolve card names into full Card objects.
+
+    Returns a list of cardlib.Card objects.
+    """
 
     cards = []
     valid = 0
@@ -719,14 +745,33 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
-    # Encoded Text File Handling
+    # Encoded Text or Decklist File Handling
     elif fname == '-' or (not fname.endswith('.json') and not fname.endswith('.mse-set')):
         if fname == '-':
             text = sys.stdin.read()
             # Stdin Format Detection
             stripped = text.strip()
-            # 1. JSON / JSONL Detection
-            if stripped.startswith('{') or stripped.startswith('['):
+
+            # 1. Decklist Detection
+            # If it looks like a decklist (starts with a count like "4 Grizzly Bears")
+            # and isn't obviously encoded text (doesn't have field separators)
+            if re.match(r'^\d+\s+', stripped) and utils.fieldsep not in stripped:
+                if verbose:
+                    print('Detected Decklist input from stdin.', file=sys.stderr)
+                if not decklist_names:
+                    # We save to a temp file because parse_decklist expects a path
+                    import tempfile
+                    with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as tf:
+                        tf.write(text)
+                        tf_path = tf.name
+                    decklist_names = parse_decklist(tf_path)
+                    os.remove(tf_path)
+
+                cards = _hydrate_decklist(decklist_names, verbose, linetrans,
+                                           exclude_sets, exclude_types, exclude_layouts, report_fobj)
+
+            # 2. JSON / JSONL Detection
+            if not cards and (stripped.startswith('{') or stripped.startswith('[')):
                 try:
                     # Try regular JSON first
                     jobj = json.loads(text)
@@ -745,7 +790,7 @@ def mtg_open_file(fname, verbose = False,
                         cards = _process_json_srcs(jsonl_srcs, bad_sets, verbose, linetrans,
                                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                                    decklist_names=decklist_names)
-            # 2. CSV Detection
+            # 3. CSV Detection
             if not cards and stripped.startswith('name,'):
                 try:
                     reader = csv.DictReader(io.StringIO(text))
@@ -758,8 +803,32 @@ def mtg_open_file(fname, verbose = False,
                 except Exception:
                     pass
         else:
-            with open(fname, 'rt', encoding='utf8') as f:
-                text = f.read()
+            # Check if it's a decklist file based on extension or content
+            is_decklist = fname.endswith('.deck') or fname.endswith('.dek')
+            if not is_decklist:
+                try:
+                    with open(fname, 'rt', encoding='utf8') as f:
+                        # Check first few lines for decklist pattern
+                        for _ in range(5):
+                            line = f.readline()
+                            if not line: break
+                            if re.match(r'^\d+\s+', line.strip()):
+                                is_decklist = True
+                                break
+                except UnicodeDecodeError:
+                    pass
+
+            if is_decklist and not decklist_names:
+                if verbose:
+                    print(f'Detected {fname} as a decklist.', file=sys.stderr)
+                decklist_names = parse_decklist(fname)
+
+                cards = _hydrate_decklist(decklist_names, verbose, linetrans,
+                                           exclude_sets, exclude_types, exclude_layouts, report_fobj)
+
+            if not cards:
+                with open(fname, 'rt', encoding='utf8') as f:
+                    text = f.read()
 
         if not cards:
             if verbose:

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the summary output. If not provided, output prints to the console. The format is automatically detected from the file extension (.json for JSON, otherwise text).')
     io_group.add_argument('--json', action='store_true',

--- a/sortcards.py
+++ b/sortcards.py
@@ -251,7 +251,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, JSONL, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console (stdout).')
 

--- a/tests/test_decklist_primary_input.py
+++ b/tests/test_decklist_primary_input.py
@@ -1,0 +1,165 @@
+import json
+import os
+import sys
+import unittest
+import tempfile
+import io
+from unittest.mock import patch, mock_open
+
+# Ensure lib is in path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+import jdecode, utils, cardlib
+
+class TestDecklistPrimaryInput(unittest.TestCase):
+    def setUp(self):
+        self.temp_files = []
+        self.real_exists = os.path.exists
+
+    def tearDown(self):
+        for f in self.temp_files:
+            if os.path.exists(f):
+                os.remove(f)
+
+    def create_temp_file(self, content, suffix='.txt'):
+        with tempfile.NamedTemporaryFile(mode='w+', suffix=suffix, delete=False, encoding='utf-8') as tmp:
+            tmp.write(content)
+            self.temp_files.append(tmp.name)
+        return tmp.name
+
+    def test_decklist_file_input(self):
+        # Create a decklist file. Use "Fire" instead of "Fire // Ice" to match mock data indexing
+        decklist_content = "4 Grizzly Bears\n2 Fire\n"
+        decklist_path = self.create_temp_file(decklist_content, suffix='.deck')
+
+        # Create a mock AllPrintings.json
+        mock_data = {
+            "data": {
+                "LEA": {
+                    "code": "LEA",
+                    "name": "Limited Edition Alpha",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Grizzly Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "rarity": "Common",
+                            "power": "2",
+                            "toughness": "2",
+                            "text": "Nom nom nom."
+                        }
+                    ]
+                },
+                "APC": {
+                    "code": "APC",
+                    "name": "Apocalypse",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Fire",
+                            "manaCost": "{1}{R}",
+                            "types": ["Instant"],
+                            "rarity": "Uncommon",
+                            "number": "101a",
+                            "text": "Fire deals 2 damage."
+                        },
+                        {
+                            "name": "Ice",
+                            "manaCost": "{1}{U}",
+                            "types": ["Instant"],
+                            "rarity": "Uncommon",
+                            "number": "101b",
+                            "text": "Tap target permanent."
+                        }
+                    ]
+                }
+            }
+        }
+
+        with patch('os.path.exists') as mock_exists:
+            def side_effect(path):
+                if 'AllPrintings.json' in path:
+                    return True
+                return self.real_exists(path)
+
+            mock_exists.side_effect = side_effect
+
+            with patch('jdecode.mtg_open_json') as mock_mtg_json:
+                mock_mtg_json.return_value = jdecode.mtg_open_json_obj(mock_data)
+
+                # Now call mtg_open_file with the decklist path
+                cards = jdecode.mtg_open_file(decklist_path, verbose=True)
+
+                # Check results
+                # 4 Grizzly Bears + 2 Fire = 6 cards
+                self.assertEqual(len(cards), 6)
+
+                names = [c.name.lower() for c in cards]
+                self.assertEqual(names.count('grizzly bears'), 4)
+                self.assertEqual(names.count('fire'), 2)
+
+                # Verify that Fire has Ice as bside
+                fire_cards = [c for c in cards if c.name.lower() == 'fire']
+                for c in fire_cards:
+                    self.assertIsNotNone(c.bside)
+                    self.assertEqual(c.bside.name.lower(), 'ice')
+
+    @patch('sys.stdin', new_callable=io.StringIO)
+    def test_decklist_stdin_input(self, mock_stdin):
+        # Setup mock stdin
+        decklist_content = "1 Grizzly Bears\n"
+        mock_stdin.write(decklist_content)
+        mock_stdin.seek(0)
+
+        # Mock data
+        mock_data = {
+            "data": {
+                "LEA": {
+                    "code": "LEA",
+                    "name": "Limited Edition Alpha",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Grizzly Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "rarity": "Common",
+                            "power": "2",
+                            "toughness": "2"
+                        }
+                    ]
+                }
+            }
+        }
+
+        with patch('os.path.exists') as mock_exists:
+            mock_exists.side_effect = lambda path: 'AllPrintings.json' in path or self.real_exists(path)
+
+            with patch('jdecode.mtg_open_json') as mock_mtg_json:
+                mock_mtg_json.return_value = jdecode.mtg_open_json_obj(mock_data)
+
+                # Call mtg_open_file with '-' for stdin
+                cards = jdecode.mtg_open_file('-', verbose=True)
+
+                self.assertEqual(len(cards), 1)
+                self.assertEqual(cards[0].name.lower(), 'grizzly bears')
+
+    def test_decklist_no_hydration_file(self):
+        # Create a decklist file
+        decklist_content = "4 Grizzly Bears\n"
+        decklist_path = self.create_temp_file(decklist_content, suffix='.deck')
+
+        # Mock os.path.exists to return False for AllPrintings.json
+        with patch('os.path.exists') as mock_exists:
+            mock_exists.side_effect = lambda path: False if 'AllPrintings.json' in path else self.real_exists(path)
+
+            # This should fall back to treating it as encoded text
+            # Since it doesn't have field separators, it will be one unparsed/invalid card
+            cards = jdecode.mtg_open_file(decklist_path, verbose=False)
+
+            # It might return 0 valid cards because it fails to parse as encoded text
+            valid_cards = [c for c in cards if c.valid]
+            self.assertEqual(len(valid_cards), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This Pull Request introduces the ability to use standard Magic: The Gathering decklist files (.txt, .deck, .dek) or stdin streams as the primary input source for all tools (`encode.py`, `decode.py`, `sortcards.py`, and `summarize.py`).

### Key Changes:
- **Detection Logic:** `lib/jdecode.py` now uses regex heuristics to identify decklist patterns (e.g., "4 Grizzly Bears") when the input doesn't match other formats like JSON or CSV.
- **Auto-Hydration:** If a decklist is detected and the standard `data/AllPrintings.json` database exists, the tool automatically resolves the card names to provide full card objects (including costs, types, and rules text) instead of just names.
- **Refactoring:** Common hydration logic was centralized into a `_hydrate_decklist` helper function.
- **Documentation:** Updated docstrings and CLI help text across the project to make this feature discoverable.
- **Testing:** Added new tests covering file-based decklists, stdin decklists, and fallback behavior when the database is missing.

This improves tool interoperability and reduces friction for users who want to work with their existing card collections and decks.

---
*PR created automatically by Jules for task [1732388103193597719](https://jules.google.com/task/1732388103193597719) started by @RainRat*