### PR TITLE
[UI/UX] Add CMC column and improve numeric alignment in tables

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -211,11 +211,11 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
         if for_md_table:
             if booster > 0:
-                writer.write("| Pack | Name | Cost | Type | Stats | Rules Text | Rarity |\n")
-                writer.write("| :--- | :--- | :--- | :--- | :--- | :--- | :--- |\n")
+                writer.write("| Pack | Name | Cost | CMC | Type | Stats | Rules Text | Rarity |\n")
+                writer.write("| ---: | :--- | :--- | ---: | :--- | ---: | :--- | :--- |\n")
             else:
-                writer.write("| Name | Cost | Type | Stats | Rules Text | Rarity |\n")
-                writer.write("| :--- | :--- | :--- | :--- | :--- | :--- |\n")
+                writer.write("| Name | Cost | CMC | Type | Stats | Rules Text | Rarity |\n")
+                writer.write("| :--- | :--- | ---: | :--- | ---: | :--- | :--- |\n")
         if for_mse:
             # have to prepend a massive chunk of formatting info
             writer.write(utils.mse_prepend)
@@ -294,7 +294,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 use_color = True
 
             rows = []
-            header = ["Name", "Cost", "Type", "Stats", "Rarity"]
+            header = ["Name", "Cost", "CMC", "Type", "Stats", "Rarity"]
             if booster > 0:
                 header.insert(0, "Pack")
             if use_color:
@@ -318,8 +318,13 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
             if booster > 0:
                 aligns[0] = 'r' # Right-align Pack column
 
-            # Right-align Stats column (index 3, or 4 if booster)
-            stats_idx = 4 if booster > 0 else 3
+            # Right-align CMC column (index 2, or 3 if booster)
+            cmc_idx = 3 if booster > 0 else 2
+            if cmc_idx < len(aligns):
+                aligns[cmc_idx] = 'r'
+
+            # Right-align Stats column (index 4, or 5 if booster)
+            stats_idx = 5 if booster > 0 else 4
             if stats_idx < len(aligns):
                 aligns[stats_idx] = 'r'
 

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -562,6 +562,11 @@ class Card:
         # Cost
         cost = self.cost.format(ansi_color=ansi_color)
 
+        # CMC
+        cmc = str(int(self.cost.cmc)) if self.cost.cmc == int(self.cost.cmc) else f"{self.cost.cmc:.1f}"
+        if ansi_color:
+            cmc = utils.colorize(cmc, utils.Ansi.BOLD + utils.Ansi.GREEN)
+
         # Type
         typeline = self.get_type_line()
         if ansi_color:
@@ -582,16 +587,17 @@ class Card:
         if ansi_color and rarity:
             rarity = utils.colorize(rarity, utils.Ansi.get_rarity_color(rarity))
 
-        return name, cost, typeline, stats, text, rarity
+        return name, cost, cmc, typeline, stats, text, rarity
 
     def _get_display_data(self, ansi_color=False, include_text=False):
         """Helper to get standardized display fields for the card, merging b-sides."""
-        name, cost, typeline, stats, text, rarity = self._get_single_face_display_data(ansi_color=ansi_color, include_text=include_text)
+        name, cost, cmc, typeline, stats, text, rarity = self._get_single_face_display_data(ansi_color=ansi_color, include_text=include_text)
 
         if self.bside:
-            b_name, b_cost, b_typeline, b_stats, b_text, b_rarity = self.bside._get_display_data(ansi_color=ansi_color, include_text=include_text)
+            b_name, b_cost, b_cmc, b_typeline, b_stats, b_text, b_rarity = self.bside._get_display_data(ansi_color=ansi_color, include_text=include_text)
             name = f"{name} // {b_name}"
             cost = f"{cost} // {b_cost}"
+            cmc = f"{cmc} // {b_cmc}"
             typeline = f"{typeline} // {b_typeline}"
             stats = f"{stats} // {b_stats}" if stats and b_stats else (stats or b_stats)
             if include_text:
@@ -599,7 +605,7 @@ class Card:
             if b_rarity and b_rarity != rarity:
                 rarity = f"{rarity} // {b_rarity}"
 
-        return name, cost, typeline, stats, text, rarity
+        return name, cost, cmc, typeline, stats, text, rarity
 
     @property
     def mechanics(self):
@@ -1472,19 +1478,19 @@ class Card:
 
     def to_markdown_row(self):
         """Returns a Markdown table row representation of the card."""
-        name, cost, typeline, stats, text, rarity = self._get_display_data(include_text=True)
+        name, cost, cmc, typeline, stats, text, rarity = self._get_display_data(include_text=True)
 
         # Escape pipe characters and ensure no actual newlines break the row
-        fields = [name, cost, typeline, stats, text, rarity]
+        fields = [name, cost, cmc, typeline, stats, text, rarity]
         fields = [f.replace('|', '\\|').replace('\n', ' ') for f in fields]
 
         return f"| {' | '.join(fields)} |"
 
     def to_table_row(self, ansi_color=False):
         """Returns a list of strings representing the card's fields for a terminal table."""
