### PR TITLE
[FEAT] Enhanced sorting options for CLI tools

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -722,7 +722,7 @@ if __name__ == '__main__':
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --shuffle --limit N).')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('-d', '--dump', action='store_true',
                         help='Show detailed debug information for cards that were not processed correctly.')

--- a/encode.py
+++ b/encode.py
@@ -168,7 +168,7 @@ if __name__ == '__main__':
                         help='Seed for the random number generator (Default: 1371367).')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --limit N). Shuffling is enabled unless --stable is used.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
                         help='Sort cards by a specific criterion (enables --stable).')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')

--- a/lib/sortlib.py
+++ b/lib/sortlib.py
@@ -5,7 +5,9 @@ except ImportError:
     def tqdm(iterable, **kwargs):
         return iterable
 
+import re
 import cardlib
+import utils
 
 def sort_colors(card_set, quiet=False):
     """Sorts cards by their color identity."""
@@ -23,7 +25,7 @@ def sort_colors(card_set, quiet=False):
         elif len(card_colors) == 1:
             colors[card_colors[0]].append(card)
         else:
-            if "land" in card.types:
+            if "land" in [t.lower() for t in card.types]:
                 colors['lands'].append(card)
             else:
                 colors['colorless'].append(card)
@@ -33,7 +35,9 @@ def sort_colors(card_set, quiet=False):
 
 def sort_type(card_set):
     """Sorts cards by their primary card type."""
-    sorting = ["creature", "enchantment", "instant", "sorcery", "artifact", "planeswalker"]
+    # Priority order for primary card types.
+    # We maintain the order expected by existing tests for backward compatibility.
+    sorting = ["creature", "enchantment", "instant", "sorcery", "artifact", "planeswalker", "battle", "land"]
 
     def type_priority(card):
         # Convert card types to lowercase for case-insensitive comparison
@@ -43,6 +47,7 @@ def sort_type(card_set):
                 return i
         return len(sorting)
 
+    # Use stable sort (Python's sorted is stable)
     return sorted(card_set, key=type_priority)
 
 def sort_cards(cards, criterion, quiet=False):
@@ -60,5 +65,48 @@ def sort_cards(cards, criterion, quiet=False):
         return [card for segment in segments for card in segment]
     elif criterion == 'type':
         return sort_type(cards)
+    elif criterion == 'rarity':
+        # Priority: Mythic > Rare > Uncommon > Common > Basic Land > Special > Other
+        # Markers: Y (Mythic), A (Rare), N (Uncommon), O (Common), L (Basic Land), I (Special)
+        rarity_priority = {
+            utils.rarity_mythic_marker: 0, 'MYTHIC': 0, 'MYTHIC RARE': 0,
+            utils.rarity_rare_marker: 1, 'RARE': 1,
+            utils.rarity_uncommon_marker: 2, 'UNCOMMON': 2,
+            utils.rarity_common_marker: 3, 'COMMON': 3,
+            utils.rarity_basic_land_marker: 4, 'BASIC LAND': 4,
+            utils.rarity_special_marker: 5, 'SPECIAL': 5,
+        }
+        def get_rarity_val(card):
+            r = card.rarity.upper() if card.rarity else ''
+            return rarity_priority.get(r, 6)
+        return sorted(cards, key=get_rarity_val)
+    elif criterion == 'power':
+        def get_pow(card):
+            val = utils.from_unary_single(card.pt_p)
+            # Use a large number for None to sort them last
+            # We return a tuple to handle the None case gracefully in a single sort pass
+            return (0, -val) if val is not None else (1, 0)
+        return sorted(cards, key=get_pow)
+    elif criterion == 'toughness':
+        def get_tou(card):
+            val = utils.from_unary_single(card.pt_t)
+            return (0, -val) if val is not None else (1, 0)
+        return sorted(cards, key=get_tou)
+    elif criterion == 'loyalty':
+        def get_loy(card):
+            val = utils.from_unary_single(card.loyalty)
+            return (0, -val) if val is not None else (1, 0)
+        return sorted(cards, key=get_loy)
+    elif criterion == 'set':
+        def get_set_key(card):
+            s = card.set_code.upper() if card.set_code else 'ZZZ'
+            n = card.number if card.number else '9999'
+            # Try to extract the numeric part for logical sorting of collector numbers
+            try:
+                n_int = int(re.sub(r'\D', '', n))
+            except (ValueError, TypeError):
+                n_int = 9999
+            return (s, n_int, n)
+        return sorted(cards, key=get_set_key)
     else:
         return cards

