### PR TITLE
[UI/UX] Add shorthand flags for common output formats

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -779,11 +779,11 @@ if __name__ == '__main__':
     fmt_group = fmt_group_title.add_mutually_exclusive_group()
     fmt_group.add_argument('--text', action='store_true',
                            help='Force plain text output (Default unless detected from extension).')
-    fmt_group.add_argument('--table', action='store_true',
+    fmt_group.add_argument('-t', '--table', action='store_true',
                            help='Generate a formatted table for terminal view (Auto-detected for .tbl or .table).')
     fmt_group.add_argument('--html', action='store_true',
                            help='Generate a nicely formatted HTML file (Auto-detected for .html).')
-    fmt_group.add_argument('--json', action='store_true',
+    fmt_group.add_argument('-j', '--json', action='store_true',
                            help='Generate a structured JSON file (Auto-detected for .json).')
     fmt_group.add_argument('--jsonl', action='store_true',
                            help='Generate a JSON Lines file (one card object per line). Auto-detected for .jsonl.')
@@ -793,7 +793,7 @@ if __name__ == '__main__':
                            help='Generate a Markdown file (Auto-detected for .md).')
     fmt_group.add_argument('--md-table', '--mdt', action='store_true',
                            help='Generate a Markdown table file (Auto-detected for .mdt).')
-    fmt_group.add_argument('--summary', action='store_true',
+    fmt_group.add_argument('-S', '--summary', action='store_true',
                            help='Generate a compact one-line summary for each card (Auto-detected for .sum or .summary).')
     fmt_group.add_argument('--deck', '--decklist', action='store_true',
                            help='Generate a standard MTG decklist (Auto-detected for .deck or .dek).')

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
                         help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, XML, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the summary output. If not provided, output prints to the console. The format is automatically detected from the file extension (.json for JSON, otherwise text).')
-    io_group.add_argument('--json', action='store_true',
+    io_group.add_argument('-j', '--json', action='store_true',
                         help='Output statistics in JSON format (Auto-detected for .json).')
 
     # Group: Encoding Options

--- a/sortcards.py
+++ b/sortcards.py
@@ -463,7 +463,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
-    proc_group.add_argument('--summary', action='store_true',
+    proc_group.add_argument('-S', '--summary', action='store_true',
                         help='Output compact card summaries instead of full encoded text.')
     proc_group.add_argument('--md', '--markdown', action='store_true',
                         help='Output in Markdown format with collapsible sections (Auto-detected for .md).')


### PR DESCRIPTION
This PR adds short-hand flags to the most frequently used output format options across the project's CLI tools. By providing '-j' for JSON, '-t' for tables, and '-S' for summaries, we reduce the keystrokes required for common workflows while maintaining consistency across scripts.

---
*PR created automatically by Jules for task [13279675123023871486](https://jules.google.com/task/13279675123023871486) started by @RainRat*