### PR TITLE
Fix Card Stat Sorting Logic Bug

### DIFF
--- a/lib/sortlib.py
+++ b/lib/sortlib.py
@@ -82,18 +82,23 @@ def sort_cards(cards, criterion, quiet=False):
         return sorted(cards, key=get_rarity_val)
     elif criterion == 'power':
         def get_pow(card):
+            if card.pt_p is None:
+                return (1, 0)
             val = utils.from_unary_single(card.pt_p)
-            # Use a large number for None to sort them last
-            # We return a tuple to handle the None case gracefully in a single sort pass
             return (0, -val) if val is not None else (1, 0)
         return sorted(cards, key=get_pow)
     elif criterion == 'toughness':
         def get_tou(card):
+            if card.pt_t is None:
+                return (1, 0)
             val = utils.from_unary_single(card.pt_t)
             return (0, -val) if val is not None else (1, 0)
         return sorted(cards, key=get_tou)
     elif criterion == 'loyalty':
         def get_loy(card):
+            # Card.loyalty defaults to an empty string when missing
+            if card.loyalty is None or card.loyalty == '':
+                return (1, 0)
             val = utils.from_unary_single(card.loyalty)
             return (0, -val) if val is not None else (1, 0)
         return sorted(cards, key=get_loy)


### PR DESCRIPTION
Improved the robustness of card stat sorting by explicitly handling missing values for power, toughness, and loyalty, ensuring they are consistently sorted after cards with a value of 0.

---
*PR created automatically by Jules for task [10378112442057455827](https://jules.google.com/task/10378112442057455827) started by @RainRat*