### PR TITLE
Improve robustness of card rarity parsing

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -289,10 +289,13 @@ def fields_from_json(src_json, linetrans = True):
         
 
     if 'rarity' in src_json:
-        if src_json['rarity'] in utils.json_rarity_map:
-            fields[field_rarity] = [(-1, utils.json_rarity_map[src_json['rarity']])]
+        rarity_val = src_json['rarity']
+        if rarity_val in utils.json_rarity_map:
+            fields[field_rarity] = [(-1, utils.json_rarity_map[rarity_val])]
+        elif hasattr(rarity_val, 'lower') and rarity_val.lower() in utils.json_rarity_map:
+            fields[field_rarity] = [(-1, utils.json_rarity_map[rarity_val.lower()])]
         else:
-            fields[field_rarity] = [(-1, src_json['rarity'])]
+            fields[field_rarity] = [(-1, rarity_val)]
             parsed = False
     else:
         parsed = False

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -494,7 +494,7 @@ def mtg_open_mse_content(content, verbose=False):
         d = {
             'name': c.get('name', ''),
             'manaCost': _format_mana_json(c.get('casting cost', '')),
-            'rarity': c.get('rarity', '').capitalize(),
+            'rarity': c.get('rarity', ''),
             'text': c.get('rule text', ''),
         }
         if c.get('power'): d['power'] = c['power']
@@ -536,7 +536,7 @@ def mtg_open_mse_content(content, verbose=False):
             b = {
                 'name': c.get('name 2', ''),
                 'manaCost': _format_mana_json(c.get('casting cost 2', '')),
-                'rarity': c.get('rarity 2', d['rarity']).capitalize(),
+                'rarity': c.get('rarity 2', d['rarity']),
                 'text': c.get('rule text 2', ''),
             }
             if c.get('power 2'): b['power'] = c['power 2']

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -62,11 +62,13 @@ json_rarity_map = {
     'Rare' : rarity_rare_marker,
     'rare' : rarity_rare_marker,
     'Mythic Rare' : rarity_mythic_marker,
+    'mythic rare' : rarity_mythic_marker,
     'Mythic' : rarity_mythic_marker,
     'mythic' : rarity_mythic_marker,
     'Special' : rarity_special_marker,
     'special' : rarity_special_marker,
     'Basic Land' : rarity_basic_land_marker,
+    'basic land' : rarity_basic_land_marker,
 }
 json_rarity_unmap = {v: k for k, v in json_rarity_map.items()}
 


### PR DESCRIPTION
### What:
- Expanded `json_rarity_map` in `lib/utils.py` to include lowercase versions of multi-word rarities ('mythic rare', 'basic land').
- Updated `fields_from_json` in `lib/cardlib.py` to perform case-insensitive lookups against the rarity map.
- Removed problematic `.capitalize()` calls in the MSE loader (`lib/jdecode.py`) that were corrupting multi-word rarity strings.

### Why:
- Fixed a logic bug where multi-word rarities from MSE files (e.g., "mythic rare") were being converted to "Mythic rare", failing the subsequent lookup and causing the card to be marked as invalid/unparsed. The system is now significantly more robust to variations in input casing across different data sources. No breaking changes were introduced; existing mappings and behaviors for single-word rarities are preserved.

---
*PR created automatically by Jules for task [16786018240667472309](https://jules.google.com/task/16786018240667472309) started by @RainRat*