### PR TITLE
Fix logic bug in card name text transformation

### DIFF
--- a/lib/transforms.py
+++ b/lib/transforms.py
@@ -66,7 +66,8 @@ def text_pass_2_cardname(s, name):
     elif name == 'fear':
         return s
 
-    s = s.replace(name, this_marker)
+    if name:
+        s = s.replace(name, this_marker)
     
     # So, some legends don't use the full cardname in their text box...
     # this check finds about 400 of them.
@@ -95,7 +96,8 @@ def text_pass_2_cardname(s, name):
     ]
     
     for override in overrides:
-        s = s.replace(override, this_marker)
+        if override in name:
+            s = s.replace(override, this_marker)
 
     # Standardize self-references in older card text (e.g., replacing masculine pronouns with the self-reference marker).
     s = s.replace('to him.', 'to ' + this_marker + '.')


### PR DESCRIPTION
Fixed two logic bugs in `lib/transforms.py` that caused incorrect card text transformations.

- **Empty Name Fix:** Added a check to ensure `name` is not empty before performing replacements. This prevents `string.replace("", this_marker)` from inserting the marker between every character of the card text.
- **Override Scoping Fix:** Updated the legendary nickname overrides loop to only perform replacements if the override string is found within the card's full name. This ensures that shortened names are only treated as self-references for the specific cards they belong to, preventing accidental replacement of other cards' names in rules text.

Verified the fixes with a dedicated reproduction script and confirmed that all 505 existing tests pass.

---
*PR created automatically by Jules for task [1117792662613014119](https://jules.google.com/task/1117792662613014119) started by @RainRat*