### PR TITLE
[FEAT] Universal Booster Simulation Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ python3 sortcards.py data/AllPrintings.json sorted_output.txt
 # Sort encoded cards with filters and sampling
 python3 sortcards.py encoded_output.txt sorted_sample.txt --sample 50 --grep "Elf"
 ```
-*   **Options:** Supports `--encoding`, `--limit`, `--shuffle`, `--sample`, and all **Advanced Filtering** flags.
+*   **Options:** Supports `--encoding`, `--limit`, `--shuffle`, `--sample`, `--booster`, and all **Advanced Filtering** flags.
 *   `--summary`: Output compact card summaries instead of full text.
 *   `--md`: Output in Markdown format with collapsible sections.
 *   `--color` / `--no-color`: Enable or disable ANSI color output.
@@ -359,7 +359,7 @@ python3 scripts/summarize.py encoded_output.txt summary.json
     *   `-a`, `--all`: Show all information, including dumping invalid cards.
     *   `--json`: Force JSON output.
     *   `--color` / `--no-color`: Enable or disable ANSI color output.
-    *   Supports all **Advanced Filtering** flags (e.g., `--limit`, `--sample`, `--cmc`, `--mechanic`).
+    *   Supports all **Advanced Filtering** flags (e.g., `--limit`, `--sample`, `--booster`, `--cmc`, `--mechanic`).
 
 ### `csv2json.py` & `combinejson.py`
 Used for integrating custom cards into your dataset. See [CUSTOM.md](CUSTOM.md) for a full guide.
@@ -395,7 +395,7 @@ python3 scripts/splitcards.py data/AllPrintings.json --outputs rb_train.txt rb_v
     *   `-q`, `--quiet`: Suppress the progress bar.
     *   `--encoding`: Choose the text encoding format (e.g., `std`, `named`, `vec`).
     *   `--shuffle` / `--no-shuffle`: Whether to randomize the order of cards before splitting (Enabled by default).
-    *   Supports all filtering and sorting flags from `encode.py` (e.g., `--limit`, `--sort`, `--grep`, `--colors`, `--cmc`, `--mechanic`).
+    *   Supports all filtering and sorting flags from `encode.py` (e.g., `--limit`, `--sample`, `--booster`, `--sort`, `--grep`, `--colors`, `--cmc`, `--mechanic`).
 
 ---
 

--- a/decode.py
+++ b/decode.py
@@ -3,7 +3,6 @@ import sys
 import os
 import zipfile
 import random
-import copy
 # tqdm is imported inside main/helpers or at top level if we want it global
 try:
     from tqdm import tqdm
@@ -118,58 +117,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
                                   mechanics=mechanics,
-                                  shuffle=shuffle, seed=seed, decklist_file=decklist_file)
-
-    if booster > 0:
-        if seed is not None:
-            random.seed(seed)
-
-        # Group by rarity using markers from utils
-        commons = [c for c in cards if c.rarity == utils.rarity_common_marker]
-        uncommons = [c for c in cards if c.rarity == utils.rarity_uncommon_marker]
-        rares = [c for c in cards if c.rarity in [utils.rarity_rare_marker, utils.rarity_mythic_marker]]
-        lands = [c for c in cards if c.rarity == utils.rarity_basic_land_marker]
-
-        # Fallback to all cards if a category is empty to avoid crashing
-        # but try to be smart about lands
-        if not commons:
-            if verbose: print("Warning: No commons found for booster generation, using all available cards.", file=sys.stderr)
-            commons = cards
-        if not uncommons:
-            if verbose: print("Warning: No uncommons found for booster generation, using all available cards.", file=sys.stderr)
-            uncommons = cards
-        if not rares:
-            if verbose: print("Warning: No rares/mythics found for booster generation, using all available cards.", file=sys.stderr)
-            rares = cards
-        if not lands:
-            # Try to find lands by type if no basic land rarity marker
-            lands = [c for c in cards if 'land' in [t.lower() for t in c.types]]
-            if not lands:
-                if verbose: print("Warning: No lands found for booster generation, using all available cards.", file=sys.stderr)
-                lands = cards
-
-        new_cards = []
-        for p in range(booster):
-            pack = []
-            # Standard distribution: 10 Commons, 3 Uncommons, 1 Rare/Mythic, 1 Land
-            # Use random.sample to avoid duplicates within each rarity slot in a single pack
-            pack.extend(random.sample(commons, min(len(commons), 10)))
-            pack.extend(random.sample(uncommons, min(len(uncommons), 3)))
-            pack.extend(random.sample(rares, min(len(rares), 1)))
-            pack.extend(random.sample(lands, min(len(lands), 1)))
-
-            # Tag cards with pack info for headers
-            for c in pack:
-                # We need a copy because the same card might appear in multiple packs
-                # and we want them to have distinct pack_id tags if we were to use them.
-                # However, for simplicity and performance, we'll just tag them.
-                # If the same object is in multiple packs, the last tag wins.
-                # To fix this, we'll use copies.
-                c_copy = copy.copy(c)
-                c_copy.pack_id = p + 1
-                new_cards.append(c_copy)
-
-        cards = new_cards
+                                  shuffle=shuffle, seed=seed, decklist_file=decklist_file,
+                                  booster=booster)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -839,7 +788,7 @@ if __name__ == '__main__':
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --shuffle --limit N).')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--booster', type=int, default=0,
                         help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')

--- a/encode.py
+++ b/encode.py
@@ -20,7 +20,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          sets=None, rarities=None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
-         seed=None, decklist_file=None):
+         seed=None, decklist_file=None, booster=0):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
     fieldsep = utils.fieldsep
@@ -82,7 +82,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   pows=pows, tous=tous, loys=loys,
                                   mechanics=mechanics,
                                   shuffle=not stable, seed=seed if seed is not None else 1371367,
-                                  decklist_file=decklist_file)
+                                  decklist_file=decklist_file, booster=booster)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -166,8 +166,10 @@ if __name__ == '__main__':
                         help='Seed for the random number generator (Default: 1371367).')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --limit N). Shuffling is enabled unless --stable is used.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
                         help='Sort cards by a specific criterion (enables --stable).')
+    proc_group.add_argument('--booster', type=int, default=0,
+                        help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
     proc_group.add_argument('--grep-name', action='append',
@@ -243,5 +245,5 @@ if __name__ == '__main__':
          sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
-         seed=args.seed, decklist_file=args.deck)
+         seed=args.seed, decklist_file=args.deck, booster=args.booster)
     exit(0)

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1314,6 +1314,9 @@ class Card:
         if self.number:
             d['number'] = self.number
 
+        if hasattr(self, 'pack_id'):
+            d['pack_id'] = self.pack_id
+
         # B-Side (Recursive)
         if self.bside:
             d['bside'] = self.bside.to_dict()

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -6,6 +6,7 @@ import csv
 import zipfile
 import random
 import io
+import copy
 import xml.etree.ElementTree as ET
 
 import utils
@@ -776,7 +777,7 @@ def mtg_open_file(fname, verbose = False,
                   mechanics=None,
                   shuffle=False, seed=None,
                   decklist_file=None,
-                  stats=None):
+                  stats=None, booster=0):
     """
     High-level entry point for loading card data from various formats.
     Supported formats: JSON, JSONL, CSV, Magic Set Editor (.mse-set),
@@ -785,6 +786,9 @@ def mtg_open_file(fname, verbose = False,
     Decklist support includes "auto-hydration": if a decklist is provided as
     the primary input and data/AllPrintings.json exists, the tool will
     automatically resolve card names into full Card objects.
+
+    The `booster` parameter simulates opening N Magic booster packs from the
+    resulting card pool, following a standard 10/3/1/1 rarity distribution.
 
     Returns a list of cardlib.Card objects.
     """
@@ -1279,4 +1283,58 @@ def mtg_open_file(fname, verbose = False,
             random.seed(seed)
         random.shuffle(cards)
 
+    if booster > 0:
+        cards = _simulate_boosters(cards, booster, seed=seed, verbose=verbose)
+
     return _check_parsing_quality(cards, report_fobj)
+
+def _simulate_boosters(cards, count, seed=None, verbose=False):
+    """
+    Simulates opening Magic booster packs from a pool of cards.
+    Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land.
+    """
+    if seed is not None:
+        random.seed(seed)
+
+    # Group by rarity using markers from utils
+    commons = [c for c in cards if c.rarity == utils.rarity_common_marker]
+    uncommons = [c for c in cards if c.rarity == utils.rarity_uncommon_marker]
+    rares = [c for c in cards if c.rarity in [utils.rarity_rare_marker, utils.rarity_mythic_marker]]
+    lands = [c for c in cards if c.rarity == utils.rarity_basic_land_marker]
+
+    # Fallback to all cards if a category is empty to avoid crashing
+    # but try to be smart about lands
+    if not commons:
+        if verbose: print("Warning: No commons found for booster generation, using all available cards.", file=sys.stderr)
+        commons = cards
+    if not uncommons:
+        if verbose: print("Warning: No uncommons found for booster generation, using all available cards.", file=sys.stderr)
+        uncommons = cards
+    if not rares:
+        if verbose: print("Warning: No rares/mythics found for booster generation, using all available cards.", file=sys.stderr)
+        rares = cards
+    if not lands:
+        # Try to find lands by type if no basic land rarity marker
+        lands = [c for c in cards if 'land' in [t.lower() for t in c.types]]
+        if not lands:
+            if verbose: print("Warning: No lands found for booster generation, using all available cards.", file=sys.stderr)
+            lands = cards
+
+    new_cards = []
+    for p in range(count):
+        pack = []
+        # Standard distribution: 10 Commons, 3 Uncommons, 1 Rare/Mythic, 1 Land
+        # Use random.sample to avoid duplicates within each rarity slot in a single pack
+        pack.extend(random.sample(commons, min(len(commons), 10)))
+        pack.extend(random.sample(uncommons, min(len(uncommons), 3)))
+        pack.extend(random.sample(rares, min(len(rares), 1)))
+        pack.extend(random.sample(lands, min(len(lands), 1)))
+
+        # Tag cards with pack info for headers
+        for c in pack:
+            # Use copy to allow distinct pack_id tags for the same card appearing in multiple packs
+            c_copy = copy.copy(c)
+            c_copy.pack_id = p + 1
+            new_cards.append(c_copy)
+
+    return new_cards

--- a/lib/sortlib.py
+++ b/lib/sortlib.py
@@ -92,6 +92,8 @@ def sort_cards(cards, criterion, quiet=False):
         return sorted(cards, key=lambda c: _get_numeric_sort_key(c.pt_t))
     elif criterion == 'loyalty':
         return sorted(cards, key=lambda c: _get_numeric_sort_key(c.loyalty))
+    elif criterion == 'pack':
+        return sorted(cards, key=lambda c: (getattr(c, 'pack_id', 0), c.name.lower()))
     elif criterion == 'set':
         def get_set_key(card):
             s = card.set_code.upper() if card.set_code else 'ZZZ'

--- a/scripts/splitcards.py
+++ b/scripts/splitcards.py
@@ -45,7 +45,7 @@ def main():
                         help='Seed for the random number generator (Default: 1371367).')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --limit N). Shuffling is enabled unless --stable is used.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
                         help='Sort cards by a specific criterion (enables --stable).')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
@@ -93,6 +93,8 @@ def main():
                         help='Only include cards with specific mechanical features or keyword abilities. Supports multiple values.')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file.')
+    proc_group.add_argument('--booster', type=int, default=0,
+                        help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
 
     # Group: Logging & Debugging
     log_group = parser.add_argument_group('Logging & Debugging')
@@ -140,7 +142,7 @@ def main():
                                   pows=args.pow, tous=args.tou, loys=args.loy,
                                   mechanics=args.mechanic,
                                   shuffle=not args.stable, seed=args.seed if args.seed is not None else 1371367,
-                                  decklist_file=args.deck)
+                                  decklist_file=args.deck, booster=args.booster)
 
     if args.sort:
         cards = sortlib.sort_cards(cards, args.sort, quiet=args.quiet)

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -30,7 +30,8 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
-         shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None):
+         shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None,
+         booster = 0, sort = None):
 
     # Set default format to JSON if no specific output format is selected and outfile is .json
     if not json_out and oname and oname.endswith('.json'):
@@ -57,7 +58,11 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
                                   exclude_layouts=lambda x: False,
                                   shuffle=shuffle, seed=seed,
                                   decklist_file=decklist_file,
-                                  stats=search_stats)
+                                  stats=search_stats,
+                                  booster=booster)
+
+    if sort:
+        cards = sortlib.sort_cards(cards, sort, quiet=quiet)
 
     if limit > 0:
         cards = cards[:limit]
@@ -123,6 +128,8 @@ if __name__ == '__main__':
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --shuffle --limit N).')
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
+                        help='Sort cards by a specific criterion.')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
     proc_group.add_argument('--grep-name', action='append',
@@ -169,6 +176,8 @@ if __name__ == '__main__':
                         help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
+    proc_group.add_argument('--booster', type=int, default=0,
+                        help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
     
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -203,5 +212,6 @@ if __name__ == '__main__':
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
-         shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck)
+         shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck,
+         booster = args.booster, sort = args.sort)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -254,7 +254,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
-         shuffle = False, seed = None, decklist_file = None):
+         shuffle = False, seed = None, decklist_file = None,
+         booster = 0):
 
     # Determine format
     fmt_ordered = cardlib.fmt_ordered_default
@@ -291,7 +292,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
                                   shuffle=shuffle, seed=seed,
-                                  decklist_file=decklist_file)
+                                  decklist_file=decklist_file,
+                                  booster=booster)
 
     if sort:
         cards = sortlib.sort_cards(cards, sort, quiet=quiet)
@@ -409,7 +411,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
     proc_group = parser.add_argument_group('Processing Options')
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Only process the first N cards.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--shuffle', action='store_true',
                         help='Randomize the order of cards before sorting.')
@@ -463,6 +465,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     proc_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
+    proc_group.add_argument('--booster', type=int, default=0,
+                        help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
     proc_group.add_argument('--summary', action='store_true',
                         help='Output compact card summaries instead of full encoded text.')
     proc_group.add_argument('--md', '--markdown', action='store_true',
@@ -515,7 +519,8 @@ Supports any encoding format supported by encode.py/decode.py.""",
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
-         shuffle = args.shuffle, seed = args.seed, decklist_file = args.deck)
+         shuffle = args.shuffle, seed = args.seed, decklist_file = args.deck,
+         booster = args.booster)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
This PR implements universal booster simulation support across the entire Magic: The Gathering Card Encoder toolset. 

Previously, booster simulation was a local feature limited to `decode.py`. This change refactors the logic into the core library (`lib/jdecode.py`), allowing any tool using the standard loader to process data as simulated booster packs.

Key Changes:
1. **Centralized Logic**: Moved booster generation to `jdecode._simulate_boosters()`, implementing the standard 10/3/1/1 rarity distribution and robust fallbacks.
2. **Suite-wide Exposure**: Added the `--booster N` flag to `encode.py`, `scripts/summarize.py`, `sortcards.py`, and `scripts/splitcards.py`.
3. **Enhanced Metadata**: Updated `Card.to_dict()` and JSON exporters to preserve `pack_id` information.
4. **Improved UX**: Introduced a new 'pack' sorting criterion to easily group generated cards.
5. **Documentation**: Updated `README.md` to reflect universal support.

This enables powerful new workflows, such as generating mechanical summaries of draft environments or creating training/validation sets that preserve pack structure. Verified with the full test suite (470/470 passed).

---
*PR created automatically by Jules for task [4518943023073695101](https://jules.google.com/task/4518943023073695101) started by @RainRat*