### PR TITLE
[FEAT] Mechanical Filtering for MTG Cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Filter which cards the tool processes using search patterns, set codes, rarities
     *   `--rarity NAME`: Only include cards of specific rarities (e.g., `common`, `rare`). Supports multiple rarities (OR logic).
     *   `--colors SYMBOLS`: Only include cards with specific colors (e.g., `W`, `U`, `B`, `R`, `G`). Use `C` or `A` for colorless. Multiple colors use OR logic.
     *   `--cmc VALUE`: Only include cards with a specific CMC (Converted Mana Cost). Supports multiple values (OR logic).
+    *   `--mechanic NAME`: Only include cards with specific mechanical features or keyword abilities (e.g., `Flying`, `Activated`, `ETB Effect`). Supports multiple mechanics (OR logic).
     *   `--deck-filter FILE` (or `--decklist-filter`): Filter cards using a standard MTG decklist file. This also multiplies cards in the output based on their counts in the decklist.
 
 > **Tip:** You can use internal shorthand markers with the `--rarity` flag: `O` (Common), `N` (Uncommon), `A` (Rare), `Y` (Mythic), `I` (Special), and `L` (Basic Land).

--- a/decode.py
+++ b/decode.py
@@ -34,6 +34,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          grep_loyalty=None, vgrep_loyalty=None,
          sets=None, rarities=None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
+         mechanics=None,
          shuffle=False, seed=None, decklist_file=None, booster=0):
 
     # Set default format to text if no specific output format is selected.
@@ -113,6 +114,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
+                                  mechanics=mechanics,
                                   shuffle=shuffle, seed=seed, decklist_file=decklist_file)
 
     if booster > 0:
@@ -772,6 +774,8 @@ if __name__ == '__main__':
                         help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
     proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
                         help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
+    proc_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck_filter',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     proc_group.add_argument('--booster', type=int, default=0,
@@ -803,6 +807,7 @@ if __name__ == '__main__':
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
+         mechanics=args.mechanic,
          shuffle=args.shuffle, seed=args.seed, decklist_file=args.deck_filter, booster=args.booster)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -21,6 +21,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          grep_loyalty=None, vgrep_loyalty=None,
          sets=None, rarities=None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
+         mechanics=None,
          seed=None, decklist_file=None):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
@@ -81,6 +82,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
+                                  mechanics=mechanics,
                                   shuffle=not stable, seed=seed if seed is not None else 1371367,
                                   decklist_file=decklist_file)
 
@@ -210,6 +212,8 @@ if __name__ == '__main__':
                         help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
     proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
                         help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
+    proc_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
 
@@ -240,5 +244,6 @@ if __name__ == '__main__':
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
+         mechanics=args.mechanic,
          seed=args.seed, decklist_file=args.deck)
     exit(0)

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -524,6 +524,69 @@ class Card:
         return 'battle' in self.types
 
     @property
+    def mechanics(self):
+        """Returns a set of mechanical features and keyword abilities identified on the card."""
+        text_raw = self.text.text.lower()
+        text_enc = self.text.encode().lower()
+        cost_enc = self.cost.encode()
+
+        m = set()
+
+        # 1. Structural / Complex Mechanics
+        if ':' in text_raw:
+            m.add('Activated')
+
+        # Triggered: check start of lines
+        for mt in self.text_lines:
+            line = mt.text.lower().strip()
+            if line.startswith('when') or line.startswith('whenever') or line.startswith('at '):
+                m.add('Triggered')
+                break
+
+        if 'enters the battlefield' in text_raw or 'enters,' in text_raw or 'enters.' in text_raw:
+            m.add('ETB Effect')
+
+        if utils.choice_open_delimiter in text_enc or utils.choice_close_delimiter in text_enc or '=' in text_enc:
+            m.add('Modal/Choice')
+
+        if 'X' in cost_enc or 'x' in text_raw:
+            m.add('X-Cost/Effect')
+
+        if 'kick' in text_raw:
+            m.add('Kicker')
+
+        if 'uncast' in text_raw:
+            m.add('Uncast')
+
+        if 'equipment' in [t.lower() for t in self.subtypes] or 'equip' in text_raw:
+            m.add('Equipment')
+
+        if 'level up' in text_raw or 'level &' in text_enc:
+            m.add('Leveler')
+
+        if '%' in text_enc or '#' in text_enc or 'counter' in text_raw:
+            m.add('Counters')
+
+        # 2. Common Keyword Abilities
+        keywords = [
+            'flying', 'trample', 'lifelink', 'haste', 'deathtouch',
+            'vigilance', 'ward', 'prowess', 'menace', 'reach',
+            'flash', 'indestructible', 'scry', 'draw a card',
+            'mill', 'exile', 'token', 'discard', 'cycling'
+        ]
+
+        for kw in keywords:
+            # Use word boundaries for keywords to avoid partial matches
+            if re.search(r'\b' + re.escape(kw) + r'\b', text_raw):
+                m.add(kw.title())
+
+        # Recursive profiling for split/double-faced cards
+        if self.bside:
+            m.update(self.bside.mechanics)
+
+        return m
+
+    @property
     def rarity_name(self):
         """Returns the human-readable rarity name (e.g., 'rare' for 'A')."""
         if not self.rarity:

--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -221,8 +221,9 @@ class Datamine:
                 inc(self.by_textlines, len(card.text_lines), [card])
                 inc(self.by_textlen, len(card.text.encode()), [card])
 
