### PR TITLE
[FEAT] Add support for reading Cockatrice XML card databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Convert AI-generated text back into a readable format. You can see the results i
 # View decoded cards in your terminal
 python3 decode.py encoded_output.txt
 
+# Convert a Cockatrice XML database to encoded text
+python3 encode.py my_database.xml encoded_output.txt
+
 # Save to a file (the format is detected from the file extension)
 python3 decode.py encoded_output.txt my_cards.html
 ```
@@ -117,7 +120,8 @@ Customization options for formatting data:
 *   `--report-unparsed FILE`: Save the raw JSON of cards that failed to parse into a separate file.
 
 ### `decode.py` (Viewing Results)
-Options for formatting the output:
+Options for formatting the output. While primarily used for AI output, this tool also supports other card data formats (**JSON, XML, CSV, etc.**) for easy conversion.
+
 *   `-g`, `--gatherer`: Formats text like the official Gatherer website (Default). This applies modern wording and capitalization.
 *   `--raw`: Shows raw text without special formatting.
 *   `--table`: Creates a formatted table for terminal view.
@@ -391,6 +395,11 @@ python3 scripts/splitcards.py data/AllPrintings.json --outputs rb_train.txt rb_v
 *   **Format Mismatch:** If you used a specific encoding flag (like `-e named`) with `encode.py`, you **must** use the same flag with `decode.py`.
 *   **Missing Symbols:** If card symbols (like mana) show as squares, you need to install the Magic fonts. See [DEPENDENCIES.md](DEPENDENCIES.md) for help.
 *   **Parsing Errors:** Some cards in older JSON formats may not parse correctly. Use the `--report-unparsed` (for `encode.py`) or `--report-failed` (for `decode.py`) flags to identify them.
+
+**Example for importing a Cockatrice XML database:**
+```bash
+python3 scripts/summarize.py my_custom_set.xml
+```
 
 ---
 

--- a/decode.py
+++ b/decode.py
@@ -758,7 +758,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, XML, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .jsonl, .csv, .md, .sum, .summary, .deck, .dek, .mse-set).')
 

--- a/encode.py
+++ b/encode.py
@@ -139,7 +139,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, XML, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the output. If not provided, output prints to the console.')
 

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -6,6 +6,7 @@ import csv
 import zipfile
 import random
 import io
+import xml.etree.ElementTree as ET
 
 import utils
 import cardlib
@@ -230,6 +231,30 @@ def mtg_open_json_obj(jobj, verbose = False):
 
     return allcards, bad_sets
 
+def _format_mana_json(s):
+    """
+    Converts a mana cost string (e.g. 2UU or {2}{U}{U}) into the format
+    expected by the internal JSON parser ({2}{U}{U}).
+    """
+    if not s: return ""
+    if s.startswith('{') and s.endswith('}'):
+        # If it's already in braces, we assume it's mostly correct,
+        # but if it's a single set of braces with multiple symbols like {2UU},
+        # we might want to split them.
+        # However, MTGJSON format {2}{U}{U} is already handled.
+        # Let's just be safe and use the same logic if there are no inner braces.
+        if s.count('{') == 1:
+            s = s[1:-1]
+        else:
+            return s
+
+    # Improved regex to handle hybrid costs like W/U, 2/W, W/U/B, and W/P
+    tokens = re.findall(r'(?:[a-zA-Z0-9]/)+[a-zA-Z0-9]|\d+|[a-zA-Z]', s)
+    res = ""
+    for t in tokens:
+        res += "{" + t.upper() + "}"
+    return res
+
 def mtg_open_json(fname, verbose = False):
     """
     Reads a JSON file containing card data.
@@ -237,6 +262,103 @@ def mtg_open_json(fname, verbose = False):
     with open(fname, 'r', encoding='utf8') as f:
         jobj = json.load(f)
     return mtg_open_json_obj(jobj, verbose)
+
+def mtg_open_xml_content(text, verbose = False):
+    """
+    Processes Cockatrice XML content.
+    """
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError:
+        return {}, set()
+
+    allcards = {}
+    bad_sets = set()
+
+    # Cockatrice XML structure:
+    # <cockatrice_carddatabase>
+    #   <cards>
+    #     <card>
+    #       <name>...</name>
+    #       <manacost>...</manacost>
+    #       <type>...</type>
+    #       <pt>...</pt>
+    #       <text>...</text>
+    #     </card>
+    #   </cards>
+    # </cockatrice_carddatabase>
+
+    cards_node = root.find('cards')
+    if cards_node is None:
+        # Some older or alternative formats might have <card> directly under root
+        cards_node = root
+
+    for card_node in cards_node.findall('card'):
+        name = card_node.findtext('name', '')
+        if not name:
+            continue
+
+        card_dict = {
+            'name': name,
+            'manaCost': _format_mana_json(card_node.findtext('manacost', '')),
+            'text': card_node.findtext('text', ''),
+            'rarity': card_node.findtext('rarity', ''),
+            'setCode': card_node.findtext('set', ''),
+            'number': card_node.findtext('number', ''),
+        }
+
+        # Handle type line
+        full_type = card_node.findtext('type', '')
+        if full_type:
+            card_dict['type'] = full_type
+            s, t, sub = utils.parse_type_line(full_type)
+            if s: card_dict['supertypes'] = s
+            if t: card_dict['types'] = t
+            if sub: card_dict['subtypes'] = sub
+
+        # Handle P/T and Loyalty/Defense
+        pt = card_node.findtext('pt', '')
+        if pt:
+            if '/' in pt:
+                # Creature or Vehicle
+                p, t = pt.split('/', 1)
+                card_dict['power'] = p.strip()
+                card_dict['toughness'] = t.strip()
+            elif 'Planeswalker' in full_type or 'Battle' in full_type:
+                # Loyalty or Defense
+                if 'Battle' in full_type:
+                    card_dict['defense'] = pt.strip()
+                else:
+                    card_dict['loyalty'] = pt.strip()
+            else:
+                # Ambiguous, but we'll try to guess
+                try:
+                    int(pt.strip())
+                    if 'Creature' in full_type:
+                        card_dict['power'] = pt.strip()
+                    else:
+                        card_dict['loyalty'] = pt.strip()
+                except ValueError:
+                    card_dict['pt'] = pt
+
+        cardname = name.lower()
+        if cardname in allcards:
+            allcards[cardname].append(card_dict)
+        else:
+            allcards[cardname] = [card_dict]
+
+    if verbose:
+        print('Opened ' + str(len(allcards)) + ' uniquely named cards from XML.', file=sys.stderr)
+
+    return allcards, bad_sets
+
+def mtg_open_xml(fname, verbose = False):
+    """
+    Reads a Cockatrice XML file containing card data.
+    """
+    with open(fname, 'r', encoding='utf8') as f:
+        text = f.read()
+    return mtg_open_xml_content(text, verbose)
 
 def mtg_open_jsonl_content(text, verbose = False):
     """
@@ -385,21 +507,12 @@ def mtg_open_mse_content(content, verbose=False):
     if current_card:
         allcards_raw.append(current_card)
 
-    def mse_mana_to_json(s):
-        if not s: return ""
-        # Improved regex to handle hybrid costs like W/U, 2/W, W/U/B, and W/P
-        tokens = re.findall(r'(?:[a-zA-Z0-9]/)+[a-zA-Z0-9]|\d+|[a-zA-Z]', s)
-        res = ""
-        for t in tokens:
-            res += "{" + t.upper() + "}"
-        return res
-
     allcards = {}
     for c in allcards_raw:
         # Main side
         d = {
             'name': c.get('name', ''),
-            'manaCost': mse_mana_to_json(c.get('casting cost', '')),
+            'manaCost': _format_mana_json(c.get('casting cost', '')),
             'rarity': c.get('rarity', '').capitalize(),
             'text': c.get('rule text', ''),
         }
@@ -441,7 +554,7 @@ def mtg_open_mse_content(content, verbose=False):
         if 'name 2' in c:
             b = {
                 'name': c.get('name 2', ''),
-                'manaCost': mse_mana_to_json(c.get('casting cost 2', '')),
+                'manaCost': _format_mana_json(c.get('casting cost 2', '')),
                 'rarity': c.get('rarity 2', d['rarity']).capitalize(),
                 'text': c.get('rule text 2', ''),
             }
@@ -710,7 +823,7 @@ def mtg_open_file(fname, verbose = False,
             srcs, bad = {}, set()
             t_cards = []
 
-            if f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set'):
+            if f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set') or f.endswith('.xml'):
                 if f.endswith('.mse-set'):
                     # Nested ZIP handling
                     with zipfile.ZipFile(io.BytesIO(content if is_zip else open(f, 'rb').read()), 'r') as nested_zf:
@@ -729,6 +842,8 @@ def mtg_open_file(fname, verbose = False,
                         pass
                 elif f.endswith('.jsonl'):
                     srcs, bad = mtg_open_jsonl_content(content if is_zip else open(f, 'r', encoding='utf8').read(), verbose=False)
+                elif f.endswith('.xml'):
+                    srcs, bad = mtg_open_xml_content(content if is_zip else open(f, 'r', encoding='utf8').read(), verbose=False)
                 else: # .csv
                     reader = csv.DictReader(io.StringIO(content if is_zip else open(f, 'r', encoding='utf8').read()))
                     srcs, bad = mtg_open_csv_reader(reader, verbose=False)
@@ -750,7 +865,7 @@ def mtg_open_file(fname, verbose = False,
 
         if is_zip:
             with zipfile.ZipFile(fname, 'r') as zf:
-                files = sorted([f for f in zf.namelist() if not f.endswith('/') and (f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set') or f.endswith('.txt'))])
+                files = sorted([f for f in zf.namelist() if not f.endswith('/') and (f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set') or f.endswith('.txt') or f.endswith('.xml'))])
                 for f in files:
                     if verbose:
                         print(f"  Loading {f} from ZIP...", file=sys.stderr)
@@ -767,7 +882,7 @@ def mtg_open_file(fname, verbose = False,
         else:
             for root, dirs, filenames in os.walk(fname):
                 for f in sorted(filenames):
-                    if f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set') or f.endswith('.txt'):
+                    if f.endswith('.json') or f.endswith('.csv') or f.endswith('.jsonl') or f.endswith('.mse-set') or f.endswith('.txt') or f.endswith('.xml'):
                         full_path = os.path.join(root, f)
                         if verbose:
                             print(f"Loading {full_path}...", file=sys.stderr)
@@ -820,6 +935,16 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
+    # Single XML File Handling
+    elif fname.endswith('.xml'):
+        if verbose:
+            print('This looks like an xml file: ' + fname, file=sys.stderr)
+        xml_srcs, bad_sets = mtg_open_xml(fname, verbose)
+
+        cards = _process_json_srcs(xml_srcs, bad_sets, verbose, linetrans,
+                                   exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                   decklist_names=decklist_names)
+
     # Single MSE File Handling
     elif fname.endswith('.mse-set'):
         if verbose:
@@ -855,7 +980,7 @@ def mtg_open_file(fname, verbose = False,
                 cards = _hydrate_decklist(decklist_names, verbose, linetrans,
                                            exclude_sets, exclude_types, exclude_layouts, report_fobj)
 
-            # 2. JSON / JSONL Detection
+            # 2. JSON / JSONL / XML Detection
             if not cards and (stripped.startswith('{') or stripped.startswith('[')):
                 try:
                     # Try regular JSON first
@@ -875,6 +1000,15 @@ def mtg_open_file(fname, verbose = False,
                         cards = _process_json_srcs(jsonl_srcs, bad_sets, verbose, linetrans,
                                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                                    decklist_names=decklist_names)
+            if not cards and stripped.startswith('<'):
+                # Try XML
+                xml_srcs, bad_sets = mtg_open_xml_content(text, verbose)
+                if xml_srcs:
+                    if verbose:
+                        print('Detected XML input from stdin.', file=sys.stderr)
+                    cards = _process_json_srcs(xml_srcs, bad_sets, verbose, linetrans,
+                                               exclude_sets, exclude_types, exclude_layouts, report_fobj,
+                                               decklist_names=decklist_names)
             # 3. CSV Detection
             if not cards and stripped.startswith('name,'):
                 try:

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
+                        help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, XML, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the summary output. If not provided, output prints to the console. The format is automatically detected from the file extension (.json for JSON, otherwise text).')
     io_group.add_argument('--json', action='store_true',

--- a/testdata/sample_cockatrice.xml
+++ b/testdata/sample_cockatrice.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cockatrice_carddatabase version="4">
+  <cards>
+    <card>
+      <name>Grizzly Bears</name>
+      <manacost>1G</manacost>
+      <type>Creature — Bear</type>
+      <pt>2/2</pt>
+      <text></text>
+      <rarity>Common</rarity>
+    </card>
+    <card>
+      <name>Jace, the Mind Sculptor</name>
+      <manacost>2UU</manacost>
+      <type>Legendary Planeswalker — Jace</type>
+      <pt>3</pt>
+      <text>[+2]: Look at the top card of target player's library. You may put that card on the bottom of that player's library.
+[0]: Draw three cards, then put two cards from your hand on top of your library in any order.
+[-1]: Return target creature to its owner's hand.
+[-12]: Exile all cards from target player's library, then that player shuffles their hand into their library.</text>
+      <rarity>Mythic</rarity>
+    </card>
+    <card>
+      <name>Invasion of Alara</name>
+      <manacost>WUBRG</manacost>
+      <type>Battle — Siege</type>
+      <pt>7</pt>
+      <text>(As a Siege enters, choose an opponent to protect it. You and others can attack it. When it's defeated, exile it, then cast it transformed.)
+When Invasion of Alara enters the battlefield, exile cards from the top of your library until you exile two nonland cards with mana value 4 or less. You may cast one of them without paying its mana cost. Put the other into your hand and the rest on the bottom of your library in a random order.</text>
+      <rarity>Rare</rarity>
+    </card>
+  </cards>
+</cockatrice_carddatabase>

--- a/tests/test_xml_input.py
+++ b/tests/test_xml_input.py
@@ -1,0 +1,124 @@
+import pytest
+import os
+import sys
+
+# Ensure lib is in path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+import jdecode
+import cardlib
+import utils
+
+def test_mtg_open_xml_content_basic():
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<cockatrice_carddatabase version="4">
+  <cards>
+    <card>
+      <name>Grizzly Bears</name>
+      <manacost>1G</manacost>
+      <type>Creature — Bear</type>
+      <pt>2/2</pt>
+      <text>Some text.</text>
+      <rarity>Common</rarity>
+    </card>
+  </cards>
+</cockatrice_carddatabase>"""
+
+    srcs, bad_sets = jdecode.mtg_open_xml_content(xml_text)
+    assert "grizzly bears" in srcs
+    card_dict = srcs["grizzly bears"][0]
+    assert card_dict['name'] == "Grizzly Bears"
+    assert card_dict['manaCost'] == "{1}{G}"
+    assert card_dict['power'] == "2"
+    assert card_dict['toughness'] == "2"
+    assert card_dict['rarity'] == "Common"
+    assert 'Creature' in card_dict['types']
+    assert 'Bear' in card_dict['subtypes']
+
+def test_mtg_open_xml_content_planeswalker():
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<cockatrice_carddatabase version="4">
+  <cards>
+    <card>
+      <name>Jace</name>
+      <manacost>2UU</manacost>
+      <type>Legendary Planeswalker — Jace</type>
+      <pt>3</pt>
+      <text>PW text</text>
+      <rarity>Mythic</rarity>
+    </card>
+  </cards>
+</cockatrice_carddatabase>"""
+
+    srcs, bad_sets = jdecode.mtg_open_xml_content(xml_text)
+    card_dict = srcs["jace"][0]
+    assert card_dict['loyalty'] == "3"
+    assert 'Planeswalker' in card_dict['types']
+
+def test_mtg_open_xml_content_battle():
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<cockatrice_carddatabase version="4">
+  <cards>
+    <card>
+      <name>Invasion</name>
+      <manacost>WUBRG</manacost>
+      <type>Battle — Siege</type>
+      <pt>7</pt>
+      <text>Battle text</text>
+      <rarity>Rare</rarity>
+    </card>
+  </cards>
+</cockatrice_carddatabase>"""
+
+    srcs, bad_sets = jdecode.mtg_open_xml_content(xml_text)
+    card_dict = srcs["invasion"][0]
+    assert card_dict['defense'] == "7"
+    assert 'Battle' in card_dict['types']
+
+def test_mtg_open_xml_content_invalid_xml():
+    xml_text = "not xml"
+    srcs, bad_sets = jdecode.mtg_open_xml_content(xml_text)
+    assert srcs == {}
+
+def test_mtg_open_file_xml(tmp_path):
+    d = tmp_path / "subdir"
+    d.mkdir()
+    f = d / "test.xml"
+    f.write_text("""<?xml version="1.0" encoding="UTF-8"?>
+<cockatrice_carddatabase version="4">
+  <cards>
+    <card>
+      <name>Test Card</name>
+      <manacost>U</manacost>
+      <type>Instant</type>
+      <text>Counter target spell.</text>
+    </card>
+  </cards>
+</cockatrice_carddatabase>""", encoding='utf8')
+
+    cards = jdecode.mtg_open_file(str(f))
+    assert len(cards) == 1
+    assert cards[0].name == "test card"
+    assert "instant" in cards[0].types
+
+def test_mtg_open_file_directory_with_xml(tmp_path):
+    d = tmp_path / "data"
+    d.mkdir()
+    f1 = d / "c1.json"
+    f1.write_text('{"name": "Json Card", "types": ["Artifact"]}', encoding='utf8')
+    f2 = d / "c2.xml"
+    f2.write_text("""<?xml version="1.0" encoding="UTF-8"?>
+<cockatrice_carddatabase version="4">
+  <cards>
+    <card>
+      <name>XML Card</name>
+      <type>Sorcery</type>
+    </card>
+  </cards>
+</cockatrice_carddatabase>""", encoding='utf8')
+
+    cards = jdecode.mtg_open_file(str(d))
+    names = [c.name for c in cards]
+    assert "json card" in names
+    assert "xml card" in names


### PR DESCRIPTION
I identified a "Symmetry" gap in the codebase: while the toolset can export to Cockatrice XML format, it could not read it back in. 

This PR adds full support for importing Magic: The Gathering card data from Cockatrice-compatible XML files (`.xml`). The functionality is integrated into the central data loader, meaning it automatically works across all major scripts (`encode.py`, `decode.py`, `summarize.py`, `splitcards.py`, etc.).

Key improvements:
- Supports single XML files, recursive directory scanning, and XML files inside ZIP archives.
- Handles various card properties: name, mana cost (with automatic normalization), type lines (parsing supertypes/types/subtypes), power/toughness, loyalty for planeswalkers, and defense for battles.
- Centralizes mana cost parsing logic to improve robustness across XML and MSE imports.
- Updated documentation and CLI help text for better user guidance.
- Verified with a new unit test suite and full project test run (461/461 passing).

---
*PR created automatically by Jules for task [15142941651745503278](https://jules.google.com/task/15142941651745503278) started by @RainRat*