### PR TITLE
[TEST] Improve NumericFilter evaluation of unary exceptions

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -794,11 +794,8 @@ class NumericFilter:
 
         try:
             if isinstance(value, str):
-                # Handle unary or decimal strings
-                if value.startswith(unary_marker):
-                    val = float(from_unary_single(value))
-                else:
-                    val = float(value)
+                # Handle unary, decimal strings, and exceptions
+                val = float(from_unary_single(value))
             else:
                 val = float(value)
         except (ValueError, TypeError):

--- a/tests/test_numeric_filters.py
+++ b/tests/test_numeric_filters.py
@@ -84,6 +84,20 @@ def test_numeric_filter_evaluation():
     assert not nf.evaluate("star")
     assert not nf.evaluate("*")
 
+def test_numeric_filter_unary_exceptions():
+    # Test unary exceptions from config.py
+    # 30 -> "thirty"
+    # 25 -> "twenty~five" (using dash_marker ~)
+    nf_30 = utils.NumericFilter("30")
+    assert nf_30.evaluate("thirty")
+
+    nf_25 = utils.NumericFilter("25")
+    assert nf_25.evaluate("twenty~five")
+
+    nf_range = utils.NumericFilter("20-40")
+    assert nf_range.evaluate("thirty")
+    assert nf_range.evaluate("twenty~five")
+
 def test_jdecode_numeric_filtering():
     # Mock cards for testing
     # Card 1: 1/1, CMC 1, Loyalty None


### PR DESCRIPTION
This PR fixes a bug in the `NumericFilter.evaluate` method where card stats represented by textual unary exceptions (like "thirty" for 30) were incorrectly evaluated as `False`. 

The fix involves simplifying the string-to-numeric conversion logic in `evaluate` to always leverage the existing `from_unary_single` utility, which is designed to handle decimal strings, unary strings, and textual exceptions.

A new test case was added to `tests/test_numeric_filters.py` to cover these scenarios and ensure continued reliability.

---
*PR created automatically by Jules for task [4324572040619440045](https://jules.google.com/task/4324572040619440045) started by @RainRat*