### PR TITLE
Fix logic bug in NumericFilter to support unary exceptions

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -794,11 +794,8 @@ class NumericFilter:
 
         try:
             if isinstance(value, str):
-                # Handle unary or decimal strings
-                if value.startswith(unary_marker):
-                    val = float(from_unary_single(value))
-                else:
-                    val = float(value)
+                # Handle unary (including exceptions) or decimal strings
+                val = float(from_unary_single(value))
             else:
                 val = float(value)
         except (ValueError, TypeError):


### PR DESCRIPTION
**What:** Updated `NumericFilter.evaluate` in `lib/utils.py` to use `from_unary_single()` for all string-to-number conversions.

**Why:** The previous implementation only used `from_unary_single()` if the string started with the unary marker ('&'). This caused it to fail for stats that use unary exceptions (like "twenty~five" for 25), as they don't start with '&'. Using `from_unary_single()` for all strings is cleaner and correctly handles unary, unary exceptions, and decimal strings. No breaking changes were introduced, and all tests passed.

---
*PR created automatically by Jules for task [931228360538077964](https://jules.google.com/task/931228360538077964) started by @RainRat*