-                # Mechanical profiling
-                self._profile_mechanics(card)
+                # Mechanical profiling using Card.mechanics
+                for m in card.mechanics:
+                    inc(self.by_mechanic, m, [card])
 
         self.avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
 
@@ -231,59 +232,6 @@ class Datamine:
         t_vals = [utils.from_unary_single(c.pt_t) for c in self.cards if c.pt_t is not None]
         self.avg_power = sum(p_vals) / len(p_vals) if p_vals else 0
         self.avg_toughness = sum(t_vals) / len(t_vals) if t_vals else 0
-
-    def _profile_mechanics(self, card):
-        """Internal helper to identify and index mechanical features of a card."""
-
-        def check_card_face(c):
-            text_raw = c.text.text.lower()
-            text_enc = c.text.encode().lower()
-            cost_enc = c.cost.encode()
-
-            mechanics = set()
-
-            # 1. Structural mechanics
-            if ':' in text_raw:
-                mechanics.add('Activated')
-
-            # Triggered: check start of lines
-            for mt in c.text_lines:
-                line = mt.text.lower().strip()
-                if line.startswith('when') or line.startswith('whenever') or line.startswith('at '):
-                    mechanics.add('Triggered')
-                    break
-
-            if 'enters the battlefield' in text_raw:
-                mechanics.add('ETB Effect')
-
-            if utils.choice_open_delimiter in text_enc or utils.choice_close_delimiter in text_enc:
-                mechanics.add('Modal/Choice')
-
-            if 'X' in cost_enc or 'x' in text_raw:
-                mechanics.add('X-Cost/Effect')
-
-            # 2. Common Keyword Abilities
-            keywords = [
-                'flying', 'trample', 'lifelink', 'haste', 'deathtouch',
-                'vigilance', 'ward', 'prowess', 'menace', 'reach',
-                'flash', 'indestructible', 'scry', 'draw a card',
-                'mill', 'exile', 'token', 'discard'
-            ]
-
-            for kw in keywords:
-                # Use word boundaries for keywords to avoid partial matches
-                if re.search(r'\b' + re.escape(kw) + r'\b', text_raw):
-                    mechanics.add(kw.title())
-
-            return mechanics
-
-        # Recursive profiling for split/double-faced cards
-        all_mechanics = check_card_face(card)
-        if card.bside:
-            all_mechanics.update(check_card_face(card.bside))
-
-        for m in all_mechanics:
-            inc(self.by_mechanic, m, [card])
 
     # summarize the indices
     def summarize(self, hsize = 10, vsize = 10, cmcsize = 20, use_color = False):

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -660,6 +660,7 @@ def mtg_open_file(fname, verbose = False,
                   sets=None, rarities=None,
                   colors=None, cmcs=None,
                   pows=None, tous=None, loys=None,
+                  mechanics=None,
                   shuffle=False, seed=None,
                   decklist_file=None):
     """
@@ -952,7 +953,7 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
-    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys:
+    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics:
         greps = [re.compile(p, re.IGNORECASE) for p in (grep if grep else [])]
         vgreps = [re.compile(p, re.IGNORECASE) for p in (vgrep if vgrep else [])]
         greps_name = [re.compile(p, re.IGNORECASE) for p in (grep_name if grep_name else [])]
@@ -980,6 +981,7 @@ def mtg_open_file(fname, verbose = False,
                     target_rarities.append(r)
 
         target_colors = [c.upper() for c in colors] if colors else None
+        target_mechanics = [m.lower() for m in mechanics] if mechanics else None
 
         # Initialize NumericFilters
         cmc_filters = [utils.NumericFilter(f) for f in cmcs] if cmcs else []
@@ -1108,6 +1110,17 @@ def mtg_open_file(fname, verbose = False,
                         match_loy = True
                         break
                 if not match_loy:
+                    return False
+
+            # Mechanic filtering
+            if target_mechanics:
+                card_mechanics = [m.lower() for m in card.mechanics]
+                match_mechanic = False
+                for tm in target_mechanics:
+                    if tm in card_mechanics:
+                        match_mechanic = True
+                        break
+                if not match_mechanic:
                     return False
 
             return True

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -30,6 +30,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
          grep_loyalty=None, vgrep_loyalty=None,
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
+         mechanics=None,
          shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None):
 
     # Set default format to JSON if no specific output format is selected and outfile is .json
@@ -50,6 +51,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
+                                  mechanics=mechanics,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
@@ -162,6 +164,8 @@ if __name__ == '__main__':
                         help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
     proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
                         help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
+    proc_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     
@@ -197,5 +201,6 @@ if __name__ == '__main__':
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
+         mechanics=args.mechanic,
          shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -253,6 +253,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          grep_loyalty=None, vgrep_loyalty=None,
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
+         mechanics=None,
          shuffle = False, seed = None, decklist_file = None):
 
     # Determine format
@@ -285,6 +286,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   sets=sets, rarities=rarities,
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
+                                  mechanics=mechanics,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
@@ -457,6 +459,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
     proc_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
                         help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
+    proc_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     proc_group.add_argument('--summary', action='store_true',
@@ -510,6 +514,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
          grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
+         mechanics=args.mechanic,
          shuffle = args.shuffle, seed = args.seed, decklist_file = args.deck)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Identified and implemented the missing mechanical filtering functionality. This feature allows users to filter and analyze card datasets based on functional features and keyword abilities, bridging the gap between stat-based filtering and textual search. The implementation includes a centralized mechanics property in the core library and full CLI integration.

---
*PR created automatically by Jules for task [3200066181699947519](https://jules.google.com/task/3200066181699947519) started by @RainRat*