### PR TITLE
Fix numeric filtering and stats for missing card attributes

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -342,8 +342,8 @@ class Datamine:
         self.avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
 
         # Calculate average P/T
-        p_vals = [utils.from_unary_single(c.pt_p) for c in self.cards if c.pt_p is not None]
-        t_vals = [utils.from_unary_single(c.pt_t) for c in self.cards if c.pt_t is not None]
+        p_vals = [v for v in map(utils.from_unary_single, (c.pt_p for c in self.cards)) if v is not None]
+        t_vals = [v for v in map(utils.from_unary_single, (c.pt_t for c in self.cards)) if v is not None]
         self.avg_power = sum(p_vals) / len(p_vals) if p_vals else 0
         self.avg_toughness = sum(t_vals) / len(t_vals) if t_vals else 0
 
@@ -408,8 +408,10 @@ class Datamine:
 
         print('  ' + color_line(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
         if len(self.by_power) > 0 and len(self.by_toughness) > 0:
-            print('  ' + ('Largest power: ' + str(max(map(utils.from_unary_single, self.by_power))) +
-                   ', largest toughness: ' + str(max(map(utils.from_unary_single, self.by_toughness)))))
+            p_max_vals = [v for v in map(utils.from_unary_single, self.by_power) if v is not None]
+            t_max_vals = [v for v in map(utils.from_unary_single, self.by_toughness) if v is not None]
+            print('  ' + ('Largest power: ' + str(max(p_max_vals) if p_max_vals else 0) +
+                   ', largest toughness: ' + str(max(t_max_vals) if t_max_vals else 0)))
             avg_pt_str = f'Average power: {self.avg_power:.2f}, Average toughness: {self.avg_toughness:.2f}'
             if use_color:
                 avg_pt_str = utils.colorize(avg_pt_str, utils.Ansi.BOLD + utils.Ansi.GREEN)
@@ -530,7 +532,7 @@ class Datamine:
 
         if len(self.by_power) > 0:
             lpower = sorted(self.by_power,
-                            key=utils.from_unary_single,
+                            key=lambda x: utils.from_unary_single(x) or 0,
                             reverse=True)[0]
             print('  ' + color_line('Largest creature power: ' + utils.from_unary(lpower), use_color))
             print('\n    ' + plimit(self.by_power[lpower][0].encode()).replace('\n', '\n    ') + '\n')
@@ -538,7 +540,7 @@ class Datamine:
             print('  No cards indexed by power?')
         if len(self.by_toughness) > 0:
             ltoughness = sorted(self.by_toughness,
-                                key=utils.from_unary_single,
+                                key=lambda x: utils.from_unary_single(x) or 0,
                                 reverse=True)[0]
             print('  ' + color_line('Largest creature toughness: ' +
                   utils.from_unary(ltoughness), use_color))

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -149,8 +149,8 @@ def from_unary(s):
 
 def from_unary_single(s):
     """Converts a single unary string (possibly with exceptions) back to a numerical value."""
-    if not s:
-        return 0
+    if s is None or s == '':
+        return None
     if s in _unary_exceptions_inv:
         return _unary_exceptions_inv[s]
     try:
@@ -159,7 +159,7 @@ def from_unary_single(s):
             return float(res)
         return int(res)
     except (ValueError, TypeError):
-        return 0
+        return None
 
 # mana syntax
 mana_open_delimiter = '{'
@@ -789,13 +789,15 @@ class NumericFilter:
         Evaluates the filter against a numeric value.
         If value is a string, it attempts to convert it to a float.
         """
-        if value is None:
-            return False
-
         try:
             if isinstance(value, str):
                 # Handle unary, decimal strings, and exceptions
-                val = float(from_unary_single(value))
+                f_val = from_unary_single(value)
+                if f_val is None:
+                    return False
+                val = float(f_val)
+            elif value is None:
+                return False
             else:
                 val = float(value)
         except (ValueError, TypeError):

--- a/tests/test_numeric_filters.py
+++ b/tests/test_numeric_filters.py
@@ -83,6 +83,12 @@ def test_numeric_filter_evaluation():
     assert not nf.evaluate(None)
     assert not nf.evaluate("star")
     assert not nf.evaluate("*")
+    assert not nf.evaluate("")
+
+    # Regression test for empty power/loyalty matching 0
+    nf_zero = utils.NumericFilter("0")
+    assert not nf_zero.evaluate(None)
+    assert not nf_zero.evaluate("")
 
 def test_numeric_filter_unary_exceptions():
     # Test unary exceptions from config.py


### PR DESCRIPTION
The issue was that cards missing specific numeric attributes (like power on an instant or loyalty on a creature) were being treated as having a value of `0` during filtering and statistical analysis. This caused `NumericFilter("0")` to incorrectly match these cards.

I refactored `utils.from_unary_single` to return `None` for empty strings or unparseable inputs. I then updated `NumericFilter.evaluate` to return `False` when it encounters `None` (missing value), and updated `lib/datalib.py` to filter out these `None` values during average power/toughness calculations and to handle them gracefully during outlier analysis.

Key changes:
- `lib/utils.py`: `from_unary_single` now returns `None` for invalid/empty inputs. `NumericFilter.evaluate` explicitly handles `None`.
- `lib/datalib.py`: Average P/T calculations and outlier sorting now account for `None` values returned by `from_unary_single`.
- `tests/test_numeric_filters.py`: Added regression tests for empty string and `None` evaluation.
- Verified that all 435 existing tests pass.

---
*PR created automatically by Jules for task [18107966911765369265](https://jules.google.com/task/18107966911765369265) started by @RainRat*