### PR TITLE
[FEAT] Symmetry and Parity for Input Encoding Configurations

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -22,6 +22,7 @@ from cbow import CBOW
 from namediff import Namediff
 
 def main(fname, oname = None, verbose = True, encoding = 'std',
+         nolinetrans = False, nolabel = False,
          gatherer = True, for_forum = False, for_mse = False,
          creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, md_table_out = False, summary_out = False, deck_out = False, quiet=False,
          report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None,
@@ -97,7 +98,9 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
     else:
         raise ValueError('decode.py: unknown encoding: ' + encoding)
 
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, fmt_ordered=fmt_ordered, report_file=report_file, grep=grep, vgrep=vgrep,
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=not nolinetrans,
+                                  fmt_ordered=fmt_ordered, fmt_labeled=None if nolabel else cardlib.fmt_labeled_default,
+                                  report_file=report_file, grep=grep, vgrep=vgrep,
                                   grep_name=grep_name, vgrep_name=vgrep_name,
                                   grep_types=grep_types, vgrep_types=vgrep_types,
                                   grep_text=grep_text, vgrep_text=vgrep_text,
@@ -560,6 +563,10 @@ if __name__ == '__main__':
                              "'noname' (No names), 'rfields' (Random field order), "
                              "'old' (Legacy), 'norarity' (No rarity), 'vec' (Numerical vectors), "
                              "or 'custom' (User-defined).")
+    content_group.add_argument('--nolabel', action='store_true',
+                        help="Input file does not have field labels (like '|cost|' or '|text|').")
+    content_group.add_argument('--nolinetrans', action='store_true',
+                        help='Input file does not use automatic line reordering.')
 
     # Gatherer formatting is on by default.
     parser.set_defaults(gatherer=True)
@@ -655,6 +662,7 @@ if __name__ == '__main__':
         args.limit = args.sample
 
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
+         nolinetrans = args.nolinetrans, nolabel = args.nolabel,
          gatherer = args.gatherer, for_forum = args.forum, for_mse = args.mse,
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text,
          json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, md_table_out = args.md_table, summary_out = args.summary, deck_out = args.deck, quiet=args.quiet,

--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -91,7 +91,7 @@ def _print_breakdown(title, index, total, use_color, vsize=None, sort_key=None, 
 
 class Datamine:
     # build the global indices
-    def __init__(self, card_srcs):
+    def __init__(self, cards_input):
         # global card pools
         self.unparsed_cards = []
         self.invalid_cards = []
@@ -141,11 +141,16 @@ class Datamine:
             'by_textlen' : self.by_textlen,
         }
 
-        for card_src in card_srcs:
+        for item in cards_input:
             # the empty card is not interesting
-            if not card_src:
+            if not item:
                 continue
