### PR TITLE
Refactor Manacost.format to return empty string for no cost

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -937,9 +937,7 @@ class Card:
 
         # Cost
         coststr = self.cost.format(ansi_color=ansi_color)
-        if coststr == '_NOCOST_':
-            coststr = ''
-        else:
+        if coststr:
             coststr = f' {coststr}'
 
         # Type Line
@@ -1022,7 +1020,7 @@ class Card:
         else:
             outstr += cardname
 
-        if vdump or not coststr == '_NOCOST_':
+        if vdump or coststr:
             outstr += ' ' + coststr
 
         if for_html and for_forum:
@@ -1335,8 +1333,6 @@ class Card:
 
             # Cost
             cost = card.cost.format()
-            if cost == '_NOCOST_':
-                cost = ''
 
             # Type
             supertypes = [titlecase(s) for s in card.supertypes]

--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -102,7 +102,7 @@ class Manacost:
 
     def format(self, for_forum = False, for_html = False, ansi_color = False):
         if self.none:
-            return '_NOCOST_'
+            return ''
         
         else:
             s = utils.mana_untranslate(utils.mana_open_delimiter + ''.join(self.sequence)

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -80,7 +80,7 @@ def check_pt(card):
 
 def check_lands(card):
     if 'land' in card.types:
-        return card.cost.format() == '_NOCOST_'
+        return card.cost.format() == ''
     else:
         return None
 

--- a/tests/test_manalib.py
+++ b/tests/test_manalib.py
@@ -109,7 +109,7 @@ class TestManacost:
         assert colored == expected
 
         # None
-        assert Manacost("").format() == "_NOCOST_"
+        assert Manacost("").format() == ""
 
     def test_encode(self):
         m = Manacost("{WWUUBBRRGG}")


### PR DESCRIPTION
* **What:** Refactored `Manacost.format()` in `lib/manalib.py` to return an empty string instead of the sentinel value `_NOCOST_` when a card has no mana cost. Updated redundant check sites in `lib/cardlib.py` and `scripts/mtg_validate.py`, and updated the corresponding test in `tests/test_manalib.py`.
* **Why:** The use of `_NOCOST_` as a sentinel string introduced "logic noise" and redundant conditional checks across the codebase. Removing it simplifies the logic and improves code hygiene. No breaking changes were introduced, and all tests passed.

---
*PR created automatically by Jules for task [10204964370517330407](https://jules.google.com/task/10204964370517330407) started by @RainRat*