### PR TITLE
[UI/UX] Consolidate mechanical frequency and budget analysis in summary output

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -178,6 +178,50 @@ def _print_breakdown(title, index, total, use_color, vsize=None, sort_key=None, 
         ])
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'l']), indent=4)
 
+def _print_mechanical_profile(mechanical_stats, total, use_color, vsize=None):
+    if not mechanical_stats:
+        return
+    print()
+    print('  ' + color_line('Mechanical Profile (Frequency & Budget):', use_color))
+
+    header = _colorize_header(['Mechanic', 'Count', 'Percent', 'Distribution', 'CMC', 'P/T'], use_color)
+
+    rows = [header]
+    # Sort by frequency
+    sorted_mechanics = sorted(mechanical_stats.keys(), key=lambda m: mechanical_stats[m]['count'], reverse=True)
+    if vsize:
+        sorted_mechanics = sorted_mechanics[:vsize]
+
+    for m in sorted_mechanics:
+        stats = mechanical_stats[m]
+        count = stats['count']
+        percent = (count / total * 100) if total > 0 else 0
+        bar = get_bar_chart(percent, use_color)
+
+        pt_str = "-"
+        if stats['avg_power'] is not None and stats['avg_toughness'] is not None:
+            pt_str = f"{stats['avg_power']:.1f}/{stats['avg_toughness']:.1f}"
+        elif stats['avg_power'] is not None:
+             pt_str = f"{stats['avg_power']:.1f}/?"
+        elif stats['avg_toughness'] is not None:
+             pt_str = f"?/{stats['avg_toughness']:.1f}"
+
+        row = [
+            m,
+            color_count(count, use_color),
+            f"{percent:5.1f}%",
+            bar,
+            f"{stats['avg_cmc']:.2f}",
+            pt_str
+        ]
+
+        if use_color:
+            row[5] = utils.colorize(row[5], utils.Ansi.RED) if pt_str != "-" else row[5]
+
+        rows.append(row)
+
+    printrows(padrows(rows, aligns=['l', 'r', 'r', 'l', 'r', 'r']), indent=4)
+
 def _print_color_pie(pie_groups, pie_mechanics, all_mechanics, use_color, vsize=None):
     if not all_mechanics:
         return
@@ -224,46 +268,6 @@ def _print_color_pie(pie_groups, pie_mechanics, all_mechanics, use_color, vsize=
         rows.append(row)
 
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'r', 'r', 'r', 'r', 'r']), indent=4)
-
-def _print_mechanical_stats(mechanical_stats, use_color, vsize=None):
-    if not mechanical_stats:
-        return
-    print()
-    print('  ' + color_line('Mechanical Budget Analysis (Averages):', use_color))
-
-    header = _colorize_header(['Mechanic', 'Count', 'CMC', 'P/T'], use_color)
-
-    rows = [header]
-    # Sort by frequency
-    sorted_mechanics = sorted(mechanical_stats.keys(), key=lambda m: mechanical_stats[m]['count'], reverse=True)
-    if vsize:
-        sorted_mechanics = sorted_mechanics[:vsize]
-
-    for m in sorted_mechanics:
-        stats = mechanical_stats[m]
-
-        pt_str = "-"
-        if stats['avg_power'] is not None and stats['avg_toughness'] is not None:
-            pt_str = f"{stats['avg_power']:.1f}/{stats['avg_toughness']:.1f}"
-        elif stats['avg_power'] is not None:
-             pt_str = f"{stats['avg_power']:.1f}/?"
-        elif stats['avg_toughness'] is not None:
-             pt_str = f"?/{stats['avg_toughness']:.1f}"
-
-        row = [
-            m,
-            color_count(stats['count'], use_color),
-            f"{stats['avg_cmc']:.2f}",
-            pt_str
-        ]
-
-        if use_color:
-            # Maybe colorize P/T red like in Card.format()
-            row[3] = utils.colorize(row[3], utils.Ansi.RED) if pt_str != "-" else row[3]
-
-        rows.append(row)
-
-    printrows(padrows(rows, aligns=['l', 'r', 'r', 'r']), indent=4)
 
 class Datamine:
     # build the global indices
@@ -534,9 +538,7 @@ class Datamine:
         print()
 
         print('  ' + color_line(str(len(self.by_mechanic)) + ' distinct mechanical features identified', use_color))
-        _print_breakdown('Mechanical Breakdown:', self.by_mechanic, len(self.allcards), use_color,
-                         vsize=vsize, sort_key=lambda x: len(self.by_mechanic[x]))
-        _print_mechanical_stats(self.mechanical_stats, use_color, vsize=vsize)
+        _print_mechanical_profile(self.mechanical_stats, len(self.allcards), use_color, vsize=vsize)
         _print_color_pie(self.pie_groups, self.pie_mechanics, self.by_mechanic, use_color, vsize=vsize)
         print()
 


### PR DESCRIPTION
This pull request improves the visual hierarchy and efficiency of the `summarize.py` tool by consolidating two redundant mechanical analysis tables into a single, high-density "Mechanical Profile" view.

**Context:** CLI
**Problem:** The user had to scan two separate tables to correlate a mechanic's frequency (how often it appears) with its design budget (its average CMC and P/T). These tables shared the same row keys (Mechanics), leading to redundant output and increased cognitive load.
**Solution:** A new `_print_mechanical_profile` function in `lib/datalib.py` merges these metrics into a single table. This provides a holistic view of each keyword's footprint and its average mechanical stats in one place, following "Friction Reduction" and "Visual Hierarchy" design priorities.

**Changes:**
- **lib/datalib.py**: Added `_print_mechanical_profile` to handle the consolidated output.
- **lib/datalib.py**: Updated `Datamine.summarize` to call the new profile function and removed the separate calls to frequency breakdown and budget analysis.
- **lib/datalib.py**: Deleted the now-redundant `_print_mechanical_stats` function.


---
*PR created automatically by Jules for task [9093219133449263069](https://jules.google.com/task/9093219133449263069) started by @RainRat*