### PR TITLE
[TEST] [GAP ANALYSIS] Add Defender mechanic recognition and coverage

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -668,9 +668,9 @@ class Card:
             ('haste', 'Haste'), ('deathtouch', 'Deathtouch'), ('vigilance', 'Vigilance'),
             ('ward', 'Ward'), ('prowess', 'Prowess'), ('menace', 'Menace'),
             ('reach', 'Reach'), ('flash', 'Flash'), ('indestructible', 'Indestructible'),
-            ('scry', 'Scry'), ('draw a card', 'Draw A Card'), ('mill', 'Mill'),
-            ('exile', 'Exile'), (r'tokens?', 'Token'), ('discard', 'Discard'),
-            ('cycling', 'Cycling')
+            ('defender', 'Defender'), ('scry', 'Scry'), ('draw a card', 'Draw A Card'),
+            ('mill', 'Mill'), ('exile', 'Exile'), (r'tokens?', 'Token'),
+            ('discard', 'Discard'), ('cycling', 'Cycling')
         ]
 
         for pattern, label in keywords:

--- a/tests/test_card_mechanics_comprehensive.py
+++ b/tests/test_card_mechanics_comprehensive.py
@@ -110,3 +110,32 @@ def test_mechanics_bside_recursive():
     }
     card = Card(split_card)
     assert 'Draw A Card' in card.mechanics
+
+def test_mechanics_defender_keyword():
+    """Verify that 'Defender' is identified as a keyword ability."""
+    card = Card({
+        "name": "Wall of Omens",
+        "manaCost": "{1}{W}",
+        "types": ["Creature"],
+        "subtypes": ["Wall"],
+        "text": "Defender\nWhen @ enters the battlefield, draw a card.",
+        "rarity": "Uncommon",
+        "power": "0",
+        "toughness": "4"
+    })
+    assert 'Defender' in card.mechanics
+    assert 'ETB Effect' in card.mechanics
+    assert 'Draw A Card' in card.mechanics
+
+def test_mechanics_defender_plural_boundary():
+    """Verify that 'Defender' does not match 'Defenders' or other partial words."""
+    card = Card({
+        "name": "Defender of Chaos",
+        "types": ["Creature"],
+        "text": "Defenders of the faith get +1/+1.",
+        "rarity": "Common",
+        "power": "2",
+        "toughness": "2"
+    })
+    # 'Defenders' should NOT trigger 'Defender'
+    assert 'Defender' not in card.mechanics


### PR DESCRIPTION
Add recognition for the 'Defender' keyword ability to the card mechanical profiling system. This improves the accuracy of summaries generated by `scripts/summarize.py`.

The implementation ensures that only standalone instances of 'Defender' are matched by using regex word boundaries, preventing misidentification in strings like "Defenders of the faith" or "Defending player".

New coverage includes:
- Verification of 'Defender' as a keyword ability.
- Negative tests for plural/substring variations.
- Integration into the existing comprehensive mechanics test suite.

---
*PR created automatically by Jules for task [13975896731673570748](https://jules.google.com/task/13975896731673570748) started by @RainRat*