### PR TITLE
[FEAT] Cockatrice XML card database export

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Options for formatting the output:
 *   `--raw`: Shows raw text without special formatting.
 *   `--html`: Creates a webpage with card images.
 *   `--deck`: Creates a standard MTG decklist.
+*   `--xml`: Creates a Cockatrice-compatible XML card database.
 *   `--mse`: Creates a file for Magic Set Editor.
 *   `--json`: Creates a structured JSON file.
 *   `--jsonl`: Creates a JSON Lines file (one card per line).
@@ -155,6 +156,7 @@ The tool detects the format automatically based on the file extension of your ou
 *   `.mdt`  -> Markdown table
 *   `.sum`, `.summary` -> One-line summary
 *   `.deck`, `.dek` -> MTG Decklist
+*   `.xml` -> Cockatrice XML database
 *   `.mse-set` -> Magic Set Editor file
 
 ### Using Pipes

--- a/decode.py
+++ b/decode.py
@@ -26,7 +26,7 @@ from namediff import Namediff
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, nolabel = False,
          gatherer = True, for_forum = False, for_mse = False,
-         creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, md_table_out = False, summary_out = False, deck_out = False, quiet=False,
+         creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, md_table_out = False, summary_out = False, deck_out = False, xml_out = False, quiet=False,
          report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None,
          grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
          grep_text=None, vgrep_text=None,
@@ -39,7 +39,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
-    if not (html or text or for_mse or json_out or jsonl_out or csv_out or md_out or md_table_out or summary_out or deck_out):
+    if not (html or text or for_mse or json_out or jsonl_out or csv_out or md_out or md_table_out or summary_out or deck_out or xml_out):
         if oname:
             if oname.endswith('.html'):
                 html = True
@@ -59,6 +59,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 for_mse = True
             elif oname.endswith('.deck') or oname.endswith('.dek'):
                 deck_out = True
+            elif oname.endswith('.xml'):
+                xml_out = True
             else:
                 text = True
         else:
@@ -66,7 +68,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     # Mutually exclusive output formats are now enforced by argparse in main block,
     # but we keep this check for programmatic access safety.
-    if sum([bool(html), bool(for_mse), bool(json_out), bool(jsonl_out), bool(text), bool(csv_out), bool(md_out), bool(md_table_out), bool(summary_out), bool(deck_out)]) > 1:
+    if sum([bool(html), bool(for_mse), bool(json_out), bool(jsonl_out), bool(text), bool(csv_out), bool(md_out), bool(md_table_out), bool(summary_out), bool(deck_out), bool(xml_out)]) > 1:
         # If user explicitly requested multiple formats programmatically, we warn or error.
         # However, argparse logic below ensures text defaults to True only if others are False.
         # But if someone calls main() directly with multiple True, we should respect that or fail.
@@ -223,9 +225,31 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
             namestr = truename + ': ' + str(dist) + '\n'
         return namestr
 
-    def writecards(writer, for_html=False, for_md=False, for_md_table=False, for_summary=False, for_mse=False):
+    def writecards(writer, for_html=False, for_md=False, for_md_table=False, for_summary=False, for_mse=False, for_xml=False):
         success_count = 0
         fail_count = 0
+
+        if for_xml:
+            writer.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+            writer.write('<cockatrice_carddatabase version="4">\n')
+            writer.write('  <sets>\n')
+            # Collect unique sets from cards
+            found_sets = {}
+            for card in cards:
+                if card.set_code:
+                    code = card.set_code.upper()
+                    if code not in found_sets:
+                        found_sets[code] = getattr(card, 'set_name', code)
+
+            if not found_sets:
+                found_sets['CUS'] = 'Custom Set'
+
+            for code, name in sorted(found_sets.items()):
+                from xml.sax.saxutils import escape
+                writer.write(f'    <set>\n      <name>{escape(code)}</name>\n      <longname>{escape(name)}</longname>\n      <settype>Custom</settype>\n    </set>\n')
+            writer.write('  </sets>\n')
+            writer.write('  <cards>\n')
+
         if for_md_table:
             if booster > 0:
                 writer.write("| Pack | Name | Cost | Type | Stats | Rules Text | Rarity |\n")
@@ -320,7 +344,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                         divider = utils.colorize(divider, utils.Ansi.BOLD + utils.Ansi.CYAN)
                     writer.write(divider + '\n')
 
-                writecard(writer, card, for_md=for_md, for_md_table=for_md_table, for_summary=for_summary, for_mse=for_mse)
+                writecard(writer, card, for_md=for_md, for_md_table=for_md_table, for_summary=for_summary, for_mse=for_mse, for_xml=for_xml)
                 success_count += 1
                 first = False
             except Exception:
@@ -329,11 +353,17 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         if for_mse:
             # more formatting info
             writer.write('version control:\n\ttype: none\napprentice code: ')
