### PR TITLE
Refine ANSI color logic for multicolored/hybrid mana symbols

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -693,8 +693,9 @@ class Ansi:
             return Ansi.BOLD + Ansi.GREEN
         if c == 'A' or 'COLORLESS' in c or 'LAND' in c:
             return Ansi.BOLD + Ansi.CYAN # Standard for colorless/artifacts in this project
-        if any(char in c for char in 'WUBRG'):
-            return Ansi.BOLD + Ansi.YELLOW # Multicolored/Hybrid/Phyrexian
+        # Multicolored/Hybrid/Phyrexian: check for 'M' marker or mixed mana characters
+        if c == 'M' or (len(c) > 1 and all(char in 'WUBRG2PSXCE/' for char in c) and any(char in 'WUBRG' for char in c)):
+            return Ansi.BOLD + Ansi.YELLOW
         return Ansi.BOLD
 
 def colorize(text, color_code):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -426,3 +426,32 @@ def test_get_rarity_color_edge_cases():
     assert utils.Ansi.get_rarity_color(None) == utils.Ansi.BOLD
     assert utils.Ansi.get_rarity_color('') == utils.Ansi.BOLD
     assert utils.Ansi.get_rarity_color('unknown') == utils.Ansi.BOLD
+
+def test_get_color_color_regression():
+    # Test individual colors
+    assert utils.Ansi.get_color_color('W') == utils.Ansi.BOLD + utils.Ansi.WHITE
+    assert utils.Ansi.get_color_color('U') == utils.Ansi.BOLD + utils.Ansi.CYAN
+    assert utils.Ansi.get_color_color('B') == utils.Ansi.BOLD + utils.Ansi.MAGENTA
+    assert utils.Ansi.get_color_color('R') == utils.Ansi.BOLD + utils.Ansi.RED
+    assert utils.Ansi.get_color_color('G') == utils.Ansi.BOLD + utils.Ansi.GREEN
+
+    # Test colorless/artifact/land
+    assert utils.Ansi.get_color_color('A') == utils.Ansi.BOLD + utils.Ansi.CYAN
+    assert utils.Ansi.get_color_color('COLORLESS') == utils.Ansi.BOLD + utils.Ansi.CYAN
+    assert utils.Ansi.get_color_color('LAND') == utils.Ansi.BOLD + utils.Ansi.CYAN
+
+    # Test multicolored / M marker
+    assert utils.Ansi.get_color_color('M') == utils.Ansi.BOLD + utils.Ansi.YELLOW
+    assert utils.Ansi.get_color_color('WU') == utils.Ansi.BOLD + utils.Ansi.YELLOW
+    assert utils.Ansi.get_color_color('W/U') == utils.Ansi.BOLD + utils.Ansi.YELLOW
+    assert utils.Ansi.get_color_color('2W') == utils.Ansi.BOLD + utils.Ansi.YELLOW
+
+    # Test avoiding false positives (the bug)
+    assert utils.Ansi.get_color_color('UNKNOWN') == utils.Ansi.BOLD
+    assert utils.Ansi.get_color_color('GLITCH') == utils.Ansi.BOLD
+    assert utils.Ansi.get_color_color('POWER') == utils.Ansi.BOLD
+    assert utils.Ansi.get_color_color('TOUGHNESS') == utils.Ansi.BOLD
+
+    # Edge cases
+    assert utils.Ansi.get_color_color(None) == utils.Ansi.BOLD
+    assert utils.Ansi.get_color_color('') == utils.Ansi.BOLD


### PR DESCRIPTION
This PR fixes a logic bug in the `Ansi.get_color_color` function. Previously, the function used an overly broad substring check (`any(char in c for char in 'WUBRG')`) to identify multicolored/hybrid mana. This caused strings like "UNKNOWN" (containing 'U') or "GLITCH" (containing 'G') to be colored yellow in CLI summaries and tables.

The fix constrains the multicolored check to:
- Explicitly match the 'M' marker.
- For longer strings, verify they consist solely of valid mana characters (`WUBRG2PSXCE/`) while still containing at least one primary color letter.

Regression tests have been added to `tests/test_utils.py` to ensure all color identifiers are correctly mapped and to guard against these false positives. All 456 existing tests pass.

---
*PR created automatically by Jules for task [15942696460464169931](https://jules.google.com/task/15942696460464169931) started by @RainRat*