### PR TITLE
[DOCS] Improve Field Labels documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,14 +212,21 @@ To help the AI learn how to count, numbers are written as a sequence of symbols 
 | 5 | `&^^^^^` |
 
 ### Field Labels
-If you don't use the `--nolabel` flag, each field is prefixed with a number:
-*   `0`: Rarity
-*   `1`: Name
-*   `3`: Mana Cost
-*   `4`: Supertypes
-*   `5`: Types
-*   `6`: Subtypes
-*   *And so on (7: Loyalty, 8: P/T, 9: Rules Text).*
+If you don't use the `--nolabel` flag, each field is prefixed with a number for easier identification:
+
+| Label | Card Part |
+| :--- | :--- |
+| `0` | Rarity |
+| `1` | Name |
+| `3` | Mana Cost |
+| `4` | Supertypes |
+| `5` | Types |
+| `6` | Subtypes |
+| `7` | Loyalty / Defense |
+| `8` | Power / Toughness |
+| `9` | Rules Text |
+
+> **Note:** The label `2` is skipped to avoid confusion with mana symbols (like `{2/B}`).
 
 ---
 


### PR DESCRIPTION
### [DOCS] Improve Field Labels documentation in README.md

**Type:** Documentation
**What:** Refactored the "Field Labels" section in `README.md`.
**Why:** The previous documentation was incomplete and used a disorganized bulleted list. By converting it to a formatted Markdown table and explicitly listing all labels (0-9), the encoded data format is much easier for users to understand. I also added a note explaining why label `2` is skipped, addressing a likely point of confusion for new users.

---
*PR created automatically by Jules for task [17423898956850144197](https://jules.google.com/task/17423898956850144197) started by @RainRat*