### PR TITLE
Simplify mana_untranslate logic in lib/utils.py

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -510,36 +510,20 @@ def mana_untranslate(manastr, for_forum = False, for_html = False, ansi_color = 
             if idx == old_idx:
                 idx += 1
     
-    if for_html:
-        if jmanastr == '':
-            return mana_html_open_delimiter + str(colorless_total) + mana_html_close_delimiter
+    colorless_str = ''
+    if colorless_total > 0 or jmanastr == '':
+        if for_html:
+            colorless_str = f"{mana_html_open_delimiter}{colorless_total}{mana_html_close_delimiter}"
+        elif for_forum:
+            colorless_str = str(colorless_total)
         else:
-            return (('' if colorless_total == 0
-                     else mana_html_open_delimiter + str(colorless_total) + mana_html_close_delimiter)
-                    + jmanastr)
-
-    elif for_forum:
-        if jmanastr == '':
-            return mana_forum_open_delimiter + str(colorless_total) + mana_forum_close_delimiter
-        else:
-            return (mana_forum_open_delimiter + ('' if colorless_total == 0 
-                                                 else str(colorless_total))
-                    + jmanastr + mana_forum_close_delimiter)
-    else:
-        colorless_str = ''
-        if colorless_total > 0 or jmanastr == '':
-            colorless_str = mana_json_open_delimiter + str(colorless_total) + mana_json_close_delimiter
+            colorless_str = f"{mana_json_open_delimiter}{colorless_total}{mana_json_close_delimiter}"
             if ansi_color:
                 colorless_str = colorize(colorless_str, Ansi.BOLD)
 
-        if jmanastr == '':
-            return colorless_str
-        else:
-            # If jmanastr is not empty, we only include colorless if it's > 0
-            if colorless_total > 0:
-                return colorless_str + jmanastr
-            else:
-                return jmanastr
+    if for_forum:
+        return f"{mana_forum_open_delimiter}{colorless_str}{jmanastr}{mana_forum_close_delimiter}"
+    return f"{colorless_str}{jmanastr}"
 
 # finally, replacing all instances in a string
 # notice the calls to .upper(), this way we recognize lowercase symbols as well just in case


### PR DESCRIPTION
This PR refactors the `mana_untranslate` function in `lib/utils.py` to simplify its final assembly logic.

**What:**
- Replaced multiple redundant `if/elif/else` blocks with a centralized construction of the `colorless_str` component.
- Simplified the final return statements using consistent f-string formatting.
- Eliminated several redundant `jmanastr == ''` checks and nested ternary operators.

**Why:**
- **Readability:** The final assembly of the mana string is now much easier to follow.
- **Maintenance:** Future changes to mana formatting only need to be applied in one place rather than being scattered across format-specific branches.
- **Safety:** External behavior is identical, as verified by the existing test suite (`tests/test_utils.py`, `tests/test_manalib.py`).


---
*PR created automatically by Jules for task [1375833246168681624](https://jules.google.com/task/1375833246168681624) started by @RainRat*