### PR TITLE
[FEAT] Advanced Numerical Filtering for Card Statistics

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -31,6 +31,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          grep_cost=None, vgrep_cost=None, grep_pt=None, vgrep_pt=None,
          grep_loyalty=None, vgrep_loyalty=None,
          sets=None, rarities=None, colors=None, cmcs=None,
+         pows=None, tous=None, loys=None,
          shuffle=False, seed=None, decklist_file=None):
 
     # Set default format to text if no specific output format is selected.
@@ -109,6 +110,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   grep_loyalty=grep_loyalty, vgrep_loyalty=vgrep_loyalty,
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
+                                  pows=pows, tous=tous, loys=loys,
                                   shuffle=shuffle, seed=seed, decklist_file=decklist_file)
 
     if sort:
@@ -646,7 +648,13 @@ if __name__ == '__main__':
     proc_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
     proc_group.add_argument('--cmc', action='append',
-                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports multiple values (OR logic).')
+                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
+    proc_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities and ranges.')
+    proc_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
+    proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck_filter',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
 
@@ -675,6 +683,7 @@ if __name__ == '__main__':
          grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
+         pows=args.pow, tous=args.tou, loys=args.loy,
          shuffle=args.shuffle, seed=args.seed, decklist_file=args.deck_filter)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -20,6 +20,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          grep_cost=None, vgrep_cost=None, grep_pt=None, vgrep_pt=None,
          grep_loyalty=None, vgrep_loyalty=None,
          sets=None, rarities=None, colors=None, cmcs=None,
+         pows=None, tous=None, loys=None,
          seed=None, decklist_file=None):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
@@ -79,6 +80,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   grep_loyalty=grep_loyalty, vgrep_loyalty=vgrep_loyalty,
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
+                                  pows=pows, tous=tous, loys=loys,
                                   shuffle=not stable, seed=seed if seed is not None else 1371367,
                                   decklist_file=decklist_file)
 