--- a/sortcards.py
+++ b/sortcards.py
@@ -409,7 +409,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
     proc_group = parser.add_argument_group('Processing Options')
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Only process the first N cards.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--shuffle', action='store_true',
                         help='Randomize the order of cards before sorting.')

--- a/tests/test_enhanced_sort.py
+++ b/tests/test_enhanced_sort.py
@@ -1,0 +1,45 @@
+import pytest
+from lib import cardlib
+from lib import sortlib
+from lib import utils
+
+def test_sort_rarity():
+    # Card objects store rarity markers ('Y', 'A', 'N', 'O', etc.) internally
+    c1 = cardlib.Card({"name": "Common", "rarity": "Common"}) # 'O'
+    c2 = cardlib.Card({"name": "Rare", "rarity": "Rare"})     # 'A'
+    c3 = cardlib.Card({"name": "Mythic", "rarity": "Mythic"}) # 'Y'
+    cards = [c1, c2, c3]
+    sorted_cards = sortlib.sort_cards(cards, 'rarity')
+    assert sorted_cards[0].name == "mythic"
+    assert sorted_cards[1].name == "rare"
+    assert sorted_cards[2].name == "common"
+
+def test_sort_power():
+    c1 = cardlib.Card({"name": "Small", "power": "1", "toughness": "1", "types": ["Creature"]})
+    c2 = cardlib.Card({"name": "Big", "power": "5", "toughness": "5", "types": ["Creature"]})
+    c3 = cardlib.Card({"name": "None", "types": ["Instant"]})
+    cards = [c1, c2, c3]
+    sorted_cards = sortlib.sort_cards(cards, 'power')
+    assert sorted_cards[0].name == "big"
+    assert sorted_cards[1].name == "small"
+    assert sorted_cards[2].name == "none"
+
+def test_sort_loyalty():
+    c1 = cardlib.Card({"name": "Low", "types": ["Planeswalker"], "loyalty": "3"})
+    c2 = cardlib.Card({"name": "High", "types": ["Planeswalker"], "loyalty": "5"})
+    c3 = cardlib.Card({"name": "None", "types": ["Creature"], "pt": "1/1"})
+    cards = [c1, c2, c3]
+    sorted_cards = sortlib.sort_cards(cards, 'loyalty')
+    assert sorted_cards[0].name == "high"
+    assert sorted_cards[1].name == "low"
+    assert sorted_cards[2].name == "none"
+
+def test_sort_set():
+    c1 = cardlib.Card({"name": "A", "setCode": "ABC", "number": "1"})
+    c2 = cardlib.Card({"name": "B", "setCode": "ABC", "number": "10"})
+    c3 = cardlib.Card({"name": "C", "setCode": "XYZ", "number": "5"})
+    cards = [c3, c2, c1]
+    sorted_cards = sortlib.sort_cards(cards, 'set')
+    assert sorted_cards[0].name == "a"
+    assert sorted_cards[1].name == "b"
+    assert sorted_cards[2].name == "c"


### PR DESCRIPTION
This PR expands the sorting capabilities of the MTG card processing suite. Users can now sort cards by rarity, power, toughness, loyalty, or set/collector number across all major CLI tools (`encode.py`, `decode.py`, and `sortcards.py`).

### Changes:
1.  **lib/sortlib.py**:
    *   Added `sort_cards` support for `rarity` (Mythic > Rare > Uncommon > Common > Basic Land > Special).
    *   Added `sort_cards` support for `power`, `toughness`, and `loyalty` (descending numeric order, non-relevant cards last).
    *   Added `sort_cards` support for `set` (grouped by Set Code, then numeric Collector Number).
    *   Updated `sort_type` priority to include `battle` and `land`.
2.  **CLI Tools**:
    *   Updated `encode.py`, `decode.py`, and `sortcards.py` to include the new criteria in the `--sort` flag's choices and help documentation.
3.  **Testing**:
    *   Created `tests/test_enhanced_sort.py` covering the new sorting logic.
    *   Verified all existing tests pass.

---
*PR created automatically by Jules for task [16460220859389921783](https://jules.google.com/task/16460220859389921783) started by @RainRat*