### PR TITLE
[UI/UX] Surface card mechanics in summaries and tables

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -296,7 +296,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         if for_table:
             import datalib
             rows = []
-            header = ["Name", "Cost", "CMC", "Type", "Stats", "Rarity"]
+            header = ["Name", "Cost", "CMC", "Type", "Stats", "Rarity", "Mechanics"]
             if booster > 0 or box > 0:
                 header.insert(0, "Pack")
             if box > 0:

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -592,14 +592,20 @@ class Card:
         if ansi_color and rarity:
             rarity = utils.colorize(rarity, utils.Ansi.get_rarity_color(rarity))
 
-        return name, cost, cmc, typeline, stats, text, rarity
+        # Mechanics
+        mech_list = sorted(list(self.get_face_mechanics()))
+        mechanics = ', '.join(mech_list)
+        if ansi_color and mechanics:
+            mechanics = utils.colorize(mechanics, utils.Ansi.CYAN)
+
+        return name, cost, cmc, typeline, stats, text, rarity, mechanics
 
     def _get_display_data(self, ansi_color=False, include_text=False):
         """Helper to get standardized display fields for the card, merging b-sides."""
-        name, cost, cmc, typeline, stats, text, rarity = self._get_single_face_display_data(ansi_color=ansi_color, include_text=include_text)
+        name, cost, cmc, typeline, stats, text, rarity, mechanics = self._get_single_face_display_data(ansi_color=ansi_color, include_text=include_text)
 
         if self.bside:
-            b_name, b_cost, b_cmc, b_typeline, b_stats, b_text, b_rarity = self.bside._get_display_data(ansi_color=ansi_color, include_text=include_text)
+            b_name, b_cost, b_cmc, b_typeline, b_stats, b_text, b_rarity, b_mechanics = self.bside._get_display_data(ansi_color=ansi_color, include_text=include_text)
             name = f"{name} // {b_name}"
             cost = f"{cost} // {b_cost}"
             cmc = f"{cmc} // {b_cmc}"
@@ -609,12 +615,13 @@ class Card:
                 text = f"{text}<br>---<br>{b_text}"
             if b_rarity and b_rarity != rarity:
                 rarity = f"{rarity} // {b_rarity}"
+            if b_mechanics:
+                mechanics = f"{mechanics} // {b_mechanics}" if mechanics else b_mechanics
 
-        return name, cost, cmc, typeline, stats, text, rarity
+        return name, cost, cmc, typeline, stats, text, rarity, mechanics
 
-    @property
-    def mechanics(self):
-        """Returns a set of mechanical features and keyword abilities identified on the card."""
+    def get_face_mechanics(self):
+        """Returns a set of mechanical features and keyword abilities identified on this card face."""
         text_raw = self.text.text.lower()
         # To handle cards named after keywords (e.g., card "Exile" with rule text "@ target..."),
         # we create a search string where @ is replaced by the card name.
@@ -677,6 +684,13 @@ class Card:
             # Use word boundaries for keywords to avoid partial matches
             if re.search(r'\b' + pattern + r'\b', text_search):
                 m.add(label)
+
+        return m
+
+    @property
+    def mechanics(self):
+        """Returns a set of mechanical features and keyword abilities identified on the card (including b-side)."""
+        m = self.get_face_mechanics()
 
         # Recursive profiling for split/double-faced cards
         if self.bside:
@@ -1111,10 +1125,18 @@ class Card:
         if not stats:
             stats = self._get_loyalty_display(ansi_color=ansi_color)
 
+        # Mechanics
+        mech_list = sorted(list(self.get_face_mechanics()))
+        mech_str = ', '.join(mech_list)
+        if ansi_color and mech_str:
+            mech_str = utils.colorize(mech_str, utils.Ansi.CYAN)
+
         # Construct final summary string with consistent bullet separators
         res = f'{status}{rarity_indicator}{cardname}{coststr} \u2022 {typeline}'
         if stats:
             res += f' \u2022 {stats}'
+        if mech_str:
+            res += f' \u2022 {mech_str}'
 
         if self.bside:
             res += ' // ' + self.bside.summary(ansi_color=ansi_color)
@@ -1491,19 +1513,23 @@ class Card:
 
     def to_markdown_row(self):
         """Returns a Markdown table row representation of the card."""
-        name, cost, cmc, typeline, stats, text, rarity = self._get_display_data(include_text=True)
+        name, cost, cmc, typeline, stats, text, rarity, mechanics = self._get_display_data(include_text=True)
 
         # Escape pipe characters and ensure no actual newlines break the row
