### PR TITLE
[TEST] Fix ANSI color false positives and improve color identity detection

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -693,8 +693,10 @@ class Ansi:
             return Ansi.BOLD + Ansi.GREEN
         if c == 'A' or 'COLORLESS' in c or 'LAND' in c:
             return Ansi.BOLD + Ansi.CYAN # Standard for colorless/artifacts in this project
-        if any(char in c for char in 'WUBRG'):
-            return Ansi.BOLD + Ansi.YELLOW # Multicolored/Hybrid/Phyrexian
+        # Multicolored, hybrid, or phyrexian mana symbols
+        # Must be 'M' or a string longer than one character consisting only of valid mana characters while containing at least one color letter.
+        if c == 'M' or (len(c) > 1 and all(char in 'WUBRG2PSXCE/' for char in c) and any(char in 'WUBRG' for char in c)):
+            return Ansi.BOLD + Ansi.YELLOW
         return Ansi.BOLD
 
 def colorize(text, color_code):

--- a/tests/test_utils_gaps.py
+++ b/tests/test_utils_gaps.py
@@ -37,8 +37,19 @@ def test_get_color_color_colorless_indicators():
 
 def test_get_color_color_multi_and_hybrid():
     Ansi = utils.Ansi
+    assert Ansi.get_color_color('M') == Ansi.BOLD + Ansi.YELLOW
     assert Ansi.get_color_color('WU') == Ansi.BOLD + Ansi.YELLOW
     assert Ansi.get_color_color('WUBRG') == Ansi.BOLD + Ansi.YELLOW
+    assert Ansi.get_color_color('2/W') == Ansi.BOLD + Ansi.YELLOW
+    assert Ansi.get_color_color('G/W/P') == Ansi.BOLD + Ansi.YELLOW
+
+def test_get_color_color_false_positives():
+    Ansi = utils.Ansi
+    # Should NOT be yellow
+    assert Ansi.get_color_color('GLITCH') == Ansi.BOLD
+    assert Ansi.get_color_color('UNKNOWN') == Ansi.BOLD
+    assert Ansi.get_color_color('SWAMP') == Ansi.BOLD
+    assert Ansi.get_color_color('MOUNTAIN') == Ansi.BOLD
 
 def test_get_color_color_edge_cases():
     Ansi = utils.Ansi


### PR DESCRIPTION
As a Lead QA Automation Agent, I identified a bug in `Ansi.get_color_color` where general text containing color letters was being miscolored as multicolored (yellow). This was discovered during gap analysis of the `lib/utils.py` module.

I have:
1. Refactored the logic in `lib/utils.py` to require either the 'M' marker or a valid composite mana symbol string for yellow coloring.
2. Added regression tests in `tests/test_utils_gaps.py` covering 'M', various hybrid/special mana symbols, and false positive cases like 'GLITCH' and basic land names.
3. Verified the fix by running the full test suite (456 tests), all of which passed.

---
*PR created automatically by Jules for task [5011958514595587090](https://jules.google.com/task/5011958514595587090) started by @RainRat*