### PR TITLE
[TEST] Fix decklist parsing for cards starting with years

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -226,7 +226,9 @@ def parse_decklist(fpath):
             # Match count and name
             # Optional count at start (digits followed by space or 'x' and space)
             # followed by name. Name ends before a '(' or '[' or '#' (comment).
-            match = re.match(r'^(\d+[xX]?\s+)?([^(\[\n#]+)', line)
+            # We restrict optional counts to 1-3 digits unless an 'x' suffix is present,
+            # to avoid misidentifying names starting with years (e.g. 1996 World Champion).
+            match = re.match(r'^(\d{1,3}\s+|\d+[xX]\s+)?([^(\[\n#]+)', line)
             if match:
                 count_str = match.group(1)
                 name = match.group(2).strip()

--- a/tests/test_year_decklist.py
+++ b/tests/test_year_decklist.py
@@ -1,0 +1,34 @@
+import pytest
+import os
+import sys
+
+# Add lib to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+import jdecode
+
+def test_parse_decklist_year_name(tmp_path):
+    """Test that card names starting with a year are correctly parsed when count is omitted."""
+    deck_content = "1996 World Champion\n4 Grizzly Bears"
+    deck_file = tmp_path / "deck.txt"
+    deck_file.write_text(deck_content)
+
+    res = jdecode.parse_decklist(str(deck_file))
+
+    # Bug: res['world champion'] == 1996
+    # Expected: res['1996 world champion'] == 1
+    assert "1996 world champion" in res
+    assert res["1996 world champion"] == 1
+    assert res["grizzly bears"] == 4
+
+def test_parse_decklist_explicit_count_with_year(tmp_path):
+    """Test that explicit counts are correctly parsed even if the name starts with a year."""
+    deck_content = "1 1996 World Champion"
+    deck_file = tmp_path / "deck.txt"
+    deck_file.write_text(deck_content)
+
+    res = jdecode.parse_decklist(str(deck_file))
+
+    assert "1996 world champion" in res
+    assert res["1996 world champion"] == 1


### PR DESCRIPTION
Updated the decklist parsing regex in `lib/jdecode.py` to restrict implicit card counts to 1-3 digits. This prevents card names starting with years (e.g., "1996 World Champion") from being misidentified as quantities when the count is omitted. Added a new test file `tests/test_year_decklist.py` to verify the fix.

---
*PR created automatically by Jules for task [5114456853095303956](https://jules.google.com/task/5114456853095303956) started by @RainRat*