-        fields = [name, cost, cmc, typeline, stats, text, rarity]
+        fields = [name, cost, cmc, typeline, stats, text, rarity, mechanics]
         fields = [f.replace('|', '\\|').replace('\n', ' ') for f in fields]
 
         return f"| {' | '.join(fields)} |"
 
     def to_table_row(self, ansi_color=False):
         """Returns a list of strings representing the card's fields for a terminal table."""
-        name, cost, cmc, typeline, stats, _, rarity = self._get_display_data(ansi_color=ansi_color)
+        import datalib
+        name, cost, cmc, typeline, stats, _, rarity, mechanics = self._get_display_data(ansi_color=ansi_color)
 
-        return [name, cost, cmc, typeline, stats, rarity]
+        # Limit mechanics list width to prevent table overflow
+        mechanics = datalib.plimit(mechanics, 30)
+
+        return [name, cost, cmc, typeline, stats, rarity, mechanics]
 
     def vectorize(self):
         """Vectorizes the card data into a string format suitable for machine learning.

--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -68,10 +68,37 @@ def inc(d, k, obj):
 
 # thanks gleemax
 def plimit(s, mlen = 1000):
-    if len(s) > mlen:
-        return s[:mlen] + '[...]'
-    else:
+    """
+    Limits the length of a string to mlen characters.
+    If the string is truncated, adds '[...]' and ensures ANSI codes are reset.
+    Uses visible_len to correctly handle strings with ANSI escape sequences.
+    """
+    if utils.visible_len(s) <= mlen:
         return s
+
+    # Basic truncation logic that tries to be ANSI-aware
+    # We find the index where visible length reaches mlen
+    vlen = 0
+    idx = 0
+    in_escape = False
+
+    while idx < len(s) and vlen < mlen:
+        if s[idx] == '\x1b':
+            in_escape = True
+
+        if not in_escape:
+            vlen += 1
+
+        if in_escape and s[idx] in 'mABCD': # simplified end of ANSI sequence
+            in_escape = False
+
+        idx += 1
+
+    res = s[:idx] + '[...]'
+    # If the original string had escape codes, append a reset just in case
+    if '\x1b' in s:
+        res += utils.Ansi.RESET
+    return res
 
 def color_count(count, use_color, color_code=utils.Ansi.BOLD + utils.Ansi.GREEN):
     s = str(count)

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -129,7 +129,7 @@ def test_card_summary(sample_card_json):
 
     # Test plain summary
     output = card.summary()
-    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2)"
+    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2) • Flying"
 
     # Test colored summary
     colored_output = card.summary(ansi_color=True)
@@ -138,8 +138,9 @@ def test_card_summary(sample_card_json):
     expected_type = utils.colorize("Artifact Creature — Thopter", utils.Ansi.GREEN)
     expected_pt = utils.colorize("(0/2)", utils.Ansi.RED)
     expected_rarity_indicator = utils.colorize("[U]", utils.Ansi.BOLD + utils.Ansi.CYAN)
+    expected_mechanics = utils.colorize("Flying", utils.Ansi.CYAN)
 
-    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt}"
+    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt} • {expected_mechanics}"
     assert colored_output == expected_colored_summary
 
 def test_card_summary_status_indicators():

--- a/tests/test_table_output.py
+++ b/tests/test_table_output.py
@@ -22,7 +22,7 @@ def test_to_table_row():
     print(f"Row: {row}")
     # Rarity is lowercase from MTGJSON if not in map, but Card(card_json) uses fields_from_json
     # which uses utils.json_rarity_map if available.
-    assert row == ["Grizzly Bears", "{1}{G}", "2", "Creature \u2014 Bear", "2/2", "common"]
+    assert row == ["Grizzly Bears", "{1}{G}", "2", "Creature \u2014 Bear", "2/2", "common", ""]
 
 def test_to_table_row_bside():
     card_json = {
@@ -40,7 +40,7 @@ def test_to_table_row_bside():
     card = Card(card_json)
     row = card.to_table_row(ansi_color=False)
     print(f"Bside Row: {row}")
-    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "2 // 2", "Instant // Instant", "", "uncommon"]
+    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "2 // 2", "Instant // Instant", "", "uncommon", ""]
 
 def test_cli_table():
     # Encode a sample card and decode it with --table


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** Users have to read the full rules text to identify card keywords like "Flying", "Haste", or "Trample", which is time-consuming when scanning large lists of cards in the terminal or in summaries.
* **Solution:** Extracted mechanical keywords (using the existing mechanics engine) and surfaced them directly in the compact card `summary()` and terminal `table` outputs. This increases information density and allows for rapid identification of card roles. Added an ANSI-aware truncation utility to ensure colorized mechanics lists don't break terminal formatting.

---
*PR created automatically by Jules for task [6941147434636992680](https://jules.google.com/task/6941147434636992680) started by @RainRat*