### PR TITLE
[DOCS] Simplify AI and Training terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project helps you turn Magic: The Gathering card data into a format that AI models can understand. It can also turn AI-generated text back into readable cards or card images.
 
 **Main features:**
-*   **Prepare Data:** Convert official card data for training AI models (like RNNs or Transformers).
+*   **Prepare Data:** Convert official card data for training AI models.
 *   **View Results:** Decode AI output into readable cards, spreadsheets, or [Magic Set Editor](http://magicseteditor.boards.net) files.
 
 ---
@@ -103,7 +103,7 @@ Customization options for formatting data:
 *   `-e rfields`: Randomizes the order of fields (like cost, types, text) for each card.
 *   `-e old`: Legacy encoding format.
 *   `-e norarity`: Standard format but without rarity labels.
-*   `-e vec`: Numerical format for vector-based models.
+*   `-e vec`: Numerical format for mathematical models.
 *   `-e custom`: Use your own user-defined formatting rules (see `lib/cardlib.py`).
 *   `--nolabel`: Removes field labels (e.g., `|cost|`, `|text|`) from the output.
 *   `--nolinetrans`: Disables the automatic reordering and normalization of card text lines.
@@ -257,22 +257,22 @@ python3 encode.py data/AllPrintings.json --deck-filter my_deck.txt encoded_deck.
 
 ---
 
-## Training a Neural Network
-Train on encoded card data using the included character-level RNN.
+## Training your own AI Model
+Use your encoded card data to train a neural network that can design its own Magic cards.
 
-1.  **Prepare Data:** Use `encode.py` to create a text file (e.g., `data/output.txt`).
+1.  **Prepare the Data:** Create a text file of encoded cards.
     ```bash
     python3 encode.py data/AllPrintings.json data/output.txt
     ```
-2.  **Train:** Use the included `train.py` script.
+2.  **Train the Model:** Run the training script.
     ```bash
     python3 train.py --mode train --infile data/output.txt --epochs 10
     ```
-3.  **Generate:** Use the same script in `sample` mode to create new card text.
+3.  **Generate New Cards:** Use your trained model to create new card text.
     ```bash
     python3 train.py --mode sample --checkpoint checkpoint.pt --length 2000 > generated.txt
     ```
-4.  **Decode:** Use `decode.py` to turn that generated text into readable cards.
+4.  **View the Results:** Turn the generated text back into readable cards.
     ```bash
     python3 decode.py generated.txt decoded.txt
     ```

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -550,7 +550,7 @@ def from_mana(s, for_forum=False, for_html=False, ansi_color=False):
     
 # Translation could also be accomplished using the datamine.Manacost object's
 # display methods, but these direct string transformations are retained for
-# quick scripting and convenience (and used under the hood by that class to
+# quick scripting and convenience (and are used internally by that class to
 # do its formatting).
 
 # more convenience features for formatting tap / untap symbols

--- a/train.py
+++ b/train.py
@@ -225,12 +225,12 @@ def sample(args):
             x = torch.tensor([[char_idx]], dtype=torch.long).to(device)
             i += 1
 
-            # Whispering logic: if a field is primed, force feed it
+            # Forcing attribute logic: if a field is set, insert the text
             if char == '|' and field_count in whisper_map and whisper_map[field_count]:
                 whisper_text = whisper_map[field_count]
                 for w_char in whisper_text:
                     w_idx = char_to_idx.get(w_char, 0)
-                    # Feed through model to update hidden state
+                    # Update the model with the forced text to keep it on track
                     x = torch.tensor([[w_idx]], dtype=torch.long).to(device)
                     output, hidden = model(x, hidden)
                     generated += w_char
@@ -239,7 +239,7 @@ def sample(args):
     print(generated)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Advanced character-level RNN for MTG training with mtg-rnn features.")
+    parser = argparse.ArgumentParser(description="Train a neural network to design Magic: The Gathering cards.")
 
     # Group: General Options
     gen_group = parser.add_argument_group('General Options')
@@ -282,9 +282,9 @@ if __name__ == "__main__":
     sample_group.add_argument("--start_text", type=str, default="|",
                         help="The text to start generation with. Default: '|'")
 
-    # Group: Priming (Forcing Attributes)
-    prime_group = parser.add_argument_group('Priming (Forcing Attributes)',
-                                          'These options force specific fields to contain the provided text. '
+    # Group: Forcing Card Attributes
+    prime_group = parser.add_argument_group('Forcing Card Attributes',
+                                          'These options force specific fields to contain your chosen text. '
                                           'Note: These depend on the legacy encoding format (-e old).')
     prime_group.add_argument("--name", type=str, help="Force a specific card name.")
     prime_group.add_argument("--supertypes", type=str, help="Force specific supertypes (e.g., 'Legendary').")


### PR DESCRIPTION
**PR Title:** [DOCS] Simplify AI and Training terminology

**Description:**
* **Type:** Documentation / Internal Help
* **What:** Updated `README.md` (installation/training instructions), `train.py` (CLI help text and internal comments), and `lib/utils.py` (code comments).
* **Why:** This change makes the project more accessible to a global audience by replacing technical jargon like "RNN," "Transformers," and "Priming" with simpler English. It also purges idioms like "under the hood" and uses active voice to clarify instructions.

**Changes:**
1.  **README.md**: Simplified AI model descriptions and renamed the training section to "Training your own AI Model" for clarity. Updated steps to use imperative, active voice.
2.  **train.py**: Renamed the "Priming" group to "Forcing Card Attributes" and simplified the script's main description. Updated internal comments to match.
3.  **lib/utils.py**: Replaced "under the hood" with "internally" in a documentation comment.

All 394 existing tests passed, ensuring no logic regressions from these text-only improvements.

---
*PR created automatically by Jules for task [13778656233849476402](https://jules.google.com/task/13778656233849476402) started by @RainRat*