### PR TITLE
[FEAT] Surface identified mechanics in card outputs

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -219,11 +219,11 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
         if for_md_table:
             if booster > 0:
-                writer.write("| Pack | Name | Cost | CMC | Type | Stats | Rules Text | Rarity |\n")
-                writer.write("| ---: | :--- | :--- | ---: | :--- | ---: | :--- | :--- |\n")
+                writer.write("| Pack | Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |\n")
+                writer.write("| ---: | :--- | :--- | ---: | :--- | ---: | :--- | :--- | :--- |\n")
             else:
-                writer.write("| Name | Cost | CMC | Type | Stats | Rules Text | Rarity |\n")
-                writer.write("| :--- | :--- | ---: | :--- | ---: | :--- | :--- |\n")
+                writer.write("| Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |\n")
+                writer.write("| :--- | :--- | ---: | :--- | ---: | :--- | :--- | :--- |\n")
         if for_mse:
             # have to prepend a massive chunk of formatting info
             writer.write(utils.mse_prepend)
@@ -296,7 +296,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         if for_table:
             import datalib
             rows = []
-            header = ["Name", "Cost", "CMC", "Type", "Stats", "Rarity"]
+            header = ["Name", "Cost", "CMC", "Type", "Stats", "Mechanics", "Rarity"]
             if booster > 0 or box > 0:
                 header.insert(0, "Pack")
             if box > 0:
@@ -347,6 +347,10 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
             if stats_idx < len(aligns):
                 aligns[stats_idx] = 'r'
+
+            # Right-align Mechanics column (optional, but keep it left aligned for readability)
+            # Mechanics is at index 5 (default), 6 (booster), 7 (box)
+            # We keep it left aligned by default.
 
             # Insert a separator row of dashes
             col_widths = datalib.get_col_widths(rows)

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -592,14 +592,20 @@ class Card:
         if ansi_color and rarity:
             rarity = utils.colorize(rarity, utils.Ansi.get_rarity_color(rarity))
 
-        return name, cost, cmc, typeline, stats, text, rarity
+        # Mechanics
+        face_mechanics = sorted(list(self.get_face_mechanics()))
+        mechanics = ", ".join(face_mechanics)
+        if ansi_color and mechanics:
+            mechanics = utils.colorize(mechanics, utils.Ansi.CYAN)
+
+        return name, cost, cmc, typeline, stats, text, rarity, mechanics
 
     def _get_display_data(self, ansi_color=False, include_text=False):
         """Helper to get standardized display fields for the card, merging b-sides."""
-        name, cost, cmc, typeline, stats, text, rarity = self._get_single_face_display_data(ansi_color=ansi_color, include_text=include_text)
+        name, cost, cmc, typeline, stats, text, rarity, mechanics = self._get_single_face_display_data(ansi_color=ansi_color, include_text=include_text)
 
         if self.bside:
-            b_name, b_cost, b_cmc, b_typeline, b_stats, b_text, b_rarity = self.bside._get_display_data(ansi_color=ansi_color, include_text=include_text)
+            b_name, b_cost, b_cmc, b_typeline, b_stats, b_text, b_rarity, b_mechanics = self.bside._get_display_data(ansi_color=ansi_color, include_text=include_text)
             name = f"{name} // {b_name}"
             cost = f"{cost} // {b_cost}"
             cmc = f"{cmc} // {b_cmc}"
@@ -609,12 +615,12 @@ class Card:
                 text = f"{text}<br>---<br>{b_text}"
             if b_rarity and b_rarity != rarity:
                 rarity = f"{rarity} // {b_rarity}"
+            mechanics = f"{mechanics} // {b_mechanics}" if mechanics and b_mechanics else (mechanics or b_mechanics)
 
-        return name, cost, cmc, typeline, stats, text, rarity
+        return name, cost, cmc, typeline, stats, text, rarity, mechanics
 
-    @property
-    def mechanics(self):
-        """Returns a set of mechanical features and keyword abilities identified on the card."""
+    def get_face_mechanics(self):
+        """Returns a set of mechanical features and keyword abilities identified on this card face."""
         text_raw = self.text.text.lower()
         # To handle cards named after keywords (e.g., card "Exile" with rule text "@ target..."),
         # we create a search string where @ is replaced by the card name.
