### PR TITLE
[TEST] Add Convoke keyword detection and verify coverage

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -673,7 +673,7 @@ class Card:
             ('reach', 'Reach'), ('flash', 'Flash'), ('indestructible', 'Indestructible'),
             ('defender', 'Defender'), ('scry', 'Scry'), ('draw a card', 'Draw A Card'),
             ('mill', 'Mill'), ('exile', 'Exile'), (r'tokens?', 'Token'),
-            ('discard', 'Discard'), ('cycling', 'Cycling')
+            ('discard', 'Discard'), ('cycling', 'Cycling'), ('convoke', 'Convoke')
         ]
 
         for pattern, label in keywords:

--- a/tests/test_mechanics_convoke.py
+++ b/tests/test_mechanics_convoke.py
@@ -1,0 +1,40 @@
+import sys
+import os
+
+# Ensure lib is in path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from lib.cardlib import Card
+
+def test_mechanics_convoke_keyword():
+    """Verify that 'Convoke' is identified as a keyword ability."""
+    card = Card({
+        "name": "Chord of Calling",
+        "manaCost": "{X}{G}{G}{G}",
+        "types": ["Instant"],
+        "text": "Convoke\nSearch your library for a creature card with mana value X or less and put it onto the battlefield. Then shuffle.",
+        "rarity": "Rare"
+    })
+    assert 'Convoke' in card.mechanics
+
+def test_mechanics_convoke_boundary():
+    """Verify that 'Convoke' does not match partial words like 'Convoker'."""
+    card = Card({
+        "name": "Convoker",
+        "types": ["Creature"],
+        "text": "A convoker of souls.",
+        "rarity": "Common",
+        "power": "1",
+        "toughness": "1"
+    })
+    assert 'Convoke' not in card.mechanics
+
+def test_mechanics_convoke_case_insensitive():
+    """Verify that 'convoke' is identified regardless of case."""
+    card = Card({
+        "name": "Case Test",
+        "types": ["Instant"],
+        "text": "some text with convoke here.",
+        "rarity": "Common"
+    })
+    assert 'Convoke' in card.mechanics


### PR DESCRIPTION
### Type: New Coverage

### What:
This pull request adds support for identifying the 'Convoke' keyword ability within the mechanical profiling logic of the `Card` class. It includes:
- An update to the `keywords` list in `lib/cardlib.py`'s `get_face_mechanics()` method.
- A new test file `tests/test_mechanics_convoke.py` covering positive, negative (boundary), and case-insensitive scenarios.

### Why:
'Convoke' was a notable omission from the codebase's mechanical keyword detection list. Adding it improves the accuracy of dataset summaries, mechanical profiles, and card summaries generated by tools like `summarize.py` and `decode.py`. The addition of comprehensive tests ensures the robustness of the identification logic and prevents regression.

---
*PR created automatically by Jules for task [9469957689843420596](https://jules.google.com/task/9469957689843420596) started by @RainRat*