### PR TITLE
Consolidate card face merging logic in Card._get_display_data

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -552,8 +552,8 @@ class Card:
             res += f' {separator} ' + ' '.join([titlecase(s) for s in self.__dict__[field_subtypes]])
         return res
 
-    def _get_display_data(self, ansi_color=False, include_text=False):
-        """Helper to get standardized display fields for the card."""
+    def _get_single_face_display_data(self, ansi_color=False, include_text=False):
+        """Helper to get standardized display fields for a single face of the card."""
         # Name
         name = titlecase(self.name)
         if ansi_color:
@@ -581,6 +581,23 @@ class Card:
         rarity = self.rarity_name
         if ansi_color and rarity:
             rarity = utils.colorize(rarity, utils.Ansi.get_rarity_color(rarity))
+
+        return name, cost, typeline, stats, text, rarity
+
+    def _get_display_data(self, ansi_color=False, include_text=False):
+        """Helper to get standardized display fields for the card, merging b-sides."""
+        name, cost, typeline, stats, text, rarity = self._get_single_face_display_data(ansi_color=ansi_color, include_text=include_text)
+
+        if self.bside:
+            b_name, b_cost, b_typeline, b_stats, b_text, b_rarity = self.bside._get_display_data(ansi_color=ansi_color, include_text=include_text)
+            name = f"{name} // {b_name}"
+            cost = f"{cost} // {b_cost}"
+            typeline = f"{typeline} // {b_typeline}"
+            stats = f"{stats} // {b_stats}" if stats and b_stats else (stats or b_stats)
+            if include_text:
+                text = f"{text}<br>---<br>{b_text}"
+            if b_rarity and b_rarity != rarity:
+                rarity = f"{rarity} // {b_rarity}"
 
         return name, cost, typeline, stats, text, rarity
 
@@ -1451,16 +1468,6 @@ class Card:
         """Returns a Markdown table row representation of the card."""
         name, cost, typeline, stats, text, rarity = self._get_display_data(include_text=True)
 
-        if self.bside:
-            b_name, b_cost, b_typeline, b_stats, b_text, b_rarity = self.bside._get_display_data(include_text=True)
-            name = f"{name} // {b_name}"
-            cost = f"{cost} // {b_cost}"
-            typeline = f"{typeline} // {b_typeline}"
-            stats = f"{stats} // {b_stats}" if stats and b_stats else (stats or b_stats)
-            text = f"{text}<br>---<br>{b_text}"
-            if b_rarity and b_rarity != rarity:
-                rarity = f"{rarity} // {b_rarity}"
-
         # Escape pipe characters and ensure no actual newlines break the row
         fields = [name, cost, typeline, stats, text, rarity]
         fields = [f.replace('|', '\\|').replace('\n', ' ') for f in fields]
@@ -1470,15 +1477,6 @@ class Card:
     def to_table_row(self, ansi_color=False):
         """Returns a list of strings representing the card's fields for a terminal table."""
         name, cost, typeline, stats, _, rarity = self._get_display_data(ansi_color=ansi_color)
-
-        if self.bside:
-            b_name, b_cost, b_typeline, b_stats, _, b_rarity = self.bside._get_display_data(ansi_color=ansi_color)
-            name = f"{name} // {b_name}"
-            cost = f"{cost} // {b_cost}"
-            typeline = f"{typeline} // {b_typeline}"
-            stats = f"{stats} // {b_stats}" if stats and b_stats else (stats or b_stats)
-            if b_rarity and b_rarity != rarity:
-                rarity = f"{rarity} // {b_rarity}"
 
         return [name, cost, typeline, stats, rarity]
 


### PR DESCRIPTION
This PR addresses a duplication issue in `lib/cardlib.py` where the logic for merging data from multiple card faces (b-sides) was repeated in both `to_markdown_row` and `to_table_row`. 

I have refactored this by:
1.  Renaming the existing `_get_display_data` to `_get_single_face_display_data` to clearly denote it handles only one face.
2.  Implementing a new `_get_display_data` method that manages recursive merging of fields (name, cost, typeline, stats, text, and rarity) from the `bside` attribute.
3.  Updating `to_markdown_row` and `to_table_row` to call the new centralized `_get_display_data`, removing their manual merging blocks.

This change is non-breaking as it preserves existing external behavior while making the code more robust (it now handles arbitrarily nested faces recursively) and easier to maintain. 

Verification:
- Ran `tests/test_table_output.py`, `tests/test_markdown_output.py`, `tests/test_cardlib.py`, and `tests/test_bside.py`. All tests passed.
- Verified file integrity and logic via `sed`.

---
*PR created automatically by Jules for task [2991337720382365044](https://jules.google.com/task/2991337720382365044) started by @RainRat*