### PR TITLE
Eliminate redundant type line formatting in Card.to_table_row()

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1473,11 +1473,7 @@ class Card:
             cost = card.cost.format(ansi_color=ansi_color)
 
             # Type
-            supertypes = [titlecase(s) for s in card.supertypes]
-            types = [titlecase(t) for t in card.types]
-            typeline = ' '.join(supertypes + types)
-            if card.subtypes:
-                typeline += f' \u2014 ' + ' '.join([titlecase(s) for s in card.subtypes])
+            typeline = card.get_type_line()
             if ansi_color:
                 typeline = utils.colorize(typeline, utils.Ansi.GREEN)
 


### PR DESCRIPTION
Eliminated redundant type line formatting in `Card.to_table_row()` by using the centralized `get_type_line()` method. This refactor improves code maintainability by removing duplicated logic while preserving identical external behavior for terminal table outputs. Verified with existing tests in `tests/test_cardlib_gaps.py` and `tests/test_type_line.py`.

---
*PR created automatically by Jules for task [17507132729899893573](https://jules.google.com/task/17507132729899893573) started by @RainRat*