### PR TITLE
Remove redundant rarity color wrapper in Card class

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -583,10 +583,6 @@ class Card:
                 return utils.Ansi.get_color_color('A')
             return utils.Ansi.BOLD
 
-    def _get_rarity_ansi_color(self, rarity):
-        """Returns the ANSI color code for a given rarity string or marker."""
-        return utils.Ansi.get_rarity_color(rarity)
-
     # These setters are invoked via name mangling, so they have to match 
     # the field names specified above to be used. Otherwise we just
     # always fall back to the (uninteresting) default handler.
@@ -922,7 +918,7 @@ class Card:
 
             indicator = f'[{indicator}]'
             if ansi_color:
-                color = self._get_rarity_ansi_color(r)
+                color = utils.Ansi.get_rarity_color(r)
                 indicator = utils.colorize(indicator, color)
 
             rarity_indicator = f'{indicator} '
@@ -1032,7 +1028,7 @@ class Card:
 
         rarity_display = rarity
         if ansi_color and rarity:
-            color = self._get_rarity_ansi_color(rarity)
+            color = utils.Ansi.get_rarity_color(rarity)
             rarity_display = utils.colorize(rarity, color)
 
         if rarity and gatherer:


### PR DESCRIPTION
I have identified and removed a redundant wrapper in `lib/cardlib.py`. Specifically, the `Card` class contained a private method `_get_rarity_ansi_color(self, rarity)` that did nothing but call `utils.Ansi.get_rarity_color(rarity)`. 

I have:
1. Updated the `summary()` method in `lib/cardlib.py` to call `utils.Ansi.get_rarity_color(r)` directly.
2. Updated the `format()` method in `lib/cardlib.py` to call `utils.Ansi.get_rarity_color(rarity)` directly.
3. Removed the redundant `_get_rarity_ansi_color` method from the `Card` class.

These changes are non-breaking as the behavior of the rarity color formatting remains unchanged. I have verified this by running the full test suite (365 tests passed).

---
*PR created automatically by Jules for task [7012013902577728233](https://jules.google.com/task/7012013902577728233) started by @RainRat*