### PR TITLE
Simplify rarity parsing logic in cardlib.py

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -291,11 +291,8 @@ def fields_from_json(src_json, linetrans = True):
     if 'rarity' in src_json:
         # Use lowercase for robust rarity lookup
         rarity_key = src_json['rarity'].lower() if hasattr(src_json['rarity'], 'lower') else src_json['rarity']
-        # Also try direct match if lowercase lookup fails (just in case)
         if rarity_key in utils.json_rarity_map:
             fields[field_rarity] = [(-1, utils.json_rarity_map[rarity_key])]
-        elif src_json['rarity'] in utils.json_rarity_map:
-            fields[field_rarity] = [(-1, utils.json_rarity_map[src_json['rarity']])]
         else:
             fields[field_rarity] = [(-1, src_json['rarity'])]
             parsed = False


### PR DESCRIPTION
This change addresses a Redundant Validation issue in lib/cardlib.py. The fields_from_json function previously performed two lookups against utils.json_rarity_map: one using a normalized lowercase key and another "just in case" fallback using the original input string. Since the map is comprehensively keyed and normalization is safe, the second check was redundant. Removal improves code clarity without changing behavior.

---
*PR created automatically by Jules for task [16034003949613066084](https://jules.google.com/task/16034003949613066084) started by @RainRat*