-            card = Card(card_src)
+
+            if isinstance(item, Card):
+                card = item
+            else:
+                card = Card(item)
+
             if card.valid:
                 self.cards += [card]
                 self.allcards += [card]

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -567,6 +567,7 @@ def _process_text_cards(txt_cards, decklist_names, verbose, report_fobj=None):
 
 def mtg_open_file(fname, verbose = False,
                   linetrans = True, fmt_ordered = cardlib.fmt_ordered_default,
+                  fmt_labeled = cardlib.fmt_labeled_default,
                   exclude_sets = default_exclude_sets,
                   exclude_types = default_exclude_types,
                   exclude_layouts = default_exclude_layouts,
@@ -654,7 +655,8 @@ def mtg_open_file(fname, verbose = False,
                 if utils.fieldsep in text:
                     for card_src in text.split(utils.cardsep):
                         if card_src:
-                            card = cardlib.Card(card_src, fmt_ordered=fmt_ordered, linetrans=linetrans)
+                            card = cardlib.Card(card_src, fmt_ordered=fmt_ordered,
+                                                fmt_labeled=fmt_labeled, linetrans=linetrans)
                             skip = False
                             for cardtype in card.types:
                                 if exclude_types(cardtype):
@@ -836,7 +838,8 @@ def mtg_open_file(fname, verbose = False,
 
             for card_src in text.split(utils.cardsep):
                 if card_src:
-                    card = cardlib.Card(card_src, fmt_ordered=fmt_ordered, linetrans=linetrans)
+                    card = cardlib.Card(card_src, fmt_ordered=fmt_ordered,
+                                        fmt_labeled=fmt_labeled, linetrans=linetrans)
 
                     # Apply exclusions to cards from encoded text
                     skip = False

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -20,7 +20,9 @@ except ImportError:
     def tqdm(iterable, **kwargs):
         return iterable
 
-def main(fname, verbose = True, outliers = False, dump_all = False, grep = None, use_color = None, limit = 0, json_out = False, vgrep = None,
+def main(fname, verbose = True, outliers = False, dump_all = False,
+         nolinetrans = False, nolabel = False,
+         grep = None, use_color = None, limit = 0, json_out = False, vgrep = None,
          grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
          grep_text=None, vgrep_text=None,
          grep_cost=None, vgrep_cost=None, grep_pt=None, vgrep_pt=None,
@@ -34,7 +36,9 @@ def main(fname, verbose = True, outliers = False, dump_all = False, grep = None,
 
     # Use the robust mtg_open_file for all loading and filtering.
     # We disable default exclusions to match original summarize.py behavior.
-    cards = jdecode.mtg_open_file(fname, verbose=verbose, grep=grep, vgrep=vgrep,
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=not nolinetrans,
+                                  fmt_labeled=None if nolabel else cardlib.fmt_labeled_default,
+                                  grep=grep, vgrep=vgrep,
                                   grep_name=grep_name, vgrep_name=vgrep_name,
                                   grep_types=grep_types, vgrep_types=vgrep_types,
                                   grep_text=grep_text, vgrep_text=vgrep_text,
@@ -52,14 +56,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False, grep = None,
     if limit > 0:
         cards = cards[:limit]
 
-    card_srcs = []
-    for card in tqdm(cards, disable=quiet or len(cards) < 5, desc="Analyzing cards", unit="card"):
-        if card.json:
-            card_srcs.append(card.json)
-        else:
-            card_srcs.append(card.raw if card.raw else card.encode())
-
-    mine = Datamine(card_srcs)
+    mine = Datamine(cards)
 
     # Determine if we should use color
     actual_use_color = False
@@ -94,11 +91,17 @@ if __name__ == '__main__':
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
                         help='Input card data (JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
-                        help='Input card data (JSON, CSV, MSE, or ZIP), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the summary output. If not provided, output prints to the console. The format is automatically detected from the file extension (.json for JSON, otherwise text).')
     io_group.add_argument('--json', action='store_true',
                         help='Output statistics in JSON format (Auto-detected for .json).')
+
+    # Group: Encoding Options
+    enc_group = parser.add_argument_group('Encoding Options')
+    enc_group.add_argument('--nolabel', action='store_true',
+                        help="Input file does not have field labels (like '|cost|' or '|text|').")
+    enc_group.add_argument('--nolinetrans', action='store_true',
+                        help='Input file does not use automatic line reordering.')
 
     # Group: Processing Options
     proc_group = parser.add_argument_group('Processing Options')
@@ -174,7 +177,9 @@ if __name__ == '__main__':
         args.shuffle = True
         args.limit = args.sample
 
-    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all, grep = args.grep, use_color = args.color, limit = args.limit, json_out = args.json, vgrep = args.vgrep,
+    main(args.infile, verbose = args.verbose, outliers = args.outliers, dump_all = args.all,
+         nolinetrans = args.nolinetrans, nolabel = args.nolabel,
+         grep = args.grep, use_color = args.color, limit = args.limit, json_out = args.json, vgrep = args.vgrep,
          grep_name=args.grep_name, vgrep_name=args.exclude_name,
          grep_types=args.grep_type, vgrep_types=args.exclude_type,
          grep_text=args.grep_text, vgrep_text=args.exclude_text,

--- a/sortcards.py
+++ b/sortcards.py
@@ -240,7 +240,110 @@ def sortcards(cards, verbose=False, use_summary=False, use_color=False, fmt_orde
     return classes
 
 
-def main():
+def main(fname, oname = None, verbose = True, encoding = 'std',
+         nolinetrans = False, nolabel = False,
+         use_summary = False, use_color = None, quiet = False,
+         limit = 0, grep = None, sort = None, vgrep = None,
+         grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
+         grep_text=None, vgrep_text=None,
+         grep_cost=None, vgrep_cost=None, grep_pt=None, vgrep_pt=None,
+         grep_loyalty=None, vgrep_loyalty=None,
+         sets = None, rarities = None, colors=None, cmcs=None,
+         shuffle = False, seed = None, decklist_file = None):
+
+    # Determine format
+    fmt_ordered = cardlib.fmt_ordered_default
+    if encoding == 'named':
+        fmt_ordered = cardlib.fmt_ordered_named
+    elif encoding == 'noname':
+        fmt_ordered = cardlib.fmt_ordered_noname
+    elif encoding == 'old':
+        fmt_ordered = cardlib.fmt_ordered_old
+    elif encoding == 'norarity':
+        fmt_ordered = cardlib.fmt_ordered_norarity
+
+    # Use the robust jdecode.mtg_open_file for loading and filtering.
+    # We disable default exclusions (sets, types, layouts) to match the original sortcards.py behavior.
+    # verbose=True enables jdecode diagnostic output (e.g. invalid cards).
+    cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=not nolinetrans,
+                                  fmt_ordered=fmt_ordered, fmt_labeled=None if nolabel else cardlib.fmt_labeled_default,
+                                  grep=grep, vgrep=vgrep,
+                                  grep_name=grep_name, vgrep_name=vgrep_name,
+                                  grep_types=grep_types, vgrep_types=vgrep_types,
+                                  grep_text=grep_text, vgrep_text=vgrep_text,
+                                  grep_cost=grep_cost, vgrep_cost=vgrep_cost,
+                                  grep_pt=grep_pt, vgrep_pt=vgrep_pt,
+                                  grep_loyalty=grep_loyalty, vgrep_loyalty=vgrep_loyalty,
+                                  sets=sets, rarities=rarities,
+                                  colors=colors, cmcs=cmcs,
+                                  exclude_sets=lambda x: False,
+                                  exclude_types=lambda x: False,
+                                  exclude_layouts=lambda x: False,
+                                  shuffle=shuffle, seed=seed,
+                                  decklist_file=decklist_file)
+
+    if limit > 0:
+        cards = cards[:limit]
+
+    # Determine if we should use color for the summary
+    actual_use_color = False
+    if use_color is True:
+        actual_use_color = True
+    elif use_color is None and sys.stderr.isatty():
+        actual_use_color = True
+
+    # Progress bar is shown unless --quiet is specified
+    classes = sortcards(cards, verbose=not quiet, use_summary=use_summary, use_color=actual_use_color, fmt_ordered=fmt_ordered)
+
+    outputter = sys.stdout
+    ofile = None
+
+    if oname:
+        if verbose:
+            print(f'Writing output to: {oname}', file=sys.stderr)
+        try:
+            ofile = open(oname, 'w', encoding='utf-8')
+            outputter = ofile
+        except Exception as e:
+            print(f"Error opening output file {oname}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        # Print summary (to stderr to separate from data)
+        # Summary is shown unless --quiet is specified
+        for cardclass, card_list in classes.items():
+            if card_list is None:
+                if not quiet:
+                    header = cardclass
+                    if actual_use_color:
+                        header = utils.colorize(header, utils.Ansi.BOLD + utils.Ansi.CYAN)
+                    print(header, file=sys.stderr)
+            else:
+                if not quiet:
+                    name = cardclass
+                    count = str(len(card_list))
+                    if actual_use_color:
+                        if len(card_list) > 0:
+                            count = utils.colorize(count, utils.Ansi.BOLD + utils.Ansi.GREEN)
+                    print(f'  {name}: {count}', file=sys.stderr)
+
+        # Write content
+        for cardclass, card_list in classes.items():
+            if card_list is None:
+                outputter.write(f'{cardclass}\n')
+            else:
+                classlen = len(card_list)
+                if classlen > 0:
+                    outputter.write(f'[spoiler={cardclass}: {classlen} cards]\n')
+                    for card_str in card_list:
+                        outputter.write(f'{card_str}\n\n')
+                    outputter.write('[/spoiler]\n')
+
+    finally:
+        if ofile:
+            ofile.close()
+
+def cli():
     parser = argparse.ArgumentParser(
         description="""Sort Magic cards into groups (like color or type) and format them for sharing on forums.
 
@@ -262,6 +365,10 @@ Supports any encoding format supported by encode.py/decode.py.""",
                              "'noname' (No names), 'rfields' (Random field order), "
                              "'old' (Legacy), 'norarity' (No rarity), 'vec' (Numerical vectors), "
                              "or 'custom' (User-defined).")
+    enc_group.add_argument('--nolabel', action='store_true',
+                        help="Input file does not have field labels (like '|cost|' or '|text|').")
+    enc_group.add_argument('--nolinetrans', action='store_true',
+                        help='Input file does not use automatic line reordering.')
 
     # Group: Processing Options
     proc_group = parser.add_argument_group('Processing Options')
@@ -348,92 +455,18 @@ Supports any encoding format supported by encode.py/decode.py.""",
         args.shuffle = True
         args.limit = args.sample
 
-    # Use the robust jdecode.mtg_open_file for loading and filtering.
-    # We disable default exclusions (sets, types, layouts) to match the original sortcards.py behavior.
-    # verbose=True enables jdecode diagnostic output (e.g. invalid cards).
-    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, fmt_ordered=fmt_ordered,
-                                  grep=args.grep, vgrep=args.vgrep,
-                                  grep_name=args.grep_name, vgrep_name=args.exclude_name,
-                                  grep_types=args.grep_type, vgrep_types=args.exclude_type,
-                                  grep_text=args.grep_text, vgrep_text=args.exclude_text,
-                                  grep_cost=args.grep_cost, vgrep_cost=args.exclude_cost,
-                                  grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
-                                  grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
-                                  sets=args.set, rarities=args.rarity,
-                                  colors=args.colors, cmcs=args.cmc,
-                                  exclude_sets=lambda x: False,
-                                  exclude_types=lambda x: False,
-                                  exclude_layouts=lambda x: False,
-                                  shuffle=args.shuffle, seed=args.seed,
-                                  decklist_file=args.deck)
-
-    if args.limit > 0:
-        cards = cards[:args.limit]
-
-    # Determine if we should use color for the summary
-    use_color = False
-    if args.color is True:
-        use_color = True
-    elif args.color is None and sys.stderr.isatty():
-        use_color = True
-
-    # Progress bar is shown unless --quiet is specified
-    classes = sortcards(cards, verbose=not args.quiet, use_summary=args.summary, use_color=use_color, fmt_ordered=fmt_ordered)
-
-    outputter = sys.stdout
-    ofile = None
-
-    if args.outfile:
-        if args.verbose:
-            print(f'Writing output to: {args.outfile}', file=sys.stderr)
-        try:
-            ofile = open(args.outfile, 'w', encoding='utf-8')
-            outputter = ofile
-        except Exception as e:
-            print(f"Error opening output file {args.outfile}: {e}", file=sys.stderr)
-            sys.exit(1)
-
-    try:
-        # Determine if we should use color for the summary
-        use_color = False
-        if args.color is True:
-            use_color = True
-        elif args.color is None and sys.stderr.isatty():
-            use_color = True
-
-        # Print summary (to stderr to separate from data)
-        # Summary is shown unless --quiet is specified
-        for cardclass, card_list in classes.items():
-            if card_list is None:
-                if not args.quiet:
-                    header = cardclass
-                    if use_color:
-                        header = utils.colorize(header, utils.Ansi.BOLD + utils.Ansi.CYAN)
-                    print(header, file=sys.stderr)
-            else:
-                if not args.quiet:
-                    name = cardclass
-                    count = str(len(card_list))
-                    if use_color:
-                        if len(card_list) > 0:
-                            count = utils.colorize(count, utils.Ansi.BOLD + utils.Ansi.GREEN)
-                    print(f'  {name}: {count}', file=sys.stderr)
-
-        # Write content
-        for cardclass, card_list in classes.items():
-            if card_list is None:
-                outputter.write(f'{cardclass}\n')
-            else:
-                classlen = len(card_list)
-                if classlen > 0:
-                    outputter.write(f'[spoiler={cardclass}: {classlen} cards]\n')
-                    for card_str in card_list:
-                        outputter.write(f'{card_str}\n\n')
-                    outputter.write('[/spoiler]\n')
-
-    finally:
-        if ofile:
-            ofile.close()
+    main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
+         nolinetrans = args.nolinetrans, nolabel = args.nolabel,
+         use_summary = args.summary, use_color = args.color, quiet = args.quiet,
+         limit = args.limit, grep = args.grep, sort = args.sort, vgrep = args.vgrep,
+         grep_name=args.grep_name, vgrep_name=args.exclude_name,
+         grep_types=args.grep_type, vgrep_types=args.exclude_type,
+         grep_text=args.grep_text, vgrep_text=args.exclude_text,
+         grep_cost=args.grep_cost, vgrep_cost=args.exclude_cost,
+         grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
+         grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
+         sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
+         shuffle = args.shuffle, seed = args.seed, decklist_file = args.deck)
 
 if __name__ == '__main__':
-    main()
+    cli()


### PR DESCRIPTION
I have implemented symmetry across the CLI tools (decode.py, sortcards.py, and summarize.py) by adding support for --nolabel and --nolinetrans flags. This ensures they can correctly read encoded card data produced with these non-default settings in encode.py. Additionally, I fixed an IndentationError in scripts/summarize.py, refactored sortcards.py for better programmatic access, and optimized scripts/summarize.py by improving the data flow to Datamine.

I noticed that while encode.py allowed users to strip field labels or disable line transformations, the other tools in the pipeline did not have corresponding flags to handle such input. This "missing piece" of functionality broke the symmetry of the toolchain. By unifying these flags and refactoring the internal data flow, I've made the "Happy Path" smoother for users who need custom encoding formats for their AI training datasets.

---
*PR created automatically by Jules for task [9345685451405136575](https://jules.google.com/task/9345685451405136575) started by @RainRat*