### PR TITLE
[UI/UX] Add "Pack" column to terminal table output for boosters

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -347,18 +347,29 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
             rows = []
             header = ["Name", "Cost", "Type", "Stats", "Rarity"]
+            if booster > 0:
+                header.insert(0, "Pack")
             if use_color:
                 header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
             rows.append(header)
 
             for card in tqdm(cards, disable=quiet or len(cards) < 5, desc="Decoding"):
                 try:
-                    rows.append(card.to_table_row(ansi_color=use_color))
+                    row = card.to_table_row(ansi_color=use_color)
+                    if booster > 0:
+                        pack_id = str(getattr(card, 'pack_id', '?'))
+                        if use_color:
+                            pack_id = utils.colorize(pack_id, utils.Ansi.BOLD + utils.Ansi.MAGENTA)
+                        row.insert(0, pack_id)
+                    rows.append(row)
                     success_count += 1
                 except Exception:
                     fail_count += 1
 
-            for row in datalib.padrows(rows, aligns=['l', 'l', 'l', 'l', 'l']):
+            aligns = ['l'] * len(header)
+            if booster > 0:
+                aligns[0] = 'r'
+            for row in datalib.padrows(rows, aligns=aligns):
                 writer.write(row + '\n')
             return success_count, fail_count
 


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** When generating booster packs using the `--booster` flag and viewing the results as a terminal table (`--table`), it is difficult to see which cards belong to which pack because there is no pack identifier in the table.
* **Solution:** Added a "Pack" column to the terminal table output when `--booster` is used. This column is right-aligned for better readability and colorized in magenta (matching other pack-based outputs) to improve visual hierarchy and clarity.

---
*PR created automatically by Jules for task [8048063029134717079](https://jules.google.com/task/8048063029134717079) started by @RainRat*