+        elif for_xml:
+            writer.write('  </cards>\n')
+            writer.write('</cockatrice_carddatabase>\n')
 
         return success_count, fail_count
 
-    def writecard(writer, card, for_html=False, for_md=False, for_md_table=False, for_summary=False, for_mse=False):
+    def writecard(writer, card, for_html=False, for_md=False, for_md_table=False, for_summary=False, for_mse=False, for_xml=False):
         try:
+            if for_xml:
+                writer.write(card.to_cockatrice_xml() + '\n')
+                return
             if for_md_table:
                 row = card.to_markdown_row()
                 if hasattr(card, 'pack_id'):
@@ -480,6 +510,13 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 print('Writing markdown table output to: ' + oname, file=sys.stderr)
             with open(oname, 'w', encoding='utf8') as ofile:
                 s, f = writecards(ofile, for_md_table=True, for_mse=for_mse)
+                total_success += s
+                total_fail += f
+        if xml_out:
+            if verbose:
+                print('Writing Cockatrice XML output to: ' + oname, file=sys.stderr)
+            with open(oname, 'w', encoding='utf8') as ofile:
+                s, f = writecards(ofile, for_xml=True, for_mse=for_mse)
                 total_success += s
                 total_fail += f
         if html:
@@ -629,8 +666,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                     total_fail += 1
             sys.stdout.flush()
         else:
-            # Correctly propagate for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out
-            s, f = writecards(sys.stdout, for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_mse=for_mse)
+            # Correctly propagate for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_xml=xml_out
+            s, f = writecards(sys.stdout, for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_mse=for_mse, for_xml=xml_out)
             total_success += s
             total_fail += f
         sys.stdout.flush()
@@ -671,6 +708,8 @@ if __name__ == '__main__':
                            help='Generate a compact one-line summary for each card (Auto-detected for .sum or .summary).')
     fmt_group.add_argument('--deck', '--decklist', action='store_true',
                            help='Generate a standard MTG decklist (Auto-detected for .deck or .dek).')
+    fmt_group.add_argument('--xml', action='store_true',
+                           help='Generate a Cockatrice-compatible XML card database (Auto-detected for .xml).')
     fmt_group.add_argument('--mse', action='store_true',
                            help='Generate a Magic Set Editor set file (Auto-detected for .mse-set). Requires an output filename.')
 
@@ -793,7 +832,7 @@ if __name__ == '__main__':
          nolinetrans = args.nolinetrans, nolabel = args.nolabel,
          gatherer = args.gatherer, for_forum = args.forum, for_mse = args.mse,
          creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text,
-         json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, md_table_out = args.md_table, summary_out = args.summary, deck_out = args.deck, quiet=args.quiet,
+         json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, md_table_out = args.md_table, summary_out = args.summary, deck_out = args.deck, xml_out = args.xml, quiet=args.quiet,
          report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep,
          sort=args.sort, vgrep=args.vgrep,
          grep_name=args.grep_name, vgrep_name=args.exclude_name,

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -5,6 +5,7 @@ import sys
 
 import utils
 import transforms
+from xml.sax.saxutils import escape
 from manalib import Manacost, Manatext
 import textwrap
 import nltk.data
@@ -1503,4 +1504,68 @@ class Card:
             outstr = '_ASIDE_ ' + outstr + '\n\n_BSIDE_ ' + self.bside.vectorize()
 
         return outstr
+
+    def to_cockatrice_xml(self):
+        """Returns a Cockatrice XML <card> block representation of the card."""
+
+        def get_fields(card):
+            name = titlecase(card.name)
+            mana_cost = card.cost.format().replace('{', '').replace('}', '')
+
+            supertypes = [titlecase(s) for s in card.supertypes]
+            types = [titlecase(t) for t in card.types]
+            typeline = ' '.join(supertypes + types)
+            if card.subtypes:
+                typeline += f' \u2014 ' + ' '.join([titlecase(s) for s in card.subtypes])
+
+            # Cockatrice <color> is the color letters
+            color = ''.join(card.cost.colors)
+
+            text = card.get_text(force_unpass=True)
+
+            pt = ""
+            if card.pt:
+                pt = utils.from_unary(card.pt)
+            elif card.loyalty:
+                pt = utils.from_unary(card.loyalty)
+
+            return name, mana_cost, typeline, color, text, pt
+
+        name, cost, typeline, color, text, pt = get_fields(self)
+
+        if self.bside:
+            b_name, b_cost, b_typeline, b_color, b_text, b_pt = get_fields(self.bside)
+            name = f"{name} // {b_name}"
+            # Combined typeline and text for splits
+            typeline = f"{typeline} // {b_typeline}"
+            text = f"{text}\n\n---\n\n{b_text}"
+            # Combined colors
+            color = "".join(sorted(list(set(color + b_color))))
+
+        # Determine tablerow
+        # 0: Land, 1: Other, 2: Creature, 3: Spells
+        tablerow = 1
+        types_lower = [t.lower() for t in self.types]
+        if 'land' in types_lower:
+            tablerow = 0
+        elif 'creature' in types_lower:
+            tablerow = 2
+        elif 'instant' in types_lower or 'sorcery' in types_lower:
+            tablerow = 3
+
+        xml_out = f"    <card>\n"
+        xml_out += f"      <name>{escape(name)}</name>\n"
+        if self.set_code:
+            xml_out += f"      <set>{escape(self.set_code.upper())}</set>\n"
+        xml_out += f"      <color>{escape(color)}</color>\n"
+        if cost:
+            xml_out += f"      <manacost>{escape(cost)}</manacost>\n"
+        xml_out += f"      <type>{escape(typeline)}</type>\n"
+        if pt:
+            xml_out += f"      <pt>{escape(pt)}</pt>\n"
+        xml_out += f"      <tablerow>{tablerow}</tablerow>\n"
+        xml_out += f"      <text>{escape(text)}</text>\n"
+        xml_out += f"    </card>"
+
+        return xml_out
             

