### PR TITLE
[UI/UX] Standardize table headers with separator lines

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -208,6 +208,12 @@ def _print_breakdown(title, index, total, use_color, vsize=None, sort_key=None, 
             f"{percent:5.1f}%",
             bar
         ])
+
+    # Insert a separator row of dashes
+    col_widths = get_col_widths(rows)
+    separator = ['-' * w for w in col_widths]
+    rows.insert(1, separator)
+
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'l']), indent=4)
 
 def _print_mechanical_profile(mechanical_stats, total, use_color, vsize=None):
@@ -251,6 +257,11 @@ def _print_mechanical_profile(mechanical_stats, total, use_color, vsize=None):
             row[5] = utils.colorize(row[5], utils.Ansi.RED) if pt_str != "-" else row[5]
 
         rows.append(row)
+
+    # Insert a separator row of dashes
+    col_widths = get_col_widths(rows)
+    separator = ['-' * w for w in col_widths]
+    rows.insert(1, separator)
 
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'l', 'r', 'r']), indent=4)
 
@@ -298,6 +309,11 @@ def _print_color_pie(pie_groups, pie_mechanics, all_mechanics, use_color, vsize=
                 val = "  - "
             row.append(val)
         rows.append(row)
+
+    # Insert a separator row of dashes
+    col_widths = get_col_widths(rows)
+    separator = ['-' * w for w in col_widths]
+    rows.insert(1, separator)
 
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'r', 'r', 'r', 'r', 'r']), indent=4)
 

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -560,6 +560,11 @@ def main(fname, oname = None, verbose = False, dump = False,
 
                     rows.append([label_colored, count_colored, f"{percent:5.1f}%", bar])
 
+                # Insert a separator row of dashes
+                col_widths = datalib.get_col_widths(rows)
+                separator = ['-' * w for w in col_widths]
+                rows.insert(1, separator)
+
                 datalib.printrows(datalib.padrows(rows, aligns=['l', 'r', 'r', 'l']), indent=2)
                 print()
 
@@ -601,6 +606,11 @@ def main(fname, oname = None, verbose = False, dump = False,
                             f"{success_pct:5.1f}%",
                             bar
                         ])
+
+                # Insert a separator row of dashes
+                col_widths = datalib.get_col_widths(b_rows)
+                separator = ['-' * w for w in col_widths]
+                b_rows.insert(1, separator)
 
                 datalib.printrows(datalib.padrows(b_rows, aligns=['l', 'r', 'r', 'r', 'r', 'l']), indent=2)
 


### PR DESCRIPTION
Standardize the look and feel of CLI tables by adding separator lines between headers and data rows. This improves visual hierarchy and makes the output easier to scan.

Key changes:
- Modified `lib/datalib.py` to include separator lines in all breakdown tables.
- Modified `scripts/mtg_validate.py` to include separator lines in its summary and breakdown tables.
- Verified that all tables (Breakdowns, Mechanical Profile, Color Pie, and Validation Summary) now follow a consistent visual style.
- Ensured all tests pass (508 passed).

---
*PR created automatically by Jules for task [14428329092878150076](https://jules.google.com/task/14428329092878150076) started by @RainRat*