### PR TITLE
[TEST] Improve MTG type line parsing coverage and reliability

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -604,13 +604,17 @@ unletters_regex = r"[^abcdefghijklmnopqrstuvwxyz']"
 
 # MTG Constants
 known_supertypes = {'Legendary', 'Basic', 'Snow', 'World', 'Ongoing'}
+_known_supertypes_lower = {s.lower(): s for s in known_supertypes}
 
 def split_types(full_type):
     """Splits a type line string into supertypes and types."""
     supertypes = []
     types = []
+
     for t in full_type.split():
-        if t in known_supertypes:
+        t_lower = t.lower()
+        if t_lower in _known_supertypes_lower:
+            # Preserve original casing but identify as supertype
             supertypes.append(t)
         else:
             types.append(t)
@@ -632,7 +636,8 @@ def parse_type_line(type_line):
     front = parts[0]
     subtypes = []
     if len(parts) > 1:
-        subtypes = parts[1].split()
+        for part in parts[1:]:
+            subtypes.extend(part.split())
 
     supertypes, types = split_types(front)
     return supertypes, types, subtypes

--- a/tests/test_type_line.py
+++ b/tests/test_type_line.py
@@ -1,0 +1,87 @@
+import pytest
+from lib import utils
+
+def test_split_types_basic():
+    supertypes, types = utils.split_types("Legendary Creature")
+    assert supertypes == ["Legendary"]
+    assert types == ["Creature"]
+
+def test_split_types_lowercase():
+    supertypes, types = utils.split_types("legendary creature")
+    assert supertypes == ["legendary"]
+    assert types == ["creature"]
+
+def test_split_types_multiple_supertypes():
+    supertypes, types = utils.split_types("Legendary Snow Creature")
+    assert supertypes == ["Legendary", "Snow"]
+    assert types == ["Creature"]
+
+def test_split_types_no_supertypes():
+    supertypes, types = utils.split_types("Artifact Creature")
+    assert supertypes == []
+    assert types == ["Artifact", "Creature"]
+
+def test_split_types_empty():
+    supertypes, types = utils.split_types("")
+    assert supertypes == []
+    assert types == []
+
+def test_parse_type_line_standard():
+    s, t, sub = utils.parse_type_line("Creature \u2014 Goblin")
+    assert s == []
+    assert t == ["Creature"]
+    assert sub == ["Goblin"]
+
+def test_parse_type_line_multiple_supertypes():
+    s, t, sub = utils.parse_type_line("Legendary Snow Creature \u2014 Spirit")
+    assert s == ["Legendary", "Snow"]
+    assert t == ["Creature"]
+    assert sub == ["Spirit"]
+
+def test_parse_type_line_en_dash():
+    s, t, sub = utils.parse_type_line("Creature \u2013 Elf Warrior")
+    assert s == []
+    assert t == ["Creature"]
+    assert sub == ["Elf", "Warrior"]
+
+def test_parse_type_line_hyphen():
+    s, t, sub = utils.parse_type_line("Artifact - Equipment")
+    assert s == []
+    assert t == ["Artifact"]
+    assert sub == ["Equipment"]
+
+def test_parse_type_line_no_subtypes():
+    s, t, sub = utils.parse_type_line("Instant")
+    assert s == []
+    assert t == ["Instant"]
+    assert sub == []
+
+def test_parse_type_line_legendary_no_subtypes():
+    s, t, sub = utils.parse_type_line("Legendary Artifact")
+    assert s == ["Legendary"]
+    assert t == ["Artifact"]
+    assert sub == []
+
+def test_parse_type_line_empty():
+    s, t, sub = utils.parse_type_line("")
+    assert s == []
+    assert t == []
+    assert sub == []
+
+def test_parse_type_line_none():
+    s, t, sub = utils.parse_type_line(None)
+    assert s == []
+    assert t == []
+    assert sub == []
+
+def test_parse_type_line_multiple_dashes():
+    s, t, sub = utils.parse_type_line("Creature \u2014 Goblin \u2014 Warrior")
+    assert s == []
+    assert t == ["Creature"]
+    assert sub == ["Goblin", "Warrior"]
+
+def test_parse_type_line_malformed_dash():
+    s, t, sub = utils.parse_type_line("Creature\u2014Goblin")
+    assert s == []
+    assert t == ["Creature\u2014Goblin"]
+    assert sub == []


### PR DESCRIPTION
- Added `tests/test_type_line.py` to provide comprehensive coverage for `utils.parse_type_line` and `utils.split_types`.
- Fixed a bug where `utils.split_types` was case-sensitive for supertypes (e.g., "legendary" was not recognized).
- Fixed a bug where `utils.parse_type_line` only handled the first dash-delimited segment, losing subsequent subtypes in lines like "Creature — Spirit — Warrior".
- Optimized supertype lookup in `lib/utils.py` by precomputing a lowercase mapping.
- Ensured `utils.parse_type_line` gracefully handles `None` input.

---
*PR created automatically by Jules for task [975756809531301844](https://jules.google.com/task/975756809531301844) started by @RainRat*