### PR TITLE
[TEST] Fix logic bug in numeric filters for unparseable stats

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -342,8 +342,8 @@ class Datamine:
         self.avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
 
         # Calculate average P/T
-        p_vals = [utils.from_unary_single(c.pt_p) for c in self.cards if c.pt_p is not None]
-        t_vals = [utils.from_unary_single(c.pt_t) for c in self.cards if c.pt_t is not None]
+        p_vals = [v for v in [utils.from_unary_single(c.pt_p) for c in self.cards] if v is not None]
+        t_vals = [v for v in [utils.from_unary_single(c.pt_t) for c in self.cards] if v is not None]
         self.avg_power = sum(p_vals) / len(p_vals) if p_vals else 0
         self.avg_toughness = sum(t_vals) / len(t_vals) if t_vals else 0
 
@@ -407,9 +407,11 @@ class Datamine:
         print()
 
         print('  ' + color_line(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
-        if len(self.by_power) > 0 and len(self.by_toughness) > 0:
-            print('  ' + ('Largest power: ' + str(max(map(utils.from_unary_single, self.by_power))) +
-                   ', largest toughness: ' + str(max(map(utils.from_unary_single, self.by_toughness)))))
+        p_vals_all = [v for v in map(utils.from_unary_single, self.by_power) if v is not None]
+        t_vals_all = [v for v in map(utils.from_unary_single, self.by_toughness) if v is not None]
+        if p_vals_all and t_vals_all:
+            print('  ' + ('Largest power: ' + str(max(p_vals_all)) +
+                   ', largest toughness: ' + str(max(t_vals_all))))
             avg_pt_str = f'Average power: {self.avg_power:.2f}, Average toughness: {self.avg_toughness:.2f}'
             if use_color:
                 avg_pt_str = utils.colorize(avg_pt_str, utils.Ansi.BOLD + utils.Ansi.GREEN)
@@ -528,16 +530,18 @@ class Datamine:
             print('  No cards indexed by cmc?')
         print()
 
-        if len(self.by_power) > 0:
-            lpower = sorted(self.by_power,
+        p_keys = [k for k in self.by_power if utils.from_unary_single(k) is not None]
+        if p_keys:
+            lpower = sorted(p_keys,
                             key=utils.from_unary_single,
                             reverse=True)[0]
             print('  ' + color_line('Largest creature power: ' + utils.from_unary(lpower), use_color))
             print('\n    ' + plimit(self.by_power[lpower][0].encode()).replace('\n', '\n    ') + '\n')
         else:
             print('  No cards indexed by power?')
-        if len(self.by_toughness) > 0:
-            ltoughness = sorted(self.by_toughness,
+        t_keys = [k for k in self.by_toughness if utils.from_unary_single(k) is not None]
+        if t_keys:
+            ltoughness = sorted(t_keys,
                                 key=utils.from_unary_single,
                                 reverse=True)[0]
             print('  ' + color_line('Largest creature toughness: ' +

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -150,7 +150,7 @@ def from_unary(s):
 def from_unary_single(s):
     """Converts a single unary string (possibly with exceptions) back to a numerical value."""
     if not s:
-        return 0
+        return None
     if s in _unary_exceptions_inv:
         return _unary_exceptions_inv[s]
     try:
@@ -159,7 +159,7 @@ def from_unary_single(s):
             return float(res)
         return int(res)
     except (ValueError, TypeError):
-        return 0
+        return None
 
 # mana syntax
 mana_open_delimiter = '{'
@@ -795,7 +795,10 @@ class NumericFilter:
         try:
             if isinstance(value, str):
                 # Handle unary, decimal strings, and exceptions
-                val = float(from_unary_single(value))
+                extracted = from_unary_single(value)
+                if extracted is None:
+                    return False
+                val = float(extracted)
             else:
                 val = float(value)
         except (ValueError, TypeError):

--- a/tests/test_numeric_filters.py
+++ b/tests/test_numeric_filters.py
@@ -83,6 +83,15 @@ def test_numeric_filter_evaluation():
     assert not nf.evaluate(None)
     assert not nf.evaluate("star")
     assert not nf.evaluate("*")
+    assert not nf.evaluate("")
+
+    # Verify that '0' filter doesn't match unparseable strings (regression test)
+    nf_zero = utils.NumericFilter("0")
+    assert not nf_zero.evaluate("star")
+    assert not nf_zero.evaluate("*")
+    assert not nf_zero.evaluate("")
+    assert nf_zero.evaluate("0")
+    assert nf_zero.evaluate("&")
 
 def test_numeric_filter_unary_exceptions():
     # Test unary exceptions from config.py


### PR DESCRIPTION
This PR fixes a logic bug in `lib/utils.py` where unparseable numeric strings (e.g., '*' for variable power/toughness) were incorrectly converted to `0`. This caused cards with variable stats to incorrectly match numeric filters for `0` (e.g., `--pow 0`) and skewed statistical averages in `Datamine` reports.

**Changes:**
*   **lib/utils.py**: Modified `from_unary_single` to return `None` for unparseable or empty strings. Updated `NumericFilter.evaluate` to handle `None` by returning `False`, ensuring indeterminate stats do not match any numeric filter.
*   **lib/datalib.py**: Updated average P/T calculations and outlier analysis to explicitly filter out `None` values, improving the accuracy of dataset summaries.
*   **tests/test_numeric_filters.py**: Added regression tests verifying that '*', 'star', and empty strings are not matched by numeric filters, including the '0' filter.

Verified that all related tests pass and statistical reporting is now more accurate.

---
*PR created automatically by Jules for task [716750952872685305](https://jules.google.com/task/716750952872685305) started by @RainRat*