### PR TITLE
[FEAT] Mechanical Feature Profiling for Dataset Analysis

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -118,6 +118,7 @@ class Datamine:
         self.by_rarity = {}
         self.by_textlines = {}
         self.by_textlen = {}
+        self.by_mechanic = {}
 
         self.indices = {
             'by_name' : self.by_name,
@@ -139,6 +140,7 @@ class Datamine:
             'by_rarity' : self.by_rarity,
             'by_textlines' : self.by_textlines,
             'by_textlen' : self.by_textlen,
+            'by_mechanic' : self.by_mechanic,
         }
 
         for item in cards_input:
@@ -146,7 +148,7 @@ class Datamine:
             if not item:
                 continue
 
-            if isinstance(item, Card):
+            if hasattr(item, 'fields'):
                 card = item
             else:
                 card = Card(item)
@@ -202,6 +204,9 @@ class Datamine:
                 inc(self.by_textlines, len(card.text_lines), [card])
                 inc(self.by_textlen, len(card.text.encode()), [card])
 
+                # Mechanical profiling
+                self._profile_mechanics(card)
+
         self.avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
 
         # Calculate average P/T
@@ -209,6 +214,59 @@ class Datamine:
         t_vals = [utils.from_unary_single(c.pt_t) for c in self.cards if c.pt_t is not None]
         self.avg_power = sum(p_vals) / len(p_vals) if p_vals else 0
         self.avg_toughness = sum(t_vals) / len(t_vals) if t_vals else 0
+
+    def _profile_mechanics(self, card):
+        """Internal helper to identify and index mechanical features of a card."""
+
+        def check_card_face(c):
+            text_raw = c.text.text.lower()
+            text_enc = c.text.encode().lower()
+            cost_enc = c.cost.encode()
+
+            mechanics = set()
+
+            # 1. Structural mechanics
+            if ':' in text_raw:
+                mechanics.add('Activated')
+
+            # Triggered: check start of lines
+            for mt in c.text_lines:
+                line = mt.text.lower().strip()
+                if line.startswith('when') or line.startswith('whenever') or line.startswith('at '):
+                    mechanics.add('Triggered')
+                    break
+
+            if 'enters the battlefield' in text_raw:
+                mechanics.add('ETB Effect')
+
+            if utils.choice_open_delimiter in text_enc or utils.choice_close_delimiter in text_enc:
+                mechanics.add('Modal/Choice')
+
+            if 'X' in cost_enc or 'x' in text_raw:
+                mechanics.add('X-Cost/Effect')
+
+            # 2. Common Keyword Abilities
+            keywords = [
+                'flying', 'trample', 'lifelink', 'haste', 'deathtouch',
+                'vigilance', 'ward', 'prowess', 'menace', 'reach',
+                'flash', 'indestructible', 'scry', 'draw a card',
+                'mill', 'exile', 'token', 'discard'
+            ]
+
+            for kw in keywords:
+                # Use word boundaries for keywords to avoid partial matches
+                if re.search(r'\b' + re.escape(kw) + r'\b', text_raw):
+                    mechanics.add(kw.title())
+
+            return mechanics
+
+        # Recursive profiling for split/double-faced cards
+        all_mechanics = check_card_face(card)
+        if card.bside:
+            all_mechanics.update(check_card_face(card.bside))
+
+        for m in all_mechanics:
+            inc(self.by_mechanic, m, [card])
 
     # summarize the indices
     def summarize(self, hsize = 10, vsize = 10, cmcsize = 20, use_color = False):
@@ -282,6 +340,11 @@ class Datamine:
                    + str(max(self.by_textlines)) + ' lines', use_color))
         _print_breakdown('Line counts by frequency:', self.by_textlines, len(self.allcards), use_color,
                          vsize=vsize, sort_key=lambda x: len(self.by_textlines[x]))
+        print()
+
+        print(color_line(str(len(self.by_mechanic)) + ' distinct mechanical features identified', use_color))
+        _print_breakdown('Mechanical Breakdown:', self.by_mechanic, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: len(self.by_mechanic[x]))
         print()
 
     # describe outliers in the indices

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -87,7 +87,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Show statistics and details about a Magic: The Gathering card dataset.")
+    parser = argparse.ArgumentParser(description="Show statistics, mechanical profiling, and details about a Magic: The Gathering card dataset.")
     
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')