@@ -677,6 +683,13 @@ class Card:
             # Use word boundaries for keywords to avoid partial matches
             if re.search(r'\b' + pattern + r'\b', text_search):
                 m.add(label)
+
+        return m
+
+    @property
+    def mechanics(self):
+        """Returns a set of mechanical features and keyword abilities identified on the card."""
+        m = self.get_face_mechanics()
 
         # Recursive profiling for split/double-faced cards
         if self.bside:
@@ -1111,10 +1124,18 @@ class Card:
         if not stats:
             stats = self._get_loyalty_display(ansi_color=ansi_color)
 
+        # Mechanics
+        face_mechanics = sorted(list(self.get_face_mechanics()))
+        mechanics_str = ", ".join(face_mechanics)
+        if ansi_color and mechanics_str:
+            mechanics_str = utils.colorize(mechanics_str, utils.Ansi.CYAN)
+
         # Construct final summary string with consistent bullet separators
         res = f'{status}{rarity_indicator}{cardname}{coststr} \u2022 {typeline}'
         if stats:
             res += f' \u2022 {stats}'
+        if mechanics_str:
+            res += f' \u2022 {mechanics_str}'
 
         if self.bside:
             res += ' // ' + self.bside.summary(ansi_color=ansi_color)
@@ -1345,6 +1366,11 @@ class Card:
         if self.text.text:
             d['text'] = self.get_text(force_unpass=True)
 
+        # Mechanics
+        face_mechanics = sorted(list(self.get_face_mechanics()))
+        if face_mechanics:
+            d['mechanics'] = face_mechanics
+
         # Metadata
         if self.set_code:
             d['setCode'] = self.set_code
@@ -1491,19 +1517,19 @@ class Card:
 
     def to_markdown_row(self):
         """Returns a Markdown table row representation of the card."""
-        name, cost, cmc, typeline, stats, text, rarity = self._get_display_data(include_text=True)
+        name, cost, cmc, typeline, stats, text, rarity, mechanics = self._get_display_data(include_text=True)
 
         # Escape pipe characters and ensure no actual newlines break the row
-        fields = [name, cost, cmc, typeline, stats, text, rarity]
+        fields = [name, cost, cmc, typeline, stats, mechanics, text, rarity]
         fields = [f.replace('|', '\\|').replace('\n', ' ') for f in fields]
 
         return f"| {' | '.join(fields)} |"
 
     def to_table_row(self, ansi_color=False):
         """Returns a list of strings representing the card's fields for a terminal table."""
-        name, cost, cmc, typeline, stats, _, rarity = self._get_display_data(ansi_color=ansi_color)
+        name, cost, cmc, typeline, stats, _, rarity, mechanics = self._get_display_data(ansi_color=ansi_color)
 
