### PR TITLE
Remove redundant import in summarize.py

### DIFF
--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -12,7 +12,6 @@ sys.path.append(libdir)
 import utils
 import cardlib
 import jdecode
-import cardlib
 from datalib import Datamine
 
 # Try to import tqdm for progress bars


### PR DESCRIPTION
This change removes a duplicate import of the `cardlib` module at the top of `scripts/summarize.py`. Removing redundant imports is a standard code maintenance task that improves readability and follows best practices. This change is non-breaking as Python handles multiple imports of the same module gracefully, and the script remains functional. Verified by running the full test suite and checking the script's help output.

---
*PR created automatically by Jules for task [10590573791109891630](https://jules.google.com/task/10590573791109891630) started by @RainRat*