### PR TITLE
[FEAT] Terminal Table Output Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Customization options for formatting data:
 Options for formatting the output:
 *   `-g`, `--gatherer`: Formats text like the official Gatherer website (Default). This applies modern wording and capitalization.
 *   `--raw`: Shows raw text without special formatting.
+*   `--table`: Creates a formatted table for terminal view.
 *   `--html`: Creates a webpage with card images.
 *   `--deck`: Creates a standard MTG decklist.
 *   `--xml`: Creates a Cockatrice-compatible XML card database.
@@ -156,6 +157,7 @@ The tool detects the format automatically based on the file extension of your ou
 *   `.mdt`  -> Markdown table
 *   `.sum`, `.summary` -> One-line summary
 *   `.deck`, `.dek` -> MTG Decklist
+*   `.tbl`, `.table` -> Formatted table
 *   `.xml` -> Cockatrice XML database
 *   `.mse-set` -> Magic Set Editor file
 

--- a/decode.py
+++ b/decode.py
@@ -26,7 +26,7 @@ from namediff import Namediff
 def main(fname, oname = None, verbose = True, encoding = 'std',
          nolinetrans = False, nolabel = False,
          gatherer = True, for_forum = False, for_mse = False,
-         creativity = False, vdump = False, html = False, text = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, md_table_out = False, summary_out = False, deck_out = False, xml_out = False, quiet=False,
+         creativity = False, vdump = False, html = False, text = False, table_out = False, json_out = False, jsonl_out = False, csv_out = False, md_out = False, md_table_out = False, summary_out = False, deck_out = False, xml_out = False, quiet=False,
          report_file=None, color_arg=None, limit=0, grep=None, sort=None, vgrep=None,
          grep_name=None, vgrep_name=None, grep_types=None, vgrep_types=None,
          grep_text=None, vgrep_text=None,
@@ -39,7 +39,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     # Set default format to text if no specific output format is selected.
     # If an output filename is provided, we try to detect the format from its extension.
-    if not (html or text or for_mse or json_out or jsonl_out or csv_out or md_out or md_table_out or summary_out or deck_out or xml_out):
+    if not (html or text or table_out or for_mse or json_out or jsonl_out or csv_out or md_out or md_table_out or summary_out or deck_out or xml_out):
         if oname:
             if oname.endswith('.html'):
                 html = True
@@ -55,6 +55,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 md_table_out = True
             elif oname.endswith('.sum') or oname.endswith('.summary'):
                 summary_out = True
+            elif oname.endswith('.tbl') or oname.endswith('.table'):
+                table_out = True
             elif oname.endswith('.mse-set'):
                 for_mse = True
             elif oname.endswith('.deck') or oname.endswith('.dek'):
@@ -68,12 +70,12 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
     # Mutually exclusive output formats are now enforced by argparse in main block,
     # but we keep this check for programmatic access safety.
-    if sum([bool(html), bool(for_mse), bool(json_out), bool(jsonl_out), bool(text), bool(csv_out), bool(md_out), bool(md_table_out), bool(summary_out), bool(deck_out), bool(xml_out)]) > 1:
+    if sum([bool(html), bool(table_out), bool(for_mse), bool(json_out), bool(jsonl_out), bool(text), bool(csv_out), bool(md_out), bool(md_table_out), bool(summary_out), bool(deck_out), bool(xml_out)]) > 1:
         # If user explicitly requested multiple formats programmatically, we warn or error.
         # However, argparse logic below ensures text defaults to True only if others are False.
         # But if someone calls main() directly with multiple True, we should respect that or fail.
         # The original code errored on >1 format.
-        print('ERROR - decode.py - incompatible output formats (choose one of --html, --mse, --json, --text)', file=sys.stderr)
+        print('ERROR - decode.py - incompatible output formats (choose one of --html, --mse, --json, --text, --table)', file=sys.stderr)
         sys.exit(1)
 
     if for_mse:
@@ -225,7 +227,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
             namestr = truename + ': ' + str(dist) + '\n'
         return namestr
 
-    def writecards(writer, for_html=False, for_md=False, for_md_table=False, for_summary=False, for_mse=False, for_xml=False):
+    def writecards(writer, for_html=False, for_md=False, for_table=False, for_md_table=False, for_summary=False, for_mse=False, for_xml=False):
         success_count = 0
         fail_count = 0
 
@@ -333,6 +335,31 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 writer.write("</div><hr style='clear:both;'>")
             # closing the html file
             writer.write(utils.html_append)
+            return success_count, fail_count
+
+        if for_table:
+            import datalib
+            use_color = False
+            if color_arg is True:
+                use_color = True
+            elif color_arg is None and writer == sys.stdout and sys.stdout.isatty():
+                use_color = True
+
+            rows = []
+            header = ["Name", "Cost", "Type", "Stats", "Rarity"]
+            if use_color:
+                header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+            rows.append(header)
+
+            for card in tqdm(cards, disable=quiet or len(cards) < 5, desc="Decoding"):
+                try:
+                    rows.append(card.to_table_row(ansi_color=use_color))
+                    success_count += 1
+                except Exception:
+                    fail_count += 1
+
+            for row in datalib.padrows(rows, aligns=['l', 'l', 'l', 'l', 'l']):
+                writer.write(row + '\n')
             return success_count, fail_count
 
         first = True
@@ -561,6 +588,13 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 s, f = writecards(ofile, for_html=True, for_mse=for_mse)
                 total_success += s
                 total_fail += f
+        if table_out:
+            if verbose:
+                print('Writing table output to: ' + oname, file=sys.stderr)
+            with open(oname, 'w', encoding='utf8') as ofile:
+                s, f = writecards(ofile, for_table=True)
+                total_success += s
+                total_fail += f
         if json_out:
             import json
             if verbose:
@@ -698,8 +732,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                     total_fail += 1
             sys.stdout.flush()
         else:
-            # Correctly propagate for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_xml=xml_out
-            s, f = writecards(sys.stdout, for_html=html, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_mse=for_mse, for_xml=xml_out)
+            # Correctly propagate for_html=html, for_table=table_out, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_xml=xml_out
+            s, f = writecards(sys.stdout, for_html=html, for_table=table_out, for_md=md_out, for_md_table=md_table_out, for_summary=summary_out, for_mse=for_mse, for_xml=xml_out)
             total_success += s
             total_fail += f
         sys.stdout.flush()
@@ -724,6 +758,8 @@ if __name__ == '__main__':
     fmt_group = fmt_group_title.add_mutually_exclusive_group()
     fmt_group.add_argument('--text', action='store_true',
                            help='Force plain text output (Default unless detected from extension).')
+    fmt_group.add_argument('--table', action='store_true',
+                           help='Generate a formatted table for terminal view (Auto-detected for .tbl or .table).')
     fmt_group.add_argument('--html', action='store_true',
                            help='Generate a nicely formatted HTML file (Auto-detected for .html).')
     fmt_group.add_argument('--json', action='store_true',
@@ -863,7 +899,7 @@ if __name__ == '__main__':
     main(args.infile, args.outfile, verbose = args.verbose, encoding = args.encoding,
          nolinetrans = args.nolinetrans, nolabel = args.nolabel,
          gatherer = args.gatherer, for_forum = args.forum, for_mse = args.mse,
-         creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text,
+         creativity = args.creativity, vdump = args.dump, html = args.html, text = args.text, table_out = args.table,
          json_out = args.json, jsonl_out = args.jsonl, csv_out = args.csv, md_out = args.md, md_table_out = args.md_table, summary_out = args.summary, deck_out = args.deck, xml_out = args.xml, quiet=args.quiet,
          report_file = args.report_failed, color_arg=args.color, limit=args.limit, grep=args.grep,
          sort=args.sort, vgrep=args.vgrep,

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1466,6 +1466,55 @@ class Card:
 
         return f"| {' | '.join(fields)} |"
 
+    def to_table_row(self, ansi_color=False):
+        """Returns a list of strings representing the card's fields for a terminal table."""
+
+        def get_fields(card):
+            # Name
+            name = titlecase(card.name)
+            if ansi_color:
+                name = utils.colorize(name, card._get_ansi_color())
+
+            # Cost
+            cost = card.cost.format(ansi_color=ansi_color)
+
+            # Type
+            supertypes = [titlecase(s) for s in card.supertypes]
+            types = [titlecase(t) for t in card.types]
+            typeline = ' '.join(supertypes + types)
+            if card.subtypes:
+                typeline += f' \u2014 ' + ' '.join([titlecase(s) for s in card.subtypes])
+            if ansi_color:
+                typeline = utils.colorize(typeline, utils.Ansi.GREEN)
+
+            # Stats (P/T or Loyalty/Defense)
+            stats = card._get_pt_display(ansi_color=ansi_color, include_parens=False)
+            if not stats:
+                stats = card._get_loyalty_display(ansi_color=ansi_color, include_parens=False)
+
+            # Rarity
+            rarity = card.rarity_name
+            if ansi_color and rarity:
+                rarity = utils.colorize(rarity, utils.Ansi.get_rarity_color(rarity))
+
+            return name, cost, typeline, stats, rarity
+
+        name, cost, typeline, stats, rarity = get_fields(self)
+
+        if self.bside:
+            b_name, b_cost, b_typeline, b_stats, b_rarity = get_fields(self.bside)
+            name = f"{name} // {b_name}"
+            cost = f"{cost} // {b_cost}"
+            typeline = f"{typeline} // {b_typeline}"
+            if stats and b_stats:
+                stats = f"{stats} // {b_stats}"
+            else:
+                stats = stats or b_stats
+            if b_rarity and b_rarity != rarity:
+                rarity = f"{rarity} // {b_rarity}"
+
+        return [name, cost, typeline, stats, rarity]
+
     def vectorize(self):
         """Vectorizes the card data into a string format suitable for machine learning.
 

--- a/tests/test_table_output.py
+++ b/tests/test_table_output.py
@@ -1,0 +1,60 @@
+
+import sys
+import os
+import subprocess
+
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+from cardlib import Card
+
+def test_to_table_row():
+    card_json = {
+        "name": "Grizzly Bears",
+        "manaCost": "{1}{G}",
+        "types": ["Creature"],
+        "subtypes": ["Bear"],
+        "power": "2",
+        "toughness": "2",
+        "rarity": "Common"
+    }
+    card = Card(card_json)
+    row = card.to_table_row(ansi_color=False)
+    print(f"Row: {row}")
+    # Rarity is lowercase from MTGJSON if not in map, but Card(card_json) uses fields_from_json
+    # which uses utils.json_rarity_map if available.
+    assert row == ["Grizzly Bears", "{1}{G}", "Creature \u2014 Bear", "2/2", "common"]
+
+def test_to_table_row_bside():
+    card_json = {
+        "name": "Fire",
+        "manaCost": "{1}{R}",
+        "types": ["Instant"],
+        "rarity": "Uncommon",
+        "bside": {
+            "name": "Ice",
+            "manaCost": "{1}{U}",
+            "types": ["Instant"],
+            "rarity": "Uncommon"
+        }
+    }
+    card = Card(card_json)
+    row = card.to_table_row(ansi_color=False)
+    print(f"Bside Row: {row}")
+    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "Instant // Instant", "", "uncommon"]
+
+def test_cli_table():
+    # Encode a sample card and decode it with --table
+    # Use - to avoid file not found
+    cmd = "echo '1Grizzly Bears|3{1}{G}|5creature|6bear|8&^^/&^^|0O' | python3 decode.py - --table"
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    assert "Name" in result.stdout
+    assert "Grizzly Bears" in result.stdout
+    assert "2/2" in result.stdout
+    # 'common' is used internally
+    assert "common" in result.stdout
+
+if __name__ == "__main__":
+    test_to_table_row()
+    test_to_table_row_bside()
+    test_cli_table()
+    print("All table tests passed!")


### PR DESCRIPTION
**What:** Added a new `--table` output format to `decode.py` that generates a nicely aligned, human-readable table in the terminal.
**Why:** I noticed that while the project has compact summaries and full text output, it lacked a structured, scannable table view for quick terminal inspection. This feature leverages the existing `padrows` utility and provides immediate value for users wanting to scan multiple cards at once.

---
*PR created automatically by Jules for task [13751617452965723357](https://jules.google.com/task/13751617452965723357) started by @RainRat*