-        return [name, cost, cmc, typeline, stats, rarity]
+        return [name, cost, cmc, typeline, stats, mechanics, rarity]
 
     def vectorize(self):
         """Vectorizes the card data into a string format suitable for machine learning.

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -129,7 +129,7 @@ def test_card_summary(sample_card_json):
 
     # Test plain summary
     output = card.summary()
-    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2)"
+    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2) • Flying"
 
     # Test colored summary
     colored_output = card.summary(ansi_color=True)
@@ -138,8 +138,9 @@ def test_card_summary(sample_card_json):
     expected_type = utils.colorize("Artifact Creature — Thopter", utils.Ansi.GREEN)
     expected_pt = utils.colorize("(0/2)", utils.Ansi.RED)
     expected_rarity_indicator = utils.colorize("[U]", utils.Ansi.BOLD + utils.Ansi.CYAN)
+    expected_mechanics = utils.colorize("Flying", utils.Ansi.CYAN)
 
-    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt}"
+    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt} • {expected_mechanics}"
     assert colored_output == expected_colored_summary
 
 def test_card_summary_status_indicators():

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -44,13 +44,15 @@ def test_markdown_table_format():
     src = "|1Table Card|5Creature|6Human|3{WW}|8&^/&^|9Lifelink|0O"
     card = cardlib.Card(src)
     row = card.to_markdown_row()
-    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | common |" in row
+    # Mechanics "Lifelink" is now present
+    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | Lifelink | common |" in row
 
 def test_markdown_table_split_card():
     src = "|1Fire|5Sorcery|3{RR}|9Fire deals &^^ damage to any target.\n|1Ice|5Sorcery|3{^}{UU}|9Draw a card."
     card = cardlib.Card(src)
     row = card.to_markdown_row()
-    assert "| Fire // Ice | {R} // {1}{U} | 1 // 2 | Sorcery // Sorcery |  | Fire deals 2 damage to any target.<br>---<br>Draw a card. |  |" in row
+    # Mechanics "Draw A Card" is now present for Ice
+    assert "| Fire // Ice | {R} // {1}{U} | 1 // 2 | Sorcery // Sorcery |  | Draw A Card | Fire deals 2 damage to any target.<br>---<br>Draw a card. |  |" in row
 
 def test_decode_markdown_table_cli(tmp_path):
     infile = tmp_path / "input.txt"
@@ -61,8 +63,8 @@ def test_decode_markdown_table_cli(tmp_path):
     decode.main(str(infile), str(outfile), quiet=True, verbose=False)
 
     content = outfile.read_text(encoding="utf-8")
-    assert "| Name | Cost | CMC | Type | Stats | Rules Text | Rarity |" in content
-    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | common |" in content
+    assert "| Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |" in content
+    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | Lifelink | common |" in content
 
 def test_decode_markdown_table_flag(tmp_path):
     infile = tmp_path / "input.txt"
@@ -73,5 +75,5 @@ def test_decode_markdown_table_flag(tmp_path):
     decode.main(str(infile), str(outfile), md_table_out=True, quiet=True, verbose=False)
 
     content = outfile.read_text(encoding="utf-8")
-    assert "| Name | Cost | CMC | Type | Stats | Rules Text | Rarity |" in content
-    assert "| Flag Card | {G} | 1 | Sorcery |  | Add {G}. | rare |" in content
+    assert "| Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |" in content
+    assert "| Flag Card | {G} | 1 | Sorcery |  |  | Add {G}. | rare |" in content

--- a/tests/test_table_output.py
+++ b/tests/test_table_output.py
@@ -22,7 +22,7 @@ def test_to_table_row():
     print(f"Row: {row}")
     # Rarity is lowercase from MTGJSON if not in map, but Card(card_json) uses fields_from_json
     # which uses utils.json_rarity_map if available.
-    assert row == ["Grizzly Bears", "{1}{G}", "2", "Creature \u2014 Bear", "2/2", "common"]
+    assert row == ["Grizzly Bears", "{1}{G}", "2", "Creature \u2014 Bear", "2/2", "", "common"]
 
 def test_to_table_row_bside():
     card_json = {
@@ -34,13 +34,14 @@ def test_to_table_row_bside():
             "name": "Ice",
             "manaCost": "{1}{U}",
             "types": ["Instant"],
-            "rarity": "Uncommon"
+            "rarity": "Uncommon",
+            "text": "Draw a card."
         }
     }
     card = Card(card_json)
     row = card.to_table_row(ansi_color=False)
     print(f"Bside Row: {row}")
-    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "2 // 2", "Instant // Instant", "", "uncommon"]
+    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "2 // 2", "Instant // Instant", "", "Draw A Card", "uncommon"]
 
 def test_cli_table():
     # Encode a sample card and decode it with --table


### PR DESCRIPTION
### What:
Refactored the `mechanics` identification logic in the `Card` class to support face-specific extraction and integrated it into all human-readable and structured output formats.
- Added `get_face_mechanics()` to the `Card` class.
- Updated `_get_single_face_display_data()` and `_get_display_data()` in `lib/cardlib.py` to return a formatted mechanics string.
- Added a "Mechanics" column to terminal tables (`--table`) and Markdown tables (`--md-table`) in `decode.py`.
- Appended identified mechanics to the compact one-line summary (`Card.summary()`).
- Included a `mechanics` key in JSON/JSONL exports (`Card.to_dict()`).
- Updated existing unit tests to reflect the new output structure.

### Why:
The codebase already possessed sophisticated regex-based mechanical profiling (keyword identification like "Flying", "Triggered", etc.) used for dataset analysis in `summarize.py`. However, this metadata was not exposed to users during standard card inspection or data conversion. Surfacing these mechanics provides immediate value by allowing users to understand a card's functional profile at a glance across all primary tools, without needing to manually parse the full rules text. This is especially useful when processing large batches of AI-generated cards.

---
*PR created automatically by Jules for task [8310565533491601454](https://jules.google.com/task/8310565533491601454) started by @RainRat*