### PR TITLE
[TEST] Improve mechanical profiling and rarity parsing robustness

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -289,7 +289,12 @@ def fields_from_json(src_json, linetrans = True):
         
 
     if 'rarity' in src_json:
-        if src_json['rarity'] in utils.json_rarity_map:
+        # Use lowercase for robust rarity lookup
+        rarity_key = src_json['rarity'].lower() if hasattr(src_json['rarity'], 'lower') else src_json['rarity']
+        # Also try direct match if lowercase lookup fails (just in case)
+        if rarity_key in utils.json_rarity_map:
+            fields[field_rarity] = [(-1, utils.json_rarity_map[rarity_key])]
+        elif src_json['rarity'] in utils.json_rarity_map:
             fields[field_rarity] = [(-1, utils.json_rarity_map[src_json['rarity']])]
         else:
             fields[field_rarity] = [(-1, src_json['rarity'])]
@@ -605,6 +610,12 @@ class Card:
     def mechanics(self):
         """Returns a set of mechanical features and keyword abilities identified on the card."""
         text_raw = self.text.text.lower()
+        # To handle cards named after keywords (e.g., card "Exile" with rule text "@ target..."),
+        # we create a search string where @ is replaced by the card name.
+        # We replace spaces with underscores to avoid false positives from names like "Trample Bear".
+        safe_name = self.name.lower().replace(' ', '_')
+        text_search = text_raw.replace(utils.this_marker, safe_name)
+
         text_enc = self.text.encode().lower()
         cost_enc = self.cost.encode()
 
@@ -616,12 +627,12 @@ class Card:
 
         # Triggered: check start of lines
         for mt in self.text_lines:
-            line = mt.text.lower().strip()
+            line = mt.text.lower().strip().replace(utils.this_marker, safe_name)
             if line.startswith('when') or line.startswith('whenever') or line.startswith('at '):
                 m.add('Triggered')
                 break
 
-        if 'enters the battlefield' in text_raw or 'enters,' in text_raw or 'enters.' in text_raw:
+        if 'enters the battlefield' in text_search or 'enters,' in text_search or 'enters.' in text_search:
             m.add('ETB Effect')
 
         if utils.choice_open_delimiter in text_enc or utils.choice_close_delimiter in text_enc or '=' in text_enc:
@@ -658,7 +669,7 @@ class Card:
 
         for pattern, label in keywords:
             # Use word boundaries for keywords to avoid partial matches
-            if re.search(r'\b' + pattern + r'\b', text_raw):
+            if re.search(r'\b' + pattern + r'\b', text_search):
                 m.add(label)
 
         # Recursive profiling for split/double-faced cards

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -62,11 +62,13 @@ json_rarity_map = {
     'Rare' : rarity_rare_marker,
     'rare' : rarity_rare_marker,
     'Mythic Rare' : rarity_mythic_marker,
+    'mythic rare' : rarity_mythic_marker,
     'Mythic' : rarity_mythic_marker,
     'mythic' : rarity_mythic_marker,
     'Special' : rarity_special_marker,
     'special' : rarity_special_marker,
     'Basic Land' : rarity_basic_land_marker,
+    'basic land' : rarity_basic_land_marker,
 }
 json_rarity_unmap = {v: k for k, v in json_rarity_map.items()}
 

--- a/tests/test_qa_gap_analysis.py
+++ b/tests/test_qa_gap_analysis.py
@@ -1,0 +1,79 @@
+import pytest
+import sys
+import os
+
+# Ensure lib is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from lib.cardlib import Card
+from lib import utils
+
+def test_mechanics_keyword_as_name():
+    """Verify that keywords are identified even when the card name is the keyword."""
+    # Test 'Exile' (Alliances)
+    exile_card = Card({
+        "name": "Exile",
+        "manaCost": "{2}{W}",
+        "types": ["Instant"],
+        "text": "Exile target nonwhite attacking creature. You gain life equal to its toughness.",
+        "rarity": "Rare"
+    })
+    assert 'Exile' in exile_card.mechanics
+
+    # Test 'Flying'
+    flying_card = Card({
+        "name": "Flying",
+        "types": ["Creature"],
+        "text": "Flying",
+        "rarity": "Common",
+        "power": "1",
+        "toughness": "1"
+    })
+    assert 'Flying' in flying_card.mechanics
+
+def test_mechanics_keyword_in_name_collision_prevention():
+    """Verify that we don't get false positives for keywords when they are part of a longer name."""
+    # A card named "Trample Bear" should not have "Trample" just because of its name.
+    # The name replacement results in "trample_bear" which should NOT match "\btrample\b".
+    trample_bear = Card({
+        "name": "Trample Bear",
+        "types": ["Creature"],
+        "text": "When @ enters the battlefield, do nothing.",
+        "rarity": "Common",
+        "power": "2",
+        "toughness": "2"
+    })
+    assert 'Trample' not in trample_bear.mechanics
+    assert 'ETB Effect' in trample_bear.mechanics
+
+def test_rarity_parsing_case_robustness():
+    """Verify that rarity parsing is case-insensitive and handles 'basic land'."""
+    # Test lowercase basic land
+    basic_land_lower = Card({
+        "name": "Plains",
+        "types": ["Land"],
+        "rarity": "basic land"
+    })
+    assert basic_land_lower.rarity == utils.rarity_basic_land_marker
+    assert basic_land_lower.parsed
+
+    # Test mixed case rarity
+    mythic_mixed = Card({
+        "name": "Mixed Mythic",
+        "types": ["Sorcery"],
+        "rarity": "mYtHiC rArE"
+    })
+    assert mythic_mixed.rarity == utils.rarity_mythic_marker
+    assert mythic_mixed.parsed
+
+def test_mechanics_triggered_as_name():
+    """Verify that trigger keywords are identified even when the card name is the trigger word."""
+    at_card = Card({
+        "name": "At",
+        "types": ["Enchantment"],
+        "text": "At the beginning of your upkeep, win.",
+        "rarity": "Rare"
+    })
+    # The text becomes "@ the beginning of your upkeep, win."
+    # Our fix ensures line.startswith('at ') works because line is @-replaced.
+    assert 'Triggered' in at_card.mechanics


### PR DESCRIPTION
This PR addresses two robustness issues in the card parsing logic:

1. **Gap in Mechanical Profiling**: The `Card.mechanics` property previously failed to identify keywords if they were replaced by the `@` marker (which happens if the card name matches the keyword). The fix ensures keywords like 'Exile' or 'Flying' are detected even when they are the card's name.
2. **Brittle Rarity Mapping**: Rarity lookups were case-sensitive and missing some common variations like 'basic land' in lowercase. This caused some valid JSON cards to be marked as invalid.

Changes:
- Modified `lib/cardlib.py` to use a name-substituted search string in `mechanics`.
- Updated `lib/cardlib.py` to use case-insensitive rarity lookups in `fields_from_json`.
- Updated `lib/utils.py` with missing lowercase rarity entries.
- Added `tests/test_qa_gap_analysis.py` with new test cases.

All 487 tests passed.

---
*PR created automatically by Jules for task [6229513537778357700](https://jules.google.com/task/6229513537778357700) started by @RainRat*