### PR TITLE
[TEST] Fix and cover plural 'tokens' in mechanical profiling

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -630,16 +630,19 @@ class Card:
 
         # 2. Common Keyword Abilities
         keywords = [
-            'flying', 'trample', 'lifelink', 'haste', 'deathtouch',
-            'vigilance', 'ward', 'prowess', 'menace', 'reach',
-            'flash', 'indestructible', 'scry', 'draw a card',
-            'mill', 'exile', 'token', 'discard', 'cycling'
+            ('flying', 'Flying'), ('trample', 'Trample'), ('lifelink', 'Lifelink'),
+            ('haste', 'Haste'), ('deathtouch', 'Deathtouch'), ('vigilance', 'Vigilance'),
+            ('ward', 'Ward'), ('prowess', 'Prowess'), ('menace', 'Menace'),
+            ('reach', 'Reach'), ('flash', 'Flash'), ('indestructible', 'Indestructible'),
+            ('scry', 'Scry'), ('draw a card', 'Draw A Card'), ('mill', 'Mill'),
+            ('exile', 'Exile'), (r'tokens?', 'Token'), ('discard', 'Discard'),
+            ('cycling', 'Cycling')
         ]
 
-        for kw in keywords:
+        for pattern, label in keywords:
             # Use word boundaries for keywords to avoid partial matches
-            if re.search(r'\b' + re.escape(kw) + r'\b', text_raw):
-                m.add(kw.title())
+            if re.search(r'\b' + pattern + r'\b', text_raw):
+                m.add(label)
 
         # Recursive profiling for split/double-faced cards
         if self.bside:

--- a/tests/test_card_mechanics_tokens.py
+++ b/tests/test_card_mechanics_tokens.py
@@ -1,0 +1,26 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from lib.cardlib import Card
+
+def test_mechanics_token_singular():
+    card_json = {
+        "name": "Token Generator",
+        "types": ["Sorcery"],
+        "text": "Create a 1/1 white Soldier creature token.",
+        "rarity": "Common"
+    }
+    card = Card(card_json)
+    assert 'Token' in card.mechanics
+
+def test_mechanics_token_plural():
+    card_json = {
+        "name": "Tokens Generator",
+        "types": ["Sorcery"],
+        "text": "Create two 1/1 white Soldier creature tokens.",
+        "rarity": "Common"
+    }
+    card = Card(card_json)
+    assert 'Token' in card.mechanics


### PR DESCRIPTION
I have identified and fixed a gap in the mechanical profiling logic where cards generating multiple "tokens" (plural) were not correctly tagged with the "Token" mechanic.

Summary of changes:
1.  **Refactored Keyword Extraction:** Modified `lib/cardlib.py` to use a more robust `(pattern, label)` structure for keyword identification. This allows for regex patterns like `tokens?` to match variations while maintaining clean, title-cased labels.
2.  **New Test Coverage:** Added `tests/test_card_mechanics_tokens.py` which specifically verifies that both "Create a token" and "Create two tokens" are correctly identified as the "Token" mechanic.
3.  **Verification:** Ran the full test suite (472 tests) to ensure no regressions were introduced in other mechanical profiling or card parsing logic.
4.  **Clean-up:** Removed a temporary reproduction script used during development to maintain repository hygiene.

---
*PR created automatically by Jules for task [15018617053523468267](https://jules.google.com/task/15018617053523468267) started by @RainRat*