@@ -201,7 +203,13 @@ if __name__ == '__main__':
     proc_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
     proc_group.add_argument('--cmc', action='append',
-                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports multiple values (OR logic).')
+                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
+    proc_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities and ranges.')
+    proc_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
+    proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
 
@@ -231,5 +239,6 @@ if __name__ == '__main__':
          grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
+         pows=args.pow, tous=args.tou, loys=args.loy,
          seed=args.seed, decklist_file=args.deck)
     exit(0)

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -659,6 +659,7 @@ def mtg_open_file(fname, verbose = False,
                   grep_loyalty=None, vgrep_loyalty=None,
                   sets=None, rarities=None,
                   colors=None, cmcs=None,
+                  pows=None, tous=None, loys=None,
                   shuffle=False, seed=None,
                   decklist_file=None):
     """
@@ -951,7 +952,7 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
-    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs:
+    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys:
         greps = [re.compile(p, re.IGNORECASE) for p in (grep if grep else [])]
         vgreps = [re.compile(p, re.IGNORECASE) for p in (vgrep if vgrep else [])]
         greps_name = [re.compile(p, re.IGNORECASE) for p in (grep_name if grep_name else [])]
@@ -979,7 +980,12 @@ def mtg_open_file(fname, verbose = False,
                     target_rarities.append(r)
 
         target_colors = [c.upper() for c in colors] if colors else None
-        target_cmcs = [float(c) for c in cmcs] if cmcs else None
+
+        # Initialize NumericFilters
+        cmc_filters = [utils.NumericFilter(f) for f in cmcs] if cmcs else []
+        pow_filters = [utils.NumericFilter(f) for f in pows] if pows else []
+        tou_filters = [utils.NumericFilter(f) for f in tous] if tous else []
+        loy_filters = [utils.NumericFilter(f) for f in loys] if loys else []
 
         def match_card(card):
             # Generic filtering (AND logic for greps, OR logic for vgreps)
@@ -1065,8 +1071,43 @@ def mtg_open_file(fname, verbose = False,
                     return False
 
             # CMC filtering
-            if target_cmcs:
-                if card.cost.cmc not in target_cmcs:
+            if cmc_filters:
+                match_cmc = False
+                for f in cmc_filters:
+                    if f.evaluate(card.cost.cmc):
+                        match_cmc = True
+                        break
+                if not match_cmc:
+                    return False
+
+            # Power filtering
+            if pow_filters:
+                match_pow = False
+                for f in pow_filters:
+                    if f.evaluate(card.pt_p):
+                        match_pow = True
+                        break
+                if not match_pow:
+                    return False
+
+            # Toughness filtering
+            if tou_filters:
+                match_tou = False
+                for f in tou_filters:
+                    if f.evaluate(card.pt_t):
+                        match_tou = True
+                        break
+                if not match_tou:
+                    return False
+
+            # Loyalty filtering
+            if loy_filters:
+                match_loy = False
+                for f in loy_filters:
+                    if f.evaluate(card.loyalty):
+                        match_loy = True
+                        break
+                if not match_loy:
                     return False
 
             return True

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -734,3 +734,81 @@ def print_operation_summary(op_name, success_count, fail_count, quiet=False):
         print(success_str, file=sys.stderr)
         print(fail_str, file=sys.stderr)
         print(footer, file=sys.stderr)
+
+
+class NumericFilter:
+    """
+    Parses and evaluates numerical filters.
+    Supports:
+    - Exact values: "5", "2.5"
+    - Inequalities: ">5", "<3", ">=2", "<=10", "!=0", "==4"
+    - Ranges: "2-4", "0.5-1.5"
+    """
+    def __init__(self, filter_str):
+        self.filter_str = filter_str.strip()
+        self.mode = None # 'exact', 'inequality', 'range'
+        self.op = None   # '>', '<', '>=', '<=', '!=', '=='
+        self.val = None
+        self.val2 = None # for range
+        self._parse()
+
+    def _parse(self):
+        s = self.filter_str
+        # Check for range
+        range_match = re.match(r'^([-+]?\d*\.?\d+)\s*-\s*([-+]?\d*\.?\d+)$', s)
+        if range_match:
+            self.mode = 'range'
+            self.val = float(range_match.group(1))
+            self.val2 = float(range_match.group(2))
+            return
+
+        # Check for inequalities
+        ineq_match = re.match(r'^([><=!]=|[><])\s*([-+]?\d*\.?\d+)$', s)
+        if ineq_match:
+            self.mode = 'inequality'
+            self.op = ineq_match.group(1)
+            self.val = float(ineq_match.group(2))
+            return
+
+        # Fallback to exact match (optionally with ==)
+        exact_match = re.match(r'^(?:==\s*)?([-+]?\d*\.?\d+)$', s)
+        if exact_match:
+            self.mode = 'exact'
+            self.val = float(exact_match.group(1))
+            return
+
+        raise ValueError(f"Invalid numerical filter: {s}")
+
+    def evaluate(self, value):
+        """
+        Evaluates the filter against a numeric value.
+        If value is a string, it attempts to convert it to a float.
+        """
+        if value is None:
+            return False
+
+        try:
+            if isinstance(value, str):
+                # Handle unary or decimal strings
+                if value.startswith(unary_marker):
+                    val = float(from_unary_single(value))
+                else:
+                    val = float(value)
+            else:
+                val = float(value)
+        except (ValueError, TypeError):
+            return False
+
+        if self.mode == 'exact':
+            return val == self.val
+        if self.mode == 'range':
+            return self.val <= val <= self.val2
+        if self.mode == 'inequality':
+            if self.op == '>': return val > self.val
+            if self.op == '<': return val < self.val
+            if self.op == '>=': return val >= self.val
+            if self.op == '<=': return val <= self.val
+            if self.op == '!=': return val != self.val
+            if self.op == '==': return val == self.val
+
+        return False

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -29,6 +29,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
          grep_cost=None, vgrep_cost=None, grep_pt=None, vgrep_pt=None,
          grep_loyalty=None, vgrep_loyalty=None,
          sets = None, rarities = None, colors=None, cmcs=None,
+         pows=None, tous=None, loys=None,
          shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None):
 
     # Set default format to JSON if no specific output format is selected and outfile is .json
@@ -48,6 +49,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
                                   grep_loyalty=grep_loyalty, vgrep_loyalty=vgrep_loyalty,
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
+                                  pows=pows, tous=tous, loys=loys,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
@@ -153,7 +155,13 @@ if __name__ == '__main__':
     proc_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
     proc_group.add_argument('--cmc', action='append',
-                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports multiple values (OR logic).')
+                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
+    proc_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities and ranges.')
+    proc_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
+    proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     
@@ -188,5 +196,6 @@ if __name__ == '__main__':
          grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
+         pows=args.pow, tous=args.tou, loys=args.loy,
          shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -252,6 +252,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          grep_cost=None, vgrep_cost=None, grep_pt=None, vgrep_pt=None,
          grep_loyalty=None, vgrep_loyalty=None,
          sets = None, rarities = None, colors=None, cmcs=None,
+         pows=None, tous=None, loys=None,
          shuffle = False, seed = None, decklist_file = None):
 
     # Determine format
@@ -283,6 +284,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   grep_loyalty=grep_loyalty, vgrep_loyalty=vgrep_loyalty,
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
+                                  pows=pows, tous=tous, loys=loys,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
@@ -448,7 +450,13 @@ Supports any encoding format supported by encode.py/decode.py.""",
     proc_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
     proc_group.add_argument('--cmc', action='append',
-                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports multiple values (OR logic).')
+                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
+    proc_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities and ranges.')
+    proc_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
+    proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     proc_group.add_argument('--summary', action='store_true',
@@ -501,6 +509,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
          grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
+         pows=args.pow, tous=args.tou, loys=args.loy,
          shuffle = args.shuffle, seed = args.seed, decklist_file = args.deck)
 
 if __name__ == '__main__':

--- a/tests/test_numeric_filters.py
+++ b/tests/test_numeric_filters.py
@@ -1,0 +1,194 @@
+import pytest
+import os
+import sys
+
+# Add lib directory to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+import utils
+import cardlib
+import jdecode
+
+def test_numeric_filter_parsing():
+    # Exact
+    nf = utils.NumericFilter("5")
+    assert nf.mode == 'exact'
+    assert nf.val == 5.0
+
+    nf = utils.NumericFilter("== 3.5")
+    assert nf.mode in ['exact', 'inequality']
+    assert nf.val == 3.5
+
+    # Inequalities
+    nf = utils.NumericFilter(">5")
+    assert nf.mode == 'inequality'
+    assert nf.op == '>'
+    assert nf.val == 5.0
+
+    nf = utils.NumericFilter("<= 10.2")
+    assert nf.mode == 'inequality'
+    assert nf.op == '<='
+    assert nf.val == 10.2
+
+    nf = utils.NumericFilter("!=0")
+    assert nf.mode == 'inequality'
+    assert nf.op == '!='
+    assert nf.val == 0.0
+
+    # Range
+    nf = utils.NumericFilter("2-4")
+    assert nf.mode == 'range'
+    assert nf.val == 2.0
+    assert nf.val2 == 4.0
+
+    nf = utils.NumericFilter("-1 - 5")
+    assert nf.mode == 'range'
+    assert nf.val == -1.0
+    assert nf.val2 == 5.0
+
+    with pytest.raises(ValueError):
+        utils.NumericFilter("abc")
+
+def test_numeric_filter_evaluation():
+    # Exact
+    nf = utils.NumericFilter("5")
+    assert nf.evaluate(5)
+    assert nf.evaluate("5")
+    assert nf.evaluate("&^^^^^") # unary 5
+    assert not nf.evaluate(4)
+    assert not nf.evaluate(6)
+
+    # Inequality
+    nf = utils.NumericFilter("> 5")
+    assert nf.evaluate(6)
+    assert nf.evaluate(5.1)
+    assert not nf.evaluate(5)
+    assert not nf.evaluate(4)
+
+    nf = utils.NumericFilter("<= 3")
+    assert nf.evaluate(3)
+    assert nf.evaluate(2)
+    assert nf.evaluate(0)
+    assert not nf.evaluate(3.1)
+    assert not nf.evaluate(4)
+
+    # Range
+    nf = utils.NumericFilter("2-4")
+    assert nf.evaluate(2)
+    assert nf.evaluate(3)
+    assert nf.evaluate(4)
+    assert not nf.evaluate(1.9)
+    assert not nf.evaluate(4.1)
+
+    # Non-numeric graceful handling
+    assert not nf.evaluate(None)
+    assert not nf.evaluate("star")
+    assert not nf.evaluate("*")
+
+def test_jdecode_numeric_filtering():
+    # Mock cards for testing
+    # Card 1: 1/1, CMC 1, Loyalty None
+    c1_json = {
+        'name': 'C1',
+        'manaCost': '{W}',
+        'types': ['Creature'],
+        'power': '1',
+        'toughness': '1',
+        'rarity': 'Common'
+    }
+    # Card 2: 5/5, CMC 5, Loyalty None
+    c2_json = {
+        'name': 'C2',
+        'manaCost': '{5}',
+        'types': ['Creature'],
+        'power': '5',
+        'toughness': '5',
+        'rarity': 'Rare'
+    }
+    # Card 3: CMC 4, Loyalty 4
+    c3_json = {
+        'name': 'C3',
+        'manaCost': '{2}{U}{U}',
+        'types': ['Planeswalker'],
+        'loyalty': 4,
+        'rarity': 'Mythic'
+    }
+
+    cards = [cardlib.Card(c1_json), cardlib.Card(c2_json), cardlib.Card(c3_json)]
+
+    # Test helper for filtering
+    def filter_cards(pows=None, tous=None, loys=None, cmcs=None):
+        # We manually apply the logic from jdecode match_card for testing
+        cmc_filters = [utils.NumericFilter(f) for f in cmcs] if cmcs else []
+        pow_filters = [utils.NumericFilter(f) for f in pows] if pows else []
+        tou_filters = [utils.NumericFilter(f) for f in tous] if tous else []
+        loy_filters = [utils.NumericFilter(f) for f in loys] if loys else []
+
+        res = []
+        for card in cards:
+            keep = True
+            if cmc_filters:
+                if not any(f.evaluate(card.cost.cmc) for f in cmc_filters): keep = False
+            if keep and pow_filters:
+                if not any(f.evaluate(card.pt_p) for f in pow_filters): keep = False
+            if keep and tou_filters:
+                if not any(f.evaluate(card.pt_t) for f in tou_filters): keep = False
+            if keep and loy_filters:
+                if not any(f.evaluate(card.loyalty) for f in loy_filters): keep = False
+
+            if keep:
+                res.append(card)
+        return res
+
+    # Exact power
+    assert len(filter_cards(pows=["1"])) == 1
+    assert filter_cards(pows=["1"])[0].name == 'c1'
+
+    # Inequality power
+    assert len(filter_cards(pows=[">2"])) == 1
+    assert filter_cards(pows=[">2"])[0].name == 'c2'
+
+    # Range CMC
+    assert len(filter_cards(cmcs=["4-6"])) == 2 # C2 (5) and C3 (4)
+
+    # Multiple flags (OR logic)
+    assert len(filter_cards(pows=["1", "5"])) == 2
+
+    # Combined filters (AND logic between types)
+    assert len(filter_cards(pows=[">0"], cmcs=["<3"])) == 1 # Only C1
+
+    # Loyalty
+    assert len(filter_cards(loys=["4"])) == 1
+    assert filter_cards(loys=["4"])[0].name == 'c3'
+
+def test_jdecode_integration(tmp_path):
+    # Verify that jdecode.mtg_open_file correctly uses the new filters
+    import json
+    d = tmp_path / "data"
+    d.mkdir()
+    p = d / "cards.json"
+    p.write_text(json.dumps({
+        "data": {
+            "SET": {
+                "name": "Test Set",
+                "code": "SET",
+                "type": "expansion",
+                "cards": [
+                    {'name': 'LowPower', 'manaCost': '{1}', 'types': ['Creature'], 'power': '1', 'toughness': '1', 'rarity': 'Common'},
+                    {'name': 'HighPower', 'manaCost': '{1}', 'types': ['Creature'], 'power': '5', 'toughness': '5', 'rarity': 'Common'},
+                ]
+            }
+        }
+    }))
+
+    # Test pow filter via mtg_open_file
+    cards = jdecode.mtg_open_file(str(p), pows=[">2"])
+    assert len(cards) == 1
+    assert cards[0].name == 'highpower' # Card names are lowercased by jdecode
+
+    # Test CMC filter via mtg_open_file
+    cards = jdecode.mtg_open_file(str(p), cmcs=["<2"])
+    assert len(cards) == 2
+
+if __name__ == "__main__":
+    # Run tests if called directly
+    pytest.main([__file__])


### PR DESCRIPTION
This Pull Request introduces **Advanced Numerical Filtering** to the Magic: The Gathering Card Encoder toolset. 

While the tools previously supported basic exact matching for CMC, they lacked a robust way to filter cards by statistical ranges or thresholds (e.g., "all creatures with power 4 or greater"). This feature fills that gap by providing a centralized numerical comparison logic.

### Key Features:
- **New Filtering Flags:** Added `--pow` (Power), `--tou` (Toughness), and `--loy` (Loyalty/Defense) to all primary CLI tools (`encode.py`, `decode.py`, `sortcards.py`, and `summarize.py`).
- **Enhanced Comparison Logic:** All numerical filters (including the existing `--cmc`) now support:
  - **Inequalities:** e.g., `>3`, `<=5`, `!=0`.
  - **Ranges:** e.g., `2-4` (inclusive).
  - **Exact Matches:** e.g., `7` or `==7`.
- **OR/AND Consistency:** Maintains consistency with existing project filtering logic: multiple instances of the same flag use OR logic, while different types of filters use AND logic.
- **Graceful Handling:** Non-numeric card statistics (like `*` for Power/Toughness) are handled gracefully without crashing.

### Implementation Details:
- **`lib/utils.py`**: Added a `NumericFilter` utility class to handle parsing and evaluation of numerical expressions.
- **`lib/jdecode.py`**: Updated the central dataset loading logic to incorporate the new filters into the card matching pipeline.
- **CLI Suite**: Updated argument parsing and help documentation across all relevant scripts to expose these new capabilities to users.
- **Testing**: Added a dedicated test suite `tests/test_numeric_filters.py` and verified it against the existing 379 unit tests.

---
*PR created automatically by Jules for task [4267391270872112970](https://jules.google.com/task/4267391270872112970) started by @RainRat*