### PR TITLE
[TEST] Add coverage for previously untested utility functions

### DIFF
--- a/tests/test_utils_gaps.py
+++ b/tests/test_utils_gaps.py
@@ -1,0 +1,61 @@
+from lib import utils
+from lib import config
+
+def test_from_unary_single_standard_conversion():
+    assert utils.from_unary_single("&^") == 1
+    assert utils.from_unary_single("&^^^^^") == 5
+
+def test_from_unary_single_numeric_strings():
+    assert utils.from_unary_single("10") == 10
+    assert utils.from_unary_single("2.5") == 2.5
+
+def test_from_unary_single_config_exceptions():
+    for k, v in config.unary_exceptions.items():
+        assert utils.from_unary_single(v) == k
+
+def test_from_unary_single_handles_none_and_empty():
+    assert utils.from_unary_single(None) is None
+    assert utils.from_unary_single("") is None
+
+def test_from_unary_single_handles_unparseable():
+    assert utils.from_unary_single("star") is None
+    assert utils.from_unary_single("*") is None
+
+def test_get_color_color_single_colors():
+    Ansi = utils.Ansi
+    assert Ansi.get_color_color('W') == Ansi.BOLD + Ansi.WHITE
+    assert Ansi.get_color_color('U') == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_color_color('B') == Ansi.BOLD + Ansi.MAGENTA
+    assert Ansi.get_color_color('R') == Ansi.BOLD + Ansi.RED
+    assert Ansi.get_color_color('G') == Ansi.BOLD + Ansi.GREEN
+
+def test_get_color_color_colorless_indicators():
+    Ansi = utils.Ansi
+    assert Ansi.get_color_color('A') == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_color_color('Colorless') == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_color_color('Land') == Ansi.BOLD + Ansi.CYAN
+
+def test_get_color_color_multi_and_hybrid():
+    Ansi = utils.Ansi
+    assert Ansi.get_color_color('WU') == Ansi.BOLD + Ansi.YELLOW
+    assert Ansi.get_color_color('WUBRG') == Ansi.BOLD + Ansi.YELLOW
+
+def test_get_color_color_edge_cases():
+    Ansi = utils.Ansi
+    assert Ansi.get_color_color(None) == Ansi.BOLD
+    assert Ansi.get_color_color('') == Ansi.BOLD
+    assert Ansi.get_color_color('X') == Ansi.BOLD
+
+def test_get_scryfall_url_generation():
+    assert utils.get_scryfall_url('LEA', '1') == 'https://scryfall.com/card/lea/1'
+    assert utils.get_scryfall_url('lea', '1') == 'https://scryfall.com/card/lea/1'
+
+def test_get_scryfall_image_url_versions():
+    assert utils.get_scryfall_image_url('LEA', '1') == 'https://api.scryfall.com/cards/lea/1?format=image&version=normal'
+    assert utils.get_scryfall_image_url('lea', '1', version='small') == 'https://api.scryfall.com/cards/lea/1?format=image&version=small'
+
+def test_get_scryfall_urls_missing_metadata():
+    assert utils.get_scryfall_url(None, '1') is None
+    assert utils.get_scryfall_url('lea', None) is None
+    assert utils.get_scryfall_image_url(None, '1') is None
+    assert utils.get_scryfall_image_url('lea', None) is None


### PR DESCRIPTION
**PR Title:** [TEST] Add coverage for previously untested utility functions 

**Description:** 
* **Type:** New Coverage 
* **What:** Added comprehensive unit tests for `from_unary_single`, `Ansi.get_color_color`, `get_scryfall_url`, and `get_scryfall_image_url` in a new test file `tests/test_utils_gaps.py`. 
* **Why:** These utility functions were identified as having no direct test coverage. Adding these tests ensures their reliability and helps prevent regressions, especially for edge cases like None handling, empty strings, and complex ANSI color mapping. The implementation follows the Lead QA guidelines for atomic, focused interventions and strictly adheres to code hygiene rules regarding descriptive naming and comment avoidance.

---
*PR created automatically by Jules for task [7915711684983621045](https://jules.google.com/task/7915711684983621045) started by @RainRat*