### PR TITLE
Fix color identity calculation for Energy symbols

### DIFF
--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -5,7 +5,7 @@ import random
 
 import utils
 
-COLOR_STRIP_CHARS = {'2', 'P', 'S', 'X', 'C'}
+COLOR_STRIP_CHARS = {'2', 'P', 'S', 'X', 'C', 'E'}
 
 class Manacost:
     '''mana cost representation with data'''


### PR DESCRIPTION
This PR fixes a logic bug in `lib/manalib.py` where Energy symbols (`{E}`) were not included in the set of symbols to be stripped when determining a card's color identity. 

Previously, the `Manacost` class would include 'E' in its `colors` property if an energy symbol was present. By adding 'E' to `COLOR_STRIP_CHARS`, energy is now correctly treated as a colorless symbol for the purpose of color identity, consistent with other non-color symbols like 'C' (Colorless) and 'S' (Snow).

Testing:
- Verified with a reproduction script that `{E}` costs now result in an empty color string.
- Ran all 404 existing tests to ensure no regressions.
- All tests passed.

---
*PR created automatically by Jules for task [15968642309254472454](https://jules.google.com/task/15968642309254472454) started by @RainRat*