-        name, cost, typeline, stats, _, rarity = self._get_display_data(ansi_color=ansi_color)
+        name, cost, cmc, typeline, stats, _, rarity = self._get_display_data(ansi_color=ansi_color)
 
-        return [name, cost, typeline, stats, rarity]
+        return [name, cost, cmc, typeline, stats, rarity]
 
     def vectorize(self):
         """Vectorizes the card data into a string format suitable for machine learning.

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -44,13 +44,13 @@ def test_markdown_table_format():
     src = "|1Table Card|5Creature|6Human|3{WW}|8&^/&^|9Lifelink|0O"
     card = cardlib.Card(src)
     row = card.to_markdown_row()
-    assert "| Table Card | {W} | Creature — Human | 1/1 | Lifelink | common |" in row
+    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | common |" in row
 
 def test_markdown_table_split_card():
     src = "|1Fire|5Sorcery|3{RR}|9Fire deals &^^ damage to any target.\n|1Ice|5Sorcery|3{^}{UU}|9Draw a card."
     card = cardlib.Card(src)
     row = card.to_markdown_row()
-    assert "| Fire // Ice | {R} // {1}{U} | Sorcery // Sorcery |  | Fire deals 2 damage to any target.<br>---<br>Draw a card. |  |" in row
+    assert "| Fire // Ice | {R} // {1}{U} | 1 // 2 | Sorcery // Sorcery |  | Fire deals 2 damage to any target.<br>---<br>Draw a card. |  |" in row
 
 def test_decode_markdown_table_cli(tmp_path):
     infile = tmp_path / "input.txt"
@@ -61,8 +61,8 @@ def test_decode_markdown_table_cli(tmp_path):
     decode.main(str(infile), str(outfile), quiet=True, verbose=False)
 
     content = outfile.read_text(encoding="utf-8")
-    assert "| Name | Cost | Type | Stats | Rules Text | Rarity |" in content
-    assert "| Table Card | {W} | Creature — Human | 1/1 | Lifelink | common |" in content
+    assert "| Name | Cost | CMC | Type | Stats | Rules Text | Rarity |" in content
+    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | common |" in content
 
 def test_decode_markdown_table_flag(tmp_path):
     infile = tmp_path / "input.txt"
@@ -73,5 +73,5 @@ def test_decode_markdown_table_flag(tmp_path):
     decode.main(str(infile), str(outfile), md_table_out=True, quiet=True, verbose=False)
 
     content = outfile.read_text(encoding="utf-8")
-    assert "| Name | Cost | Type | Stats | Rules Text | Rarity |" in content
-    assert "| Flag Card | {G} | Sorcery |  | Add {G}. | rare |" in content
+    assert "| Name | Cost | CMC | Type | Stats | Rules Text | Rarity |" in content
+    assert "| Flag Card | {G} | 1 | Sorcery |  | Add {G}. | rare |" in content

--- a/tests/test_table_output.py
+++ b/tests/test_table_output.py
@@ -22,7 +22,7 @@ def test_to_table_row():
     print(f"Row: {row}")
     # Rarity is lowercase from MTGJSON if not in map, but Card(card_json) uses fields_from_json
     # which uses utils.json_rarity_map if available.
-    assert row == ["Grizzly Bears", "{1}{G}", "Creature \u2014 Bear", "2/2", "common"]
+    assert row == ["Grizzly Bears", "{1}{G}", "2", "Creature \u2014 Bear", "2/2", "common"]
 
 def test_to_table_row_bside():
     card_json = {
@@ -40,7 +40,7 @@ def test_to_table_row_bside():
     card = Card(card_json)
     row = card.to_table_row(ansi_color=False)
     print(f"Bside Row: {row}")
-    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "Instant // Instant", "", "uncommon"]
+    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "2 // 2", "Instant // Instant", "", "uncommon"]
 
 def test_cli_table():
     # Encode a sample card and decode it with --table


### PR DESCRIPTION
This PR introduces a significant usability improvement to the card decoding tools by adding a 'CMC' column to the table-based outputs (`--table` and `--md-table`). CMC is a critical metric for evaluating Magic cards, and adding it reduces cognitive load for users who previously had to manually calculate it from mana symbols.

Additionally, the PR improves the visual hierarchy of these tables by right-aligning all numeric-intensive columns ('CMC', 'Stats', and 'Pack'). This follows standard HCI principles for tabular data, making vertical comparisons much faster and more accurate.

Changes include:
- Centralized CMC display logic in `lib/cardlib.py`.
- Updated header and alignment configurations in `decode.py`.
- Updated test suites in `tests/test_table_output.py` and `tests/test_markdown_output.py` to ensure continued correctness.

---
*PR created automatically by Jules for task [17847941553704821464](https://jules.google.com/task/17847941553704821464) started by @RainRat*