### PR TITLE
[FEAT] Add dynamic breakdown limits and logical rarity sorting to summarize tool

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -456,8 +456,8 @@ class Datamine:
         print(color_line('COLORS & MANA', use_color, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE))
         print('  ' + color_line(str(len(self.by_color_inclusive)) + ' represented colors (including colorless as \'A\'), '
                + str(len(self.by_color)) + ' combinations', use_color))
-        _print_breakdown('Breakdown by color:', self.by_color_inclusive, len(self.allcards), use_color)
-        _print_breakdown('Breakdown by number of colors:', self.by_color_count, len(self.allcards), use_color)
+        _print_breakdown('Breakdown by color:', self.by_color_inclusive, len(self.allcards), use_color, vsize=vsize)
+        _print_breakdown('Breakdown by number of colors:', self.by_color_count, len(self.allcards), use_color, vsize=vsize)
         print()
 
         print('  ' + color_line(str(len(self.by_cmc)) + ' different CMCs, ' +
@@ -497,7 +497,12 @@ class Datamine:
         # Section: Stats & Rarity
         print(color_line('STATS & RARITY', use_color, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE))
         print('  ' + color_line(str(len(self.by_rarity)) + ' represented rarities', use_color))
-        _print_breakdown('Breakdown by rarity:', self.by_rarity, len(self.allcards), use_color)
+        rarity_priorities = {
+            'mythic': 0, 'rare': 1, 'uncommon': 2, 'common': 3,
+            'basic land': 4, 'special': 5
+        }
+        _print_breakdown('Breakdown by rarity:', self.by_rarity, len(self.allcards), use_color,
+                         vsize=vsize, sort_key=lambda x: rarity_priorities.get(x.lower(), 6), reverse=False)
         print()
 
         print('  ' + color_line(str(len(self.by_pt)) + ' unique p/t combinations', use_color))
@@ -569,9 +574,11 @@ class Datamine:
                        key=lambda x: len(self.by_name[x]),
                        reverse = True)
             rows = []
-            for k in d[0:vsize]:
+            for k in d:
                 if len(self.by_name[k]) > 1:
                     rows += [[k, color_count(len(self.by_name[k]), use_color)]]
+                if len(rows) >= vsize:
+                    break
             if rows == []:
                 print('  No duplicated cardnames')
             else:

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -30,7 +30,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
-         shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None):
+         shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None, top = 10):
 
     # Set default format to JSON if no specific output format is selected and outfile is .json
     if not json_out and oname and oname.endswith('.json'):
@@ -82,9 +82,9 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
             output_f.write(json.dumps(mine.to_dict(), indent=2) + '\n')
         else:
             with redirect_stdout(output_f):
-                mine.summarize(use_color=actual_use_color)
+                mine.summarize(use_color=actual_use_color, vsize=top)
                 if outliers or dump_all:
-                    mine.outliers(dump_invalid = dump_all, use_color=actual_use_color)
+                    mine.outliers(dump_invalid = dump_all, use_color=actual_use_color, vsize=top)
     finally:
         if oname:
             output_f.close()
@@ -119,6 +119,8 @@ if __name__ == '__main__':
                         help='Only process the first N cards.')
     proc_group.add_argument('--shuffle', action='store_true',
                         help='Randomize the order of cards before summarizing.')
+    proc_group.add_argument('-t', '--top', type=int, default=10,
+                        help='Limit the number of entries in breakdown tables.')
     proc_group.add_argument('--seed', type=int,
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
@@ -203,5 +205,6 @@ if __name__ == '__main__':
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
-         shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck)
+         shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck,
+         top = args.top)
     exit(0)


### PR DESCRIPTION
This PR introduces several improvements to the `summarize.py` utility and the underlying `Datamine` library to enhance dataset analysis flexibility and readability.

### Changes:
1.  **Dynamic Breakdown Limits:** Added the `--top` (or `-t`) flag to `scripts/summarize.py`. Users can now specify how many entries to display in breakdown tables (e.g., `-t 5` for a more concise view).
2.  **Logical Rarity Sorting:** Refactored the "Breakdown by rarity" section to use a logical MTG priority order (Mythic > Rare > Uncommon > Common > Basic Land > Special) instead of alphabetical sorting.
3.  **Robust Duplicate Detection:** Improved the logic in `Datamine.outliers` for identifying duplicated card names, ensuring that all relevant duplicates are captured regardless of their position in the initial sorted list.
4.  **API Stability:** Updated `lib/datalib.py` to support these features while preserving the original method signatures for `summarize()` and `outliers()`, ensuring no breaking changes for external callers.

### Verification:
- Verified the `--top` flag truncation logic with sample data.
- Verified the rarity ordering with a dedicated test dataset.
- Ran the full test suite (`pytest`); all 470 tests passed.

---
*PR created automatically by Jules for task [8405641287211994830](https://jules.google.com/task/8405641287211994830) started by @RainRat*