--- a/tests/test_xml_output.py
+++ b/tests/test_xml_output.py
@@ -1,0 +1,65 @@
+import sys
+import os
+import pytest
+import io
+import re
+
+libdir = os.path.join(os.getcwd(), 'lib')
+sys.path.append(libdir)
+import cardlib
+import utils
+import decode
+
+def test_card_to_cockatrice_xml():
+    card_json = {
+        "name": "Testing Card",
+        "manaCost": "{1}{W}{U}",
+        "types": ["Creature"],
+        "subtypes": ["Angel"],
+        "power": "&^^",
+        "toughness": "&^^^",
+        "text": "Flying\nWhen this enters, draw a card.",
+        "rarity": "rare",
+        "setCode": "TST"
+    }
+    card = cardlib.Card(card_json)
+    xml = card.to_cockatrice_xml()
+
+    assert "<name>Testing Card</name>" in xml
+    assert "<set>TST</set>" in xml
+    assert "<color>UW</color>" in xml
+    assert "<manacost>1WU</manacost>" in xml
+    assert "<type>Creature — Angel</type>" in xml
+    assert "<pt>2/3</pt>" in xml
+    assert "<tablerow>2</tablerow>" in xml
+    assert "Flying" in xml
+    assert "draw a card" in xml
+
+def test_decode_xml_output():
+    # Use a real file if available or a temp one
+    infile = "testdata/uthros.json"
+    outfile = "test_output.xml"
+
+    # Run decode main with xml_out=True
+    decode.main(infile, oname=outfile, xml_out=True, verbose=False)
+
+    assert os.path.exists(outfile)
+    with open(outfile, 'r') as f:
+        content = f.read()
+
+    assert '<?xml version="1.0" encoding="UTF-8"?>' in content
+    assert '<cockatrice_carddatabase version="4">' in content
+    assert '<sets>' in content
+    assert '<set>' in content
+    assert '<name>EOC</name>' in content
+    assert '<cards>' in content
+    assert '<card>' in content
+    assert '<name>Uthros Research Craft</name>' in content
+    assert '</card>' in content
+    assert '</cards>' in content
+    assert '</cockatrice_carddatabase>' in content
+
+    os.remove(outfile)
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This PR adds a new export format to `decode.py`: **Cockatrice XML**.

Cockatrice is a widely used open-source platform for playing Magic: The Gathering. By adding support for its XML card database format, we bridge the gap between card generation/decoding and actual playtesting.

### Features:
- **Automatic Detection:** Saving output to a file ending in `.xml` automatically triggers the format.
- **Smart Metadata:** Includes a heuristic for the `<tablerow>` property based on card types (Land: 0, Creature: 2, Spell: 3, Other: 1), ensuring cards appear in the correct zones on the Cockatrice table.
- **Set Integration:** Dynamically generates the `<sets>` block from processed cards, defaulting to "CUS" (Custom Set) if metadata is missing.
- **Robustness:** Uses safe XML escaping for all card text and properties.
- **Split Card Support:** Correctly handles multi-faced/split cards by merging them into combined blocks as expected by Cockatrice.

### Implementation Details:
- New method `Card.to_cockatrice_xml()` in `lib/cardlib.py`.
- Updated `decode.py` CLI and `writecards` logic.
- New test suite `tests/test_xml_output.py`.
- Updated `README.md`.

All existing tests pass, and the new feature is strictly additive.

---
*PR created automatically by Jules for task [5240010415738367773](https://jules.google.com/task/5240010415738367773) started by @RainRat*