### PR TITLE
[FEAT] Add json2csv.py for Round-Trip Custom Card Design

### DIFF
--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -17,11 +17,18 @@ To get the best results, follow these tips:
 
 ## How to Add Custom Cards
 
-We provide two scripts in the `scripts/` directory to help you:
-*   `scripts/csv2json.py`: Converts a spreadsheet of cards into JSON format.
+We provide several scripts in the `scripts/` directory to help you:
+*   `scripts/json2csv.py`: Exports existing cards to a CSV format for easy editing.
+*   `scripts/csv2json.py`: Converts your edited spreadsheet back into JSON format.
 *   `scripts/combinejson.py`: Merges your custom JSON with the official card data.
 
-### Step 1: Create a Spreadsheet
+### Step 0: (Optional) Export Existing Cards
+If you want to use existing cards as a starting point, use `json2csv.py`.
+```bash
+python3 scripts/json2csv.py data/AllPrintings.json my_base.csv --set MOM
+```
+
+### Step 1: Create or Edit a Spreadsheet
 Create a CSV file with your custom cards. You can start with this [Google Sheet template](https://docs.google.com/spreadsheets/d/1bYqDoRc6tD6uEchANzDUFZp0xaL4GTgFa4iadXcXRRQ/edit#gid=0).
 1.  Open the link.
 2.  Add your cards following the format (Name, Mana Cost, Type, Subtypes, Text, P/T, Rarity).

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -765,20 +765,21 @@ def mtg_open_file(fname, verbose = False,
                                 aggregated_srcs[key] = val
                         txt_cards.extend(t_cards)
         else:
-            files = sorted([f for f in os.listdir(fname) if f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set') or f.endswith('.txt')])
-            for f in files:
-                if verbose:
-                    print(f"Loading {f}...", file=sys.stderr)
-                full_path = os.path.join(fname, f)
-                # For directories, we don't read content here but let the helper do it
-                srcs, bad, t_cards = process_file_content(full_path, None, False)
-                aggregated_bad_sets.update(bad)
-                for key, val in srcs.items():
-                    if key in aggregated_srcs:
-                        aggregated_srcs[key].extend(val)
-                    else:
-                        aggregated_srcs[key] = val
-                txt_cards.extend(t_cards)
+            for root, dirs, filenames in os.walk(fname):
+                for f in sorted(filenames):
+                    if f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set') or f.endswith('.txt'):
+                        full_path = os.path.join(root, f)
+                        if verbose:
+                            print(f"Loading {full_path}...", file=sys.stderr)
+                        # For directories, we don't read content here but let the helper do it
+                        srcs, bad, t_cards = process_file_content(full_path, None, False)
+                        aggregated_bad_sets.update(bad)
+                        for key, val in srcs.items():
+                            if key in aggregated_srcs:
+                                aggregated_srcs[key].extend(val)
+                            else:
+                                aggregated_srcs[key] = val
+                        txt_cards.extend(t_cards)
 
         if verbose:
              if aggregated_srcs:

--- a/scripts/json2csv.py
+++ b/scripts/json2csv.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import sys
+import os
+import argparse
+import csv
+
+# Ensure lib is in path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+import jdecode
+import cardlib
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Converts MTG card data into the CSV format used by csv2json.py and the custom card template."
+    )
+    parser.add_argument('infile', help='Input card data (JSON, JSONL, MSE, ZIP, or encoded text)')
+    parser.add_argument('outfile', help='Output CSV file path')
+    parser.add_argument('--set', action='append', help='Filter by set code (e.g., MOM)')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output')
+
+    args = parser.parse_args()
+
+    # Load cards using the standard loader
+    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, sets=args.set)
+
+    if not cards:
+        print("No cards found matching the criteria.", file=sys.stderr)
+        return
+
+    with open(args.outfile, 'w', encoding='utf8', newline='') as f:
+        writer = csv.writer(f)
+        # Header row compatible with csv2json.py
+        writer.writerow(['name', 'mana_cost', 'type', 'subtypes', 'text', 'pt', 'rarity'])
+
+        for card in cards:
+            # Reconstruct the fields in the exact order csv2json.py expects
+
+            # P/T or Loyalty/Defense
+            pt_val = card._get_pt_display(include_parens=False)
+            if not pt_val:
+                pt_val = card._get_loyalty_display(include_parens=False)
+
+            # Rarity shorthand
+            rarity_short = cardlib.RARITY_MAP.get(card.rarity, card.rarity)
+
+            row = [
+                card.name,
+                card.cost.format(),
+                ' '.join(card.supertypes + card.types),
+                ' '.join(card.subtypes),
+                card.get_text(force_unpass=True),
+                pt_val,
+                rarity_short
+            ]
+            writer.writerow(row)
+
+    if args.verbose:
+        print(f"Successfully exported {len(cards)} cards to {args.outfile}")
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_jdecode_csv.py
+++ b/tests/test_jdecode_csv.py
@@ -131,9 +131,9 @@ class TestJDecodeCSV(unittest.TestCase):
             cards = jdecode.mtg_open_file(subdir, verbose=True)
             output = fake_stderr.getvalue()
             self.assertIn('Scanning directory', output)
-            self.assertIn('Loading card1.csv...', output)
-            self.assertIn('Loading card2.csv...', output)
-            self.assertIn('Loading card3.csv...', output)
+            self.assertIn('card1.csv...', output)
+            self.assertIn('card2.csv...', output)
+            self.assertIn('card3.csv...', output)
             # Should have 2 unique names: bolt and shock
             self.assertIn('Opened 2 uniquely named cards', output)
 


### PR DESCRIPTION
This PR introduces a new utility script, `scripts/json2csv.py`, which enables a complete "round-trip" workflow for custom card design. Users can now export existing Magic: The Gathering cards into the specific CSV format required by `scripts/csv2json.py`, allowing them to edit cards in a spreadsheet and re-import them for training.

Additionally, the core card loader in `lib/jdecode.py` was enhanced to support recursive directory scanning, improving the ability of all tools in the repository to process complex dataset structures. Documentation in `CUSTOM.md` has been updated to include instructions for this new workflow.

---
*PR created automatically by Jules for task [17140926406981089359](https://jules.google.com/task/17140926406981089359) started by @RainRat*