### PR TITLE
[UI/UX] Add search statistics to summarize.py

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -213,8 +213,9 @@ def _print_color_pie(pie_groups, pie_mechanics, all_mechanics, use_color, vsize=
 
 class Datamine:
     # build the global indices
-    def __init__(self, cards_input):
+    def __init__(self, cards_input, search_stats=None):
         # global card pools
+        self.search_stats = search_stats
         self.unparsed_cards = []
         self.invalid_cards = []
         self.cards = []
@@ -349,6 +350,36 @@ class Datamine:
 
     # summarize the indices
     def summarize(self, hsize = 10, vsize = 10, cmcsize = 20, use_color = False):
+
+        if self.search_stats:
+            print(color_line('SEARCH STATISTICS', use_color, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE))
+
+            total = self.search_stats.get('matched', 0) + self.search_stats.get('filtered', 0)
+            matched = self.search_stats.get('matched', 0)
+            filtered = self.search_stats.get('filtered', 0)
+
+            rows = []
+
+            for label, count in [('Matched', matched), ('Filtered Out', filtered)]:
+                percent = (count / total * 100) if total > 0 else 0
+                bar_width = 10
+                filled = int(round(percent / 100 * bar_width))
+                if filled == 0 and percent > 0:
+                    filled = 1
+                bar = '[' + '█' * filled + ' ' * (bar_width - filled) + ']'
+                if use_color:
+                    color = utils.Ansi.BOLD + utils.Ansi.GREEN if label == 'Matched' else utils.Ansi.BOLD + utils.Ansi.RED
+                    bar = utils.colorize(bar, color)
+
+                rows.append([
+                    label,
+                    color_count(count, use_color),
+                    f"{percent:5.1f}%",
+                    bar
+                ])
+
+            printrows(padrows(rows, aligns=['l', 'r', 'r', 'l']), indent=4)
+            print()
 
         print(color_line('DATASET SUMMARY', use_color, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE))
         print('  ' + color_count(len(self.cards), use_color) + ' valid cards, ' +
@@ -582,6 +613,7 @@ class Datamine:
     def to_dict(self):
         """Returns a dictionary representation of the collected statistics."""
         result = {
+            'search_stats': self.search_stats,
             'counts': {
                 'valid': len(self.cards),
                 'invalid': len(self.invalid_cards),

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -662,7 +662,8 @@ def mtg_open_file(fname, verbose = False,
                   pows=None, tous=None, loys=None,
                   mechanics=None,
                   shuffle=False, seed=None,
-                  decklist_file=None):
+                  decklist_file=None,
+                  stats=None):
     """
     High-level entry point for loading card data from various formats.
     Supported formats: JSON, JSONL, CSV, Magic Set Editor (.mse-set),
@@ -1124,7 +1125,19 @@ def mtg_open_file(fname, verbose = False,
                     return False
 
             return True
-        cards = [c for c in cards if match_card(c)]
+
+        matched_cards = []
+        filtered_count = 0
+        for c in cards:
+            if match_card(c):
+                matched_cards.append(c)
+            else:
+                filtered_count += 1
+
+        cards = matched_cards
+        if stats is not None:
+            stats['matched'] = len(cards)
+            stats['filtered'] = filtered_count
 
     if shuffle:
         if seed is not None:

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -39,6 +39,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
 
     # Use the robust mtg_open_file for all loading and filtering.
     # We disable default exclusions to match original summarize.py behavior.
+    search_stats = {}
     cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=not nolinetrans,
                                   fmt_labeled=None if nolabel else cardlib.fmt_labeled_default,
                                   grep=grep, vgrep=vgrep,
@@ -56,12 +57,13 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
                                   shuffle=shuffle, seed=seed,
-                                  decklist_file=decklist_file)
+                                  decklist_file=decklist_file,
+                                  stats=search_stats)
 
     if limit > 0:
         cards = cards[:limit]
 
-    mine = Datamine(cards)
+    mine = Datamine(cards, search_stats=search_stats)
 
     # Determine if we should use color
     actual_use_color = False


### PR DESCRIPTION
**Context:** CLI
**Problem:** When applying filters (like `--grep`, `--rarity`, or `--cmc`) to a large dataset using `summarize.py`, users had no visibility into how many cards were actually being excluded by their search criteria. This lacked feedback and clarity, especially when a query returned very few or zero results.
**Solution:** Added a "SEARCH STATISTICS" section at the top of the summary output that appears only when filters are active. It provides a high-level breakdown of "Matched" vs "Filtered Out" cards, complete with counts, percentages, and colorized visual bars. This gives power users immediate confirmation of their query's impact and precision without adding unnecessary decoration.
**Changes:**
- `lib/jdecode.py`: Modified `mtg_open_file` to accept a `stats` dictionary that tracks filtering results.
- `lib/datalib.py`: Updated `Datamine` class to store search statistics and added the reporting logic to `summarize()` and `to_dict()`.
- `scripts/summarize.py`: Updated to capture search statistics from the loading process and pass them to the datamine object for reporting.

---
*PR created automatically by Jules for task [591021277616199508](https://jules.google.com/task/591021277616199508) started by @RainRat*