### PR TITLE
[FEAT] Advanced Filtering for json2csv.py

### DIFF
--- a/scripts/json2csv.py
+++ b/scripts/json2csv.py
@@ -9,23 +9,91 @@ libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
 sys.path.append(libdir)
 import jdecode
 import cardlib
+import utils
 
 def main():
     parser = argparse.ArgumentParser(
         description="Converts MTG card data into the CSV format used by csv2json.py and the custom card template."
     )
-    parser.add_argument('infile', help='Input card data (JSON, JSONL, MSE, ZIP, or encoded text)')
-    parser.add_argument('outfile', help='Output CSV file path')
-    parser.add_argument('--set', action='append', help='Filter by set code (e.g., MOM)')
-    parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output')
+
+    # Group: Input / Output
+    io_group = parser.add_argument_group('Input / Output')
+    io_group.add_argument('infile', help='Input card data (JSON, JSONL, MSE, ZIP, or encoded text).')
+    io_group.add_argument('outfile', help='Output CSV file path.')
+
+    # Group: Filtering Options
+    filter_group = parser.add_argument_group('Filtering Options')
+    filter_group.add_argument('--grep', action='append',
+                        help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
+    filter_group.add_argument('--grep-name', action='append',
+                        help='Only include cards whose name matches a search pattern.')
+    filter_group.add_argument('--grep-type', action='append',
+                        help='Only include cards whose typeline matches a search pattern.')
+    filter_group.add_argument('--grep-text', action='append',
+                        help='Only include cards whose rules text matches a search pattern.')
+    filter_group.add_argument('--grep-cost', action='append',
+                        help='Only include cards whose mana cost matches a search pattern.')
+    filter_group.add_argument('--grep-pt', action='append',
+                        help='Only include cards whose power/toughness matches a search pattern.')
+    filter_group.add_argument('--grep-loyalty', action='append',
+                        help='Only include cards whose loyalty/defense matches a search pattern.')
+    filter_group.add_argument('--vgrep', '--exclude', action='append',
+                        help='Exclude cards matching a search pattern (checks name, type, and text). Use multiple times for OR logic.')
+    filter_group.add_argument('--exclude-name', action='append',
+                        help='Exclude cards whose name matches a search pattern.')
+    filter_group.add_argument('--exclude-type', action='append',
+                        help='Exclude cards whose typeline matches a search pattern.')
+    filter_group.add_argument('--exclude-text', action='append',
+                        help='Exclude cards whose rules text matches a search pattern.')
+    filter_group.add_argument('--exclude-cost', action='append',
+                        help='Exclude cards whose mana cost matches a search pattern.')
+    filter_group.add_argument('--exclude-pt', action='append',
+                        help='Exclude cards whose power/toughness matches a search pattern.')
+    filter_group.add_argument('--exclude-loyalty', action='append',
+                        help='Exclude cards whose loyalty/defense matches a search pattern.')
+    filter_group.add_argument('--set', action='append',
+                        help='Only include cards from specific sets (e.g., MOM, MRD). Supports multiple sets (OR logic).')
+    filter_group.add_argument('--rarity', action='append',
+                        help="Only include cards of specific rarities. Supports full names or shorthands (O, N, A, Y, I, L). Supports multiple rarities.")
+    filter_group.add_argument('--colors', action='append',
+                        help="Only include cards of specific colors (W, U, B, R, G, C/A). Supports multiple colors.")
+    filter_group.add_argument('--cmc', action='append',
+                        help='Only include cards with specific CMC values. Supports inequalities and ranges.')
+    filter_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities and ranges.')
+    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
+    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
+    filter_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities. Supports multiple values.')
+    filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
+                        help='Filter cards using a standard MTG decklist file.')
+
+    # Group: Logging & Debugging
+    debug_group = parser.add_argument_group('Logging & Debugging')
+    debug_group.add_argument('-v', '--verbose', action='store_true', help='Enable detailed status messages.')
 
     args = parser.parse_args()
 
     # Load cards using the standard loader
-    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose, sets=args.set)
+    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose,
+                                  grep=args.grep, vgrep=args.vgrep,
+                                  grep_name=args.grep_name, vgrep_name=args.exclude_name,
+                                  grep_types=args.grep_type, vgrep_types=args.exclude_type,
+                                  grep_text=args.grep_text, vgrep_text=args.exclude_text,
+                                  grep_cost=args.grep_cost, vgrep_cost=args.exclude_cost,
+                                  grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
+                                  grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
+                                  sets=args.set, rarities=args.rarity,
+                                  colors=args.colors, cmcs=args.cmc,
+                                  pows=args.pow, tous=args.tou, loys=args.loy,
+                                  mechanics=args.mechanic,
+                                  decklist_file=args.deck)
 
     if not cards:
-        print("No cards found matching the criteria.", file=sys.stderr)
+        if args.verbose:
+            print("No cards found matching the criteria.", file=sys.stderr)
         return
 
     with open(args.outfile, 'w', encoding='utf8', newline='') as f:
@@ -57,6 +125,9 @@ def main():
 
     if args.verbose:
         print(f"Successfully exported {len(cards)} cards to {args.outfile}")
+
+    # Also print a standard summary for consistency
+    utils.print_operation_summary("CSV Export", len(cards), 0, quiet=not args.verbose)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Enhanced `scripts/json2csv.py` with standard filtering options, including grep (global and field-specific), exclusions, and metadata filters (colors, CMC, rarity, power/toughness, mechanics, and set codes). This brings the utility tool in line with the rest of the MTG Card Encoder suite, enabling a more efficient workflow for custom card designers who need to export specific subsets of cards for editing.

---
*PR created automatically by Jules for task [8589068956759112079](https://jules.google.com/task/8589068956759112079) started by @RainRat*