### PR TITLE
Fix ANSI-unaware string truncation in plimit

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -67,11 +67,43 @@ def inc(d, k, obj):
             d[k] = obj
 
 # thanks gleemax
-def plimit(s, mlen = 1000):
-    if len(s) > mlen:
-        return s[:mlen] + '[...]'
-    else:
+def plimit(s, mlen=1000):
+    vlen = utils.visible_len(s)
+    raw_len = len(s)
+
+    if raw_len == vlen:
+        if raw_len > mlen:
+            return s[:mlen] + '[...]'
         return s
+
+    if vlen <= mlen:
+        return s
+
+    res = ""
+    visible_count = 0
+    last_idx = 0
+    ansi_encountered = False
+
+    for match in utils._ansi_escape_re.finditer(s):
+        pre_text = s[last_idx:match.start()]
+        if visible_count + len(pre_text) > mlen:
+            res += pre_text[:mlen - visible_count]
+            return res + '[...]' + (utils.Ansi.RESET if ansi_encountered else "")
+
+        res += pre_text
+        visible_count += len(pre_text)
+
+        res += match.group()
+        ansi_encountered = True
+        last_idx = match.end()
+
+    remaining = s[last_idx:]
+    if visible_count + len(remaining) > mlen:
+        res += remaining[:mlen - visible_count]
+        return res + '[...]' + (utils.Ansi.RESET if ansi_encountered else "")
+
+    res += remaining
+    return res
 
 def color_count(count, use_color, color_code=utils.Ansi.BOLD + utils.Ansi.GREEN):
     s = str(count)


### PR DESCRIPTION
Fixed a logic bug in the `plimit` function within `lib/datalib.py`. The original implementation used a naive string slice based on raw character count, which caused issues when dealing with ANSI escape sequences (e.g., color codes) commonly used in the project's CLI tools. 

The updated version:
1. Calculates truncation limits based on visible character count using `utils.visible_len`.
2. Preserves ANSI sequences up to the truncation point.
3. Appends an ANSI reset code if truncation occurs in a string that contains ANSI sequences, preventing "color bleeding" in the terminal.
4. Includes an optimized fast-path for plain strings to ensure 100% backward compatibility with existing tests and performance requirements.

Verified the fix with a reproduction script and confirmed that all existing unit tests in `tests/test_datalib.py` and `tests/test_datalib_coverage.py` pass.

---
*PR created automatically by Jules for task [12031671510164733550](https://jules.google.com/task/12031671510164733550) started by @RainRat*