### PR TITLE
[FEAT] Markdown output support for sortcards.py

### DIFF
--- a/sortcards.py
+++ b/sortcards.py
@@ -20,7 +20,7 @@ except ImportError:
     def tqdm(iterable, **kwargs):
         return iterable
 
-def sortcards(cards, verbose=False, use_summary=False, use_color=False, fmt_ordered=cardlib.fmt_ordered_default):
+def sortcards(cards, verbose=False, use_summary=False, use_markdown=False, use_color=False, fmt_ordered=cardlib.fmt_ordered_default):
     """
     Sorts a list of Card objects into various categories.
     """
@@ -90,6 +90,8 @@ def sortcards(cards, verbose=False, use_summary=False, use_color=False, fmt_orde
         # Determine the string representation to use
         if use_summary:
             card_str = card.summary(ansi_color=use_color)
+        elif use_markdown:
+            card_str = card.format(for_md=True)
         else:
             # Use card.raw for the original string representation
             # Ensure we have a string to write out
@@ -243,7 +245,7 @@ def sortcards(cards, verbose=False, use_summary=False, use_color=False, fmt_orde
 
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, nolabel = False,
-         use_summary = False, use_color = None, quiet = False,
+         use_summary = False, use_markdown = False, use_color = None, quiet = False,
          limit = 0, grep = None, sort = None, vgrep = None,
          grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
          grep_text=None, vgrep_text=None,
@@ -262,6 +264,10 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         fmt_ordered = cardlib.fmt_ordered_old
     elif encoding == 'norarity':
         fmt_ordered = cardlib.fmt_ordered_norarity
+
+    # Auto-detect markdown format from extension
+    if not use_markdown and oname and oname.endswith('.md'):
+        use_markdown = True
 
     # Use the robust jdecode.mtg_open_file for loading and filtering.
     # We disable default exclusions (sets, types, layouts) to match the original sortcards.py behavior.
@@ -297,7 +303,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         actual_use_color = True
 
     # Progress bar is shown unless --quiet is specified
-    classes = sortcards(cards, verbose=not quiet, use_summary=use_summary, use_color=actual_use_color, fmt_ordered=fmt_ordered)
+    classes = sortcards(cards, verbose=not quiet, use_summary=use_summary, use_markdown=use_markdown, use_color=actual_use_color, fmt_ordered=fmt_ordered)
 
     outputter = sys.stdout
     ofile = None
@@ -351,10 +357,18 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
                     # Content block
                     classlen = len(card_list)
-                    outputter.write(f'[spoiler={name}: {classlen} cards]\n')
+                    if use_markdown:
+                        outputter.write(f'<details><summary>{name}: {classlen} cards</summary>\n\n')
+                    else:
+                        outputter.write(f'[spoiler={name}: {classlen} cards]\n')
+
                     for card_str in card_list:
                         outputter.write(f'{card_str}\n\n')
-                    outputter.write('[/spoiler]\n')
+
+                    if use_markdown:
+                        outputter.write('</details>\n\n')
+                    else:
+                        outputter.write('[/spoiler]\n')
 
     finally:
         if ofile:
@@ -439,6 +453,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     proc_group.add_argument('--summary', action='store_true',
                         help='Output compact card summaries instead of full encoded text.')
+    proc_group.add_argument('--md', '--markdown', action='store_true',
+                        help='Output in Markdown format with collapsible sections (Auto-detected for .md).')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -476,7 +492,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
 
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          nolinetrans = args.nolinetrans, nolabel = args.nolabel,
-         use_summary = args.summary, use_color = args.color, quiet = args.quiet,
+         use_summary = args.summary, use_markdown = args.md, use_color = args.color, quiet = args.quiet,
          limit = args.limit, grep = args.grep, sort = args.sort, vgrep = args.vgrep,
          grep_name=args.grep_name, vgrep_name=args.exclude_name,
          grep_types=args.grep_type, vgrep_types=args.exclude_type,

--- a/tests/test_sortcards_markdown.py
+++ b/tests/test_sortcards_markdown.py
@@ -1,0 +1,101 @@
+import pytest
+import os
+import sys
+
+# Add lib directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+import sortcards
+import cardlib
+import utils
+
+def test_markdown_output_format(tmp_path):
+    # Test that Markdown output uses <details> and <summary> tags
+    # and that cards are formatted as Markdown
+    card_data = {
+        "name": "Markdown Card",
+        "manaCost": "{1}{W}",
+        "types": ["Creature"],
+        "subtypes": ["Human"],
+        "power": "1",
+        "toughness": "1",
+        "text": "Lifelink",
+        "rarity": "common"
+    }
+    card = cardlib.Card(card_data)
+
+    infile = tmp_path / "input.json"
+    import json
+    infile.write_text(json.dumps({"data": {"TST": {"name": "Test", "code": "TST", "type": "expansion", "cards": [card_data]}}}), encoding="utf-8")
+
+    outfile = tmp_path / "output.md"
+
+    # Run sortcards main
+    sortcards.main(str(infile), str(outfile), use_markdown=True, quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert "<details><summary>" in content
+    assert "</details>" in content
+    assert "**Markdown Card**" in content
+    assert "Creature ~ Human" in content
+    assert "(1/1)" in content
+
+def test_markdown_auto_detection(tmp_path):
+    # Test that .md extension triggers Markdown mode automatically
+    card_data = {
+        "name": "Auto MD Card",
+        "types": ["Instant"],
+        "rarity": "rare"
+    }
+
+    infile = tmp_path / "input.json"
+    import json
+    infile.write_text(json.dumps({"data": {"TST": {"name": "Test", "code": "TST", "type": "expansion", "cards": [card_data]}}}), encoding="utf-8")
+
+    outfile = tmp_path / "auto.md"
+
+    # Run sortcards main without explicit use_markdown=True
+    sortcards.main(str(infile), str(outfile), quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert "<details><summary>" in content
+    assert "**Auto Md Card**" in content
+
+def test_markdown_summary_mode(tmp_path):
+    # Test that --summary flag still produces summaries even in Markdown mode
+    card_data = {
+        "name": "Summary MD Card",
+        "manaCost": "{U}",
+        "types": ["Sorcery"],
+        "rarity": "common"
+    }
+
+    infile = tmp_path / "input.json"
+    import json
+    infile.write_text(json.dumps({"data": {"TST": {"name": "Test", "code": "TST", "type": "expansion", "cards": [card_data]}}}), encoding="utf-8")
+
+    outfile = tmp_path / "summary.md"
+
+    # Run sortcards main with both summary and markdown
+    sortcards.main(str(infile), str(outfile), use_markdown=True, use_summary=True, quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert "<details><summary>" in content
+    # Card should be a summary line, not full format
+    # Summary includes rarity indicator [C] and titlecase "Md"
+    assert "Summary Md Card {U} \u2022 Sorcery" in content
+    assert "**Summary Md Card**" not in content
+
+def test_markdown_no_cards(tmp_path):
+    # Test that headers are not printed if no cards match
+    infile = tmp_path / "empty.json"
+    import json
+    infile.write_text(json.dumps({"data": {"TST": {"name": "Test", "code": "TST", "type": "expansion", "cards": []}}}), encoding="utf-8")
+
+    outfile = tmp_path / "empty.md"
+
+    sortcards.main(str(infile), str(outfile), use_markdown=True, quiet=True, verbose=False)
+
+    content = outfile.read_text(encoding="utf-8")
+    assert content.strip() == ""


### PR DESCRIPTION
Identified and implemented Markdown output support for `sortcards.py` as a logical "missing piece" of functionality.

### Core Functionality
- **Markdown Support:** Implemented a new `--markdown` (or `--md`) flag.
- **Auto-detection:** Automatically enables Markdown mode if the output file has a `.md` extension.
- **Collapsible Sections:** Uses standard HTML `<details>` and `<summary>` tags for grouping, which is the idiomatic way to handle collapsible sections in Markdown.
- **Consistent Formatting:** Individual cards are now formatted as Markdown (e.g., bolded names) using the library's existing `for_md=True` mode, ensuring high-quality output.

### Technical Details
- Updated function signatures for `main()` and `sortcards()` to propagate the `use_markdown` flag.
- Modified the output loop to switch between BBCode `[spoiler]` and HTML `<details>` based on the active mode.
- Ensured non-breaking behavior: default BBCode output remains the standard.

### Verification Results
- Created a new test suite `tests/test_sortcards_markdown.py` covering auto-detection, grouping tags, and card formatting.
- All 369 tests in the repository (including the new ones) passed successfully.
- Code reviewed and finalized with clean imports.

---
*PR created automatically by Jules for task [4113199082148998120](https://jules.google.com/task/4113199082148998120) started by @RainRat*