### PR TITLE
[lib/cardlib.py] Fix brittle planeswalker type check in to_mse()

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1283,7 +1283,7 @@ class Card:
                 outstr += '\trule text 2:\n\t\t' + newtext2 + '\n'
 
         # Need to do Special Things if it's a planeswalker.
-        elif "planeswalker" in str(self.__dict__[field_types]):
+        elif self.is_planeswalker:
             outstr += '\tstylesheet: m15-planeswalker\n'
 
             # set up the loyalty cost fields using regex to find how many there are.

--- a/tests/test_planeswalker_x_mse.py
+++ b/tests/test_planeswalker_x_mse.py
@@ -31,3 +31,23 @@ def test_planeswalker_lowercase_x_loyalty_to_mse():
 
     assert "loyalty cost 1: +X" in mse_output
     assert "\trule text:\n\t\tDamage.\n\t\tDraw." in mse_output
+
+def test_non_planeswalker_substring_not_planeswalker_to_mse():
+    # Verify that types containing 'planeswalker' as a substring but not as a whole word
+    # do not trigger planeswalker-specific logic in to_mse()
+    card_json = {
+        "name": "Not a Walker",
+        "manaCost": "{2}{G}",
+        "types": ["Not Planeswalker"],
+        "rarity": "Common",
+        "text": "This is just a card."
+    }
+    card = Card(card_json)
+    mse_output = card.to_mse()
+
+    # Should NOT have the planeswalker stylesheet
+    assert "stylesheet: m15-planeswalker" not in mse_output
+    # Should NOT have loyalty cost fields
+    assert "loyalty cost" not in mse_output
+    # Should have the rule text formatted normally
+    assert "\trule text:\n\t\tThis is just a card." in mse_output


### PR DESCRIPTION
* **What:** Replaced a substring-based type check in `Card.to_mse()` that was performed on a string representation of a list (`"planeswalker" in str(self.__dict__[field_types])`) with a robust property check (`self.is_planeswalker`). Added a test case to verify correct behavior for types containing "planeswalker" as a substring (e.g., "Not Planeswalker").
* **Why:** The original check was brittle and could produce false positives if a card had a type like "Not Planeswalker" or false negatives due to case sensitivity. Using the `is_planeswalker` property is cleaner, more idiomatic, and ensures that the specialized planeswalker formatting in Magic Set Editor (MSE) output is only applied to actual Planeswalker cards. No breaking changes were introduced, as verified by the existing and new test cases.

---
*PR created automatically by Jules for task [7152777399843116628](https://jules.google.com/task/7152777399843116628) started by @RainRat*