--- a/tests/test_datalib_mechanics.py
+++ b/tests/test_datalib_mechanics.py
@@ -1,0 +1,129 @@
+import unittest
+import sys
+import os
+
+# Ensure lib is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib')))
+
+from cardlib import Card
+from datalib import Datamine
+import utils
+
+class TestDatalibMechanics(unittest.TestCase):
+    def test_basic_keyword_profiling(self):
+        card_data = {
+            "name": "Aerial Elf",
+            "manaCost": "{1}{G}",
+            "types": ["Creature"],
+            "subtypes": ["Elf"],
+            "text": "Flying\nTrample",
+            "rarity": "common",
+            "power": "2",
+            "toughness": "2"
+        }
+        card = Card(card_data)
+        mine = Datamine([card])
+
+        self.assertIn('Flying', mine.by_mechanic)
+        self.assertIn('Trample', mine.by_mechanic)
+        self.assertEqual(len(mine.by_mechanic['Flying']), 1)
+
+    def test_structural_mechanics(self):
+        card_data = {
+            "name": "Test Wizard",
+            "manaCost": "{U}",
+            "types": ["Creature"],
+            "text": "When @ enters the battlefield, draw a card.\n{1}, {T}: Scry 1.",
+            "rarity": "rare",
+            "power": "1",
+            "toughness": "1"
+        }
+        card = Card(card_data)
+        mine = Datamine([card])
+
+        self.assertIn('Triggered', mine.by_mechanic)
+        self.assertIn('Activated', mine.by_mechanic)
+        self.assertIn('ETB Effect', mine.by_mechanic)
+        self.assertIn('Draw A Card', mine.by_mechanic)
+        self.assertIn('Scry', mine.by_mechanic)
+
+    def test_modal_and_x_cost(self):
+        card_data = {
+            "name": "Fireball",
+            "manaCost": "{X}{R}",
+            "types": ["Sorcery"],
+            "text": "Choose one \u2014\n\u2022 Fireball deals X damage to target creature.\n\u2022 Fireball deals X damage to target player.",
+            "rarity": "uncommon"
+        }
+
+        card = Card(card_data)
+        mine = Datamine([card])
+
+        self.assertIn('Modal/Choice', mine.by_mechanic)
+        self.assertIn('X-Cost/Effect', mine.by_mechanic)
+
+    def test_recursive_bside_profiling(self):
+        # Split card
+        card_data = {
+            "name": "Fire // Ice",
+            "manaCost": "{1}{R}",
+            "types": ["Instant"],
+            "text": "Fire deals 2 damage.",
+            "rarity": "uncommon",
+            "bside": {
+                "name": "Ice",
+                "manaCost": "{1}{U}",
+                "types": ["Instant"],
+                "text": "Tap target permanent. Draw a card."
+            }
+        }
+        card = Card(card_data)
+        mine = Datamine([card])
+
+        # B-side has 'Draw A Card'
+        self.assertIn('Draw A Card', mine.by_mechanic)
+        # Check counts
+        self.assertEqual(len(mine.by_mechanic['Draw A Card']), 1)
+
+    def test_keyword_boundaries(self):
+        # Ensure 'mill' doesn't match 'million'
+        card_data = {
+            "name": "Rich Man",
+            "text": "I have a million dollars.",
+            "types": ["Creature"],
+            "rarity": "common"
+        }
+        card = Card(card_data)
+        mine = Datamine([card])
+        self.assertNotIn('Mill', mine.by_mechanic)
+
+        # Ensure it matches at boundaries
+        card_data["text"] = "Mill three cards."
+        card = Card(card_data)
+        mine = Datamine([card])
+        self.assertIn('Mill', mine.by_mechanic)
+
+    def test_json_export_consistency(self):
+        card_data = {
+            "name": "Flying Token Maker",
+            "types": ["Sorcery"],
+            "text": "Create a 1/1 white Spirit creature token with flying.",
+            "rarity": "common"
+        }
+        card = Card(card_data)
+        mine = Datamine([card])
+
+        d = mine.to_dict()
+        self.assertIn('by_mechanic', d['indices'])
+        # Datamine.to_dict() converts counts to strings: {str(k): len(v) for k, v in index.items()}
+        # Wait, I saw len(v) was 1 and it failed 1 != '1'.
+        # result['indices'][name] = {str(k): len(v) for k, v in index.items()}
+        # Flying is the key 'k'. len(v) is 1. So it should be 1 (int).
+        # Ah, the test said AssertionError: 1 != '1'.
+        # Let's check datalib.py again.
+
+        self.assertEqual(d['indices']['by_mechanic']['Flying'], 1)
+        self.assertEqual(d['indices']['by_mechanic']['Token'], 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### What:
Added comprehensive mechanical profiling to the `Datamine` class in `lib/datalib.py`. The tool now automatically identifies and categorizes cards based on:
- **Structural Mechanics:** Activated abilities (via `:`), Triggered abilities (line starts), ETB effects, Modal/Choice structures (via delimiters), and X-costs/effects.
- **Keyword Abilities:** Common keywords like Flying, Trample, Lifelink, Ward, Scry, Token creation, and more.

The analysis is recursive, ensuring split and double-faced cards are fully profiled. The `summarize.py` CLI utility now includes a "Mechanical Breakdown" section with frequencies and bar charts. Profiling data is also included in JSON exports for downstream analysis.

### Why:
I noticed that while the existing tools provided excellent analysis of card metadata (colors, CMC, rarities), they lacked insight into the actual gameplay mechanics contained within the text. For users training AI models, understanding the mechanical distribution of their training set—and the mechanical coherence of generated output—is crucial. This feature fills that gap by providing a high-level "mechanical fingerprint" of any card collection or generated dataset without requiring manual labeling.

---
*PR created automatically by Jules for task [15219194888180308144](https://jules.google.com/task/15219194888180308144) started by @RainRat*