### PR TITLE
[TEST] Fix Ansi.get_rarity_color bug and add tests for rarity markers

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -656,11 +656,11 @@ class Ansi:
         if not rarity:
             return Ansi.BOLD
         r_lower = rarity.lower() if hasattr(rarity, 'lower') else rarity
-        if r_lower in ['uncommon', rarity_uncommon_marker]:
+        if r_lower == 'uncommon' or rarity == rarity_uncommon_marker:
             return Ansi.BOLD + Ansi.CYAN
-        if r_lower in ['rare', rarity_rare_marker]:
+        if r_lower == 'rare' or rarity == rarity_rare_marker:
             return Ansi.BOLD + Ansi.YELLOW
-        if r_lower in ['mythic rare', 'mythic', rarity_mythic_marker]:
+        if r_lower in ['mythic rare', 'mythic'] or rarity == rarity_mythic_marker:
             return Ansi.BOLD + Ansi.RED
         return Ansi.BOLD
 

--- a/tests/test_rarity_color.py
+++ b/tests/test_rarity_color.py
@@ -1,0 +1,26 @@
+import sys
+import os
+import pytest
+
+# Add lib directory to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+from utils import Ansi, rarity_uncommon_marker, rarity_rare_marker, rarity_mythic_marker, rarity_common_marker
+
+def test_get_rarity_color_names():
+    assert Ansi.get_rarity_color('uncommon') == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_rarity_color('rare') == Ansi.BOLD + Ansi.YELLOW
+    assert Ansi.get_rarity_color('mythic') == Ansi.BOLD + Ansi.RED
+    assert Ansi.get_rarity_color('mythic rare') == Ansi.BOLD + Ansi.RED
+    assert Ansi.get_rarity_color('common') == Ansi.BOLD
+
+def test_get_rarity_color_markers():
+    # These are expected to fail currently due to the bug
+    assert Ansi.get_rarity_color(rarity_uncommon_marker) == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_rarity_color(rarity_rare_marker) == Ansi.BOLD + Ansi.YELLOW
+    assert Ansi.get_rarity_color(rarity_mythic_marker) == Ansi.BOLD + Ansi.RED
+    assert Ansi.get_rarity_color(rarity_common_marker) == Ansi.BOLD
+
+def test_get_rarity_color_edge_cases():
+    assert Ansi.get_rarity_color(None) == Ansi.BOLD
+    assert Ansi.get_rarity_color('') == Ansi.BOLD
+    assert Ansi.get_rarity_color('unknown') == Ansi.BOLD


### PR DESCRIPTION
**Type:** Bug Fix / New Coverage

**What:**
- Fixed a logic bug in `Ansi.get_rarity_color` within `lib/utils.py`. The method now correctly handles rarity markers (e.g., 'N', 'A', 'Y') by performing exact matches on the raw input while maintaining case-insensitive matches for human-readable rarity names.
- Created `tests/test_rarity_color.py` to provide comprehensive coverage for the `get_rarity_color` utility, including markers, names, and edge cases.

**Why:**
Rarity markers are internal, case-sensitive identifiers. Lowercasing them before comparison caused lookup failures, resulting in incorrect ANSI coloring (defaulting to BOLD instead of the intended color). This fix ensures visual consistency across CLI tools that utilize these markers for colorized output.

---
*PR created automatically by Jules for task [6743236045998325014](https://jules.google.com/task/6743236045998325014) started by @RainRat*