### PR TITLE
[FEAT] Add mtg_diff.py for comparing card datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,20 @@ python3 scripts/mtg_validate.py data/AllPrintings.json --dump
     *   `-d`, `--dump`: Print full details for cards that failed validation.
     *   `-v`, `--verbose`: Enable detailed status messages.
 
+### `mtg_diff.py`
+Compares two card datasets and identifies additions, removals, and modifications. It highlights changes in cost, type, stats, text, and rarity.
+```bash
+# Compare two JSON datasets
+python3 scripts/mtg_diff.py data/OldSet.json data/NewSet.json
+
+# Compare encoded text against official data
+python3 scripts/mtg_diff.py data/AllPrintings.json generated_cards.txt
+```
+*   **Options:**
+    *   `--summary-only`: Only show count summary, not detailed card diffs.
+    *   `--color` / `--no-color`: Enable or disable ANSI color output.
+    *   Supports all **Advanced Filtering** flags (e.g., `--grep`, `--set`, `--rarity`).
+
 ### `csv2json.py` & `combinejson.py`
 Used for integrating custom cards into your dataset. See [CUSTOM.md](CUSTOM.md) for a full guide.
 ```bash

--- a/scripts/mtg_diff.py
+++ b/scripts/mtg_diff.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+import sys
+import os
+import argparse
+from collections import OrderedDict
+
+# Add lib directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+import utils
+import jdecode
+import cardlib
+
+def get_card_map(cards):
+    """Groups cards by name for easier comparison."""
+    m = OrderedDict()
+    for c in cards:
+        name = c.name.lower()
+        if name not in m:
+            m[name] = c
+    return m
+
+def compare_cards(c1, c2):
+    """Compares two card objects and returns a list of differences."""
+    diffs = []
+
+    # 1. Mana Cost
+    if c1.cost.format() != c2.cost.format():
+        diffs.append(('Cost', c1.cost.format(), c2.cost.format()))
+
+    # 2. Type Line
+    if c1.get_type_line() != c2.get_type_line():
+        diffs.append(('Type', c1.get_type_line(), c2.get_type_line()))
+
+    # 3. Stats (P/T)
+    s1 = c1._get_pt_display(include_parens=False)
+    s2 = c2._get_pt_display(include_parens=False)
+    if s1 != s2:
+        diffs.append(('P/T', s1, s2))
+
+    # 4. Loyalty / Defense
+    l1 = c1._get_loyalty_display(include_parens=False)
+    l2 = c2._get_loyalty_display(include_parens=False)
+    if l1 != l2:
+        diffs.append(('Loyalty/Defense', l1, l2))
+
+    # 5. Rules Text
+    t1 = c1.get_text(force_unpass=True)
+    t2 = c2.get_text(force_unpass=True)
+    if t1 != t2:
+        diffs.append(('Text', t1, t2))
+
+    # 6. Rarity
+    if c1.rarity_name != c2.rarity_name:
+        diffs.append(('Rarity', c1.rarity_name, c2.rarity_name))
+
+    # B-side recursive comparison
+    if c1.bside and c2.bside:
+        b_diffs = compare_cards(c1.bside, c2.bside)
+        for field, v1, v2 in b_diffs:
+            diffs.append((f'B-Side {field}', v1, v2))
+    elif c1.bside:
+        diffs.append(('B-Side', 'Present', 'Missing'))
+    elif c2.bside:
+        diffs.append(('B-Side', 'Missing', 'Present'))
+
+    return diffs
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare two Magic: The Gathering card datasets and identify additions, removals, and modifications."
+    )
+
+    # Group: Input / Output
+    io_group = parser.add_argument_group('Input / Output')
+    io_group.add_argument('file1', help='The base card dataset (JSON, CSV, XML, encoded text, etc.).')
+    io_group.add_argument('file2', help='The target card dataset to compare against the base.')
+
+    # Group: Processing Options
+    proc_group = parser.add_argument_group('Processing Options')
+    proc_group.add_argument('-v', '--verbose', action='store_true', help='Enable detailed status messages.')
+    proc_group.add_argument('-q', '--quiet', action='store_true', help='Suppress the progress bar.')
+    proc_group.add_argument('--summary-only', action='store_true', help='Only show a summary of changes, not detailed card diffs.')
+
+    # Group: Filtering Options (Standard across tools)
+    filter_group = parser.add_argument_group('Filtering Options')
+    filter_group.add_argument('--grep', action='append', help='Only include cards matching a search pattern.')
+    filter_group.add_argument('--set', action='append', help='Only include cards from specific sets.')
+    filter_group.add_argument('--rarity', action='append', help='Only include cards of specific rarities.')
+    filter_group.add_argument('--colors', action='append', help='Only include cards of specific colors.')
+    filter_group.add_argument('--cmc', action='append', help='Only include cards with specific CMC values.')
+    filter_group.add_argument('--pow', '--power', action='append', dest='pow', help='Only include cards with specific Power values.')
+    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou', help='Only include cards with specific Toughness values.')
+    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy', help='Only include cards with specific Loyalty or Defense values.')
+    filter_group.add_argument('--mechanic', action='append', help='Only include cards with specific mechanical features.')
+
+    # Color options
+    color_group = parser.add_mutually_exclusive_group()
+    color_group.add_argument('--color', action='store_true', default=None, help='Force enable ANSI color output.')
+    color_group.add_argument('--no-color', action='store_false', dest='color', help='Disable ANSI color output.')
+
+    args = parser.parse_args()
+
+    # Determine if we should use color
+    use_color = False
+    if args.color is True:
+        use_color = True
+    elif args.color is None and sys.stdout.isatty():
+        use_color = True
+
+    # Load datasets
+    if args.verbose:
+        print(f"Loading {args.file1}...", file=sys.stderr)
+    cards1 = jdecode.mtg_open_file(args.file1, verbose=args.verbose,
+                                  grep=args.grep, sets=args.set, rarities=args.rarity,
+                                  colors=args.colors, cmcs=args.cmc, pows=args.pow,
+                                  tous=args.tou, loys=args.loy, mechanics=args.mechanic)
+
+    if args.verbose:
+        print(f"Loading {args.file2}...", file=sys.stderr)
+    cards2 = jdecode.mtg_open_file(args.file2, verbose=args.verbose,
+                                  grep=args.grep, sets=args.set, rarities=args.rarity,
+                                  colors=args.colors, cmcs=args.cmc, pows=args.pow,
+                                  tous=args.tou, loys=args.loy, mechanics=args.mechanic)
+
+    map1 = get_card_map(cards1)
+    map2 = get_card_map(cards2)
+
+    added = []
+    removed = []
+    modified = []
+
+    # Check for removals and modifications
+    for name, c1 in map1.items():
+        if name not in map2:
+            removed.append(c1)
+        else:
+            c2 = map2[name]
+            diffs = compare_cards(c1, c2)
+            if diffs:
+                modified.append((c2, diffs))
+
+    # Check for additions
+    for name, c2 in map2.items():
+        if name not in map1:
+            added.append(c2)
+
+    # Output report
+    header_color = utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE
+    added_color = utils.Ansi.BOLD + utils.Ansi.GREEN
+    removed_color = utils.Ansi.BOLD + utils.Ansi.RED
+    mod_color = utils.Ansi.BOLD + utils.Ansi.YELLOW
+
+    def print_header(text):
+        if use_color:
+            print(utils.colorize(text, header_color))
+        else:
+            print(f"=== {text} ===")
+
+    print_header("SUMMARY")
+    print(f"  Added:    {len(added)}")
+    print(f"  Removed:  {len(removed)}")
+    print(f"  Modified: {len(modified)}")
+    print(f"  Shared:   {len(map1.keys() & map2.keys())}")
+    print()
+
+    if args.summary_only:
+        return
+
+    if removed:
+        print_header("REMOVED CARDS")
+        for c in removed:
+            name = c.name
+            if use_color:
+                name = utils.colorize(name, removed_color)
+            print(f"  - {name}")
+        print()
+
+    if added:
+        print_header("ADDED CARDS")
+        for c in added:
+            name = c.name
+            if use_color:
+                name = utils.colorize(name, added_color)
+            print(f"  - {name}")
+        print()
+
+    if modified:
+        print_header("MODIFIED CARDS")
+        for c, diffs in modified:
+            name = c.name
+            if use_color:
+                name = utils.colorize(name, mod_color)
+            print(f"  * {name}")
+            for field, old, new in diffs:
+                if use_color:
+                    field_str = utils.colorize(f"    {field}:", utils.Ansi.CYAN)
+                    old_str = utils.colorize(str(old), utils.Ansi.RED)
+                    new_str = utils.colorize(str(new), utils.Ansi.GREEN)
+                    print(f"{field_str} {old_str} -> {new_str}")
+                else:
+                    print(f"    {field}: {old} -> {new}")
+        print()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have implemented `scripts/mtg_diff.py`, a new utility that allows users to compare two Magic: The Gathering card datasets. This script fills a gap in the project's data management capabilities, enabling users to easily see what has changed between different versions of a set or between AI-generated output and official training data.

The script leverages the project's core libraries (`jdecode`, `cardlib`, `utils`) to support all common input formats (JSON, CSV, XML, MSE, encoded text) and provides a clear, colorized report of the differences. It also includes "Advanced Filtering" support to allow targeted comparisons.

---
*PR created automatically by Jules for task [2196597725693344569](https://jules.google.com/task/2196597725693344569) started by @RainRat*