### PR TITLE
[DOCS] Clarify custom card CSV format for modern card types

### DIFF
--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -23,8 +23,16 @@ We provide two scripts in the `scripts/` directory to help you:
 
 ### Step 1: Create a Spreadsheet
 Create a CSV file with your custom cards. You can start with this [Google Sheet template](https://docs.google.com/spreadsheets/d/1bYqDoRc6tD6uEchANzDUFZp0xaL4GTgFa4iadXcXRRQ/edit#gid=0).
+
 1.  Open the link.
-2.  Add your cards following the format (Name, Mana Cost, Type, Subtypes, Text, P/T, Rarity).
+2.  Add your cards following the format:
+    *   **Name**: Card title.
+    *   **Mana Cost**: Use brackets for symbols (e.g., `{1}{W}{B}`).
+    *   **Type**: Supertypes and Types (e.g., `Legendary Creature`).
+    *   **Subtypes**: (e.g., `Elf Warrior`).
+    *   **Text**: Rules text. Use `\n` for new lines.
+    *   **P/T, Loyalty, or Defense**: Use `3/3` for creatures, or a single number for Planeswalker loyalty or Battle defense.
+    *   **Rarity**: Use shorthands: `C` (Common), `U` (Uncommon), `R` (Rare), `M` (Mythic).
 3.  Click **File -> Download -> Comma Separated Values (.csv)**.
 4.  Save it as `custom.csv`.
 

--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -25,7 +25,7 @@ CSV Format:
   3. Types & Supertypes (e.g., "Legendary Creature")
   4. Subtypes (e.g., "Elf Warrior")
   5. Rules Text (e.g., "Target creature gets +3/+3 until end of turn.")
-  6. P/T (e.g., "3/3")
+  6. P/T, Loyalty, or Defense (e.g., "3/3" for creatures, "5" for Planeswalkers)
   7. Rarity (e.g., "C", "U", "R", "M")
 
   The first row (header) is ignored if the first column is exactly "name".


### PR DESCRIPTION
Improved the documentation for custom card integration by clarifying the expected CSV format in `CUSTOM.md` and the `csv2json.py` script. Specifically, I highlighted that the 6th column (P/T) also accepts Loyalty for Planeswalkers and Defense for Battles, which was previously undocumented. I also added clearer descriptions for all CSV columns to assist new users.

---
*PR created automatically by Jules for task [3909584303612913022](https://jules.google.com/task/3909584303612913022) started by @RainRat*