### PR TITLE
[FEAT] Comprehensive Color Identity Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Customization options for formatting data:
 *   `--nolinetrans`: Disables the automatic reordering and normalization of card text lines.
 *   `-r`, `--randomize`: Randomizes mana symbol order (e.g., `{U}{W}` vs `{W}{U}`) to help the AI learn better.
 *   `-s`, `--stable`: Preserve the original order of cards from the input (the tool shuffles cards by default).
-*   `--sort`: Sorts cards by `name`, `color`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, or `set` before encoding. Automatically enables `--stable`.
+*   `--sort`: Sorts cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, or `set` before encoding. Automatically enables `--stable`.
 *   `--seed N`: Seed for the random number generator (Default: 1371367).
 *   `--limit N`: Only process the first N cards.
 *   `--sample N`: Shorthand for `--limit N`. The tool shuffles cards by default unless you use `--stable`.
@@ -139,7 +139,7 @@ Options for formatting the output. While primarily used for AI output, this tool
 *   `--summary`: Creates a compact one-line summary for each card.
 *   `--color` / `--no-color`: Manually enable or disable ANSI color output in your terminal.
 *   `--shuffle`: Randomizes the order of cards (the tool does not shuffle cards by default for decoding).
-*   `--sort`: Sorts cards by `name`, `color`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, or `set`.
+*   `--sort`: Sorts cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, or `set`.
 *   `--seed N`: Seed for the random number generator.
 *   `--limit N`: Only process the first N cards.
 *   `--sample N`: Pick N random cards (shorthand for `--shuffle --limit N`).
@@ -270,6 +270,8 @@ Filter which cards the tool processes using search patterns, set codes, rarities
     *   `--set CODE`: Only include cards from specific sets (e.g., `MOM`, `MRD`). Supports multiple sets (OR logic).
     *   `--rarity NAME`: Only include cards of specific rarities (e.g., `common`, `rare`). Supports multiple rarities (OR logic).
     *   `--colors SYMBOLS`: Only include cards with specific colors (e.g., `W`, `U`, `B`, `R`, `G`). Use `C` or `A` for colorless. Multiple colors use OR logic.
+*   `--identity SYMBOLS`: Only include cards with specific colors in their color identity (e.g., `W`, `U`, `B`, `R`, `G`). Use `C` or `A` for colorless. Multiple colors use OR logic.
+*   `--id-count VALUE`: Only include cards with specific color identity counts. Supports inequalities (e.g., `>3`, `<=2`), ranges (e.g., `1-4`), and multiple values (OR logic).
     *   `--cmc VALUE`: Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., `>3`, `<=2`), ranges (e.g., `1-4`), and multiple values (OR logic).
     *   `--pow VALUE` (or `--power`): Only include cards with specific Power values. Supports inequalities and ranges.
     *   `--tou VALUE` (or `--toughness`): Only include cards with specific Toughness values. Supports inequalities and ranges.

--- a/decode.py
+++ b/decode.py
@@ -33,6 +33,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          sets=None, rarities=None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
+         identities=None, id_counts=None,
          shuffle=False, seed=None, decklist_file=None, booster=0, box=0):
 
     # Set default format to text if no specific output format is selected.
@@ -117,6 +118,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
                                   mechanics=mechanics,
+                                  identities=identities, id_counts=id_counts,
                                   shuffle=shuffle, seed=seed, decklist_file=decklist_file,
                                   booster=booster, box=box)
 
@@ -802,7 +804,7 @@ if __name__ == '__main__':
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --shuffle --limit N).')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--booster', type=int, default=0,
                         help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
@@ -845,6 +847,10 @@ if __name__ == '__main__':
                         help="Only include cards of specific rarities. Supports full names (e.g., 'common', 'mythic') or shorthands: O (Common), N (Uncommon), A (Rare), Y (Mythic), I (Special), L (Basic Land). Supports multiple rarities (OR logic).")
     filter_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
     filter_group.add_argument('--cmc', action='append',
                         help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
     filter_group.add_argument('--pow', '--power', action='append', dest='pow',
@@ -904,6 +910,7 @@ if __name__ == '__main__':
          sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
+         identities=args.identity, id_counts=args.id_count,
          shuffle=args.shuffle, seed=args.seed, decklist_file=args.deck_filter, booster=args.booster, box=args.box)
 
     exit(0)

--- a/encode.py
+++ b/encode.py
@@ -20,6 +20,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          sets=None, rarities=None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
+         identities=None, id_counts=None,
          seed=None, decklist_file=None, booster=0, box=0):
     fmt_ordered = cardlib.fmt_ordered_default
     fmt_labeled = None if nolabel else cardlib.fmt_labeled_default
@@ -81,6 +82,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
                                   mechanics=mechanics,
+                                  identities=identities, id_counts=id_counts,
                                   shuffle=not stable, seed=seed if seed is not None else 1371367,
                                   decklist_file=decklist_file, booster=booster, box=box)
 
@@ -166,7 +168,7 @@ if __name__ == '__main__':
                         help='Seed for the random number generator (Default: 1371367).')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --limit N). Shuffling is enabled unless --stable is used.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box'],
                         help='Sort cards by a specific criterion (enables --stable).')
     proc_group.add_argument('--booster', type=int, default=0,
                         help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
@@ -209,6 +211,10 @@ if __name__ == '__main__':
                         help="Only include cards of specific rarities. Supports full names (e.g., 'common', 'mythic') or shorthands: O (Common), N (Uncommon), A (Rare), Y (Mythic), I (Special), L (Basic Land). Supports multiple rarities (OR logic).")
     filter_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
     filter_group.add_argument('--cmc', action='append',
                         help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
     filter_group.add_argument('--pow', '--power', action='append', dest='pow',
@@ -250,5 +256,6 @@ if __name__ == '__main__':
          sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
+         identities=args.identity, id_counts=args.id_count,
          seed=args.seed, decklist_file=args.deck, booster=args.booster, box=args.box)
     exit(0)

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -545,6 +545,21 @@ class Card:
         """Returns True if the card is a sorcery."""
         return 'sorcery' in self.types
 
+    @property
+    def color_identity(self):
+        """Returns the color identity of the card (mana cost + rules text symbols)."""
+        colors = set(self.cost.colors)
+        if hasattr(self.text, 'costs'):
+            for cost in self.text.costs:
+                for char in cost.colors:
+                    colors.add(char)
+
+        if self.bside:
+            for char in self.bside.color_identity:
+                colors.add(char)
+
+        return "".join(sorted(list(colors)))
+
     def get_type_line(self, separator='\u2014'):
         """Returns a formatted type line string (e.g., 'Legendary Creature — Human Warrior')."""
         supertypes = [titlecase(s) for s in self.__dict__[field_supertypes]]
@@ -1367,6 +1382,13 @@ class Card:
         face_mechanics = sorted(list(self.get_face_mechanics()))
         if face_mechanics:
             d['mechanics'] = face_mechanics
+
+        # Color Identity
+        identity = self.color_identity
+        if identity:
+            d['colorIdentity'] = list(identity)
+        else:
+            d['colorIdentity'] = []
 
         # Metadata
         if self.set_code:

--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -166,6 +166,8 @@ def _print_breakdown(title, index, total, use_color, vsize=None, sort_key=None, 
         cat_header = 'Combination'
     elif 'rarity' in t_lower:
         cat_header = 'Rarity'
+    elif 'identity' in t_lower:
+        cat_header = 'Identity'
     elif 'p/t' in t_lower:
         cat_header = 'P/T'
     elif 'loyalty' in t_lower:
@@ -190,7 +192,7 @@ def _print_breakdown(title, index, total, use_color, vsize=None, sort_key=None, 
             if 'rarity' in title.lower():
                 display_color = utils.Ansi.get_rarity_color(k)
                 display_key = utils.colorize(display_key, display_color)
-            elif 'color' in title.lower() and 'number' not in title.lower():
+            elif ('color' in title.lower() or 'identity' in title.lower()) and 'number' not in title.lower() and 'count' not in title.lower():
                 display_color = utils.Ansi.get_color_color(k)
                 display_key = utils.colorize(display_key, display_color)
             elif 'mana costs' in title.lower():
@@ -333,6 +335,9 @@ class Datamine:
         self.by_pt = {}
         self.by_loyalty = {}
         self.by_rarity = {}
+        self.by_identity = {}
+        self.by_identity_inclusive = {}
+        self.by_identity_count = {}
         self.by_textlines = {}
         self.by_textlen = {}
         self.by_mechanic = {}
@@ -348,6 +353,9 @@ class Datamine:
             'by_color' : self.by_color,
             'by_color_inclusive' : self.by_color_inclusive,
             'by_color_count' : self.by_color_count,
+            'by_identity' : self.by_identity,
+            'by_identity_inclusive' : self.by_identity_inclusive,
+            'by_identity_count' : self.by_identity_count,
             'by_cmc' : self.by_cmc,
             'by_cost' : self.by_cost,
             'by_power' : self.by_power,
@@ -414,6 +422,18 @@ class Datamine:
 
                 inc(self.by_rarity, card.rarity_name, [card])
 
+                # Color Identity indexing
+                identity = card.color_identity
+                if identity:
+                    inc(self.by_identity, identity, [card])
+                    for c in identity:
+                        inc(self.by_identity_inclusive, c, [card])
+                    inc(self.by_identity_count, len(identity), [card])
+                else:
+                    inc(self.by_identity, 'A', [card])
+                    inc(self.by_identity_inclusive, 'A', [card])
+                    inc(self.by_identity_count, 0, [card])
+
                 inc(self.by_textlines, len(card.text_lines), [card])
                 inc(self.by_textlen, len(card.text.encode()), [card])
 
@@ -466,7 +486,7 @@ class Datamine:
                 percent = (count / total * 100) if total > 0 else 0
                 color = (utils.Ansi.BOLD + utils.Ansi.GREEN if label == 'Matched'
                          else utils.Ansi.BOLD + utils.Ansi.RED)
-                bar = _get_bar_chart(percent, use_color, color=color)
+                bar = get_bar_chart(percent, use_color, color=color)
 
                 rows.append([
                     label,
@@ -492,6 +512,12 @@ class Datamine:
                + str(len(self.by_color)) + ' combinations', use_color))
         _print_breakdown('Breakdown by color:', self.by_color_inclusive, len(self.allcards), use_color, vsize=vsize)
         _print_breakdown('Breakdown by number of colors:', self.by_color_count, len(self.allcards), use_color, vsize=vsize)
+        print()
+
+        print('  ' + color_line(str(len(self.by_identity_inclusive)) + ' represented identity colors, '
+               + str(len(self.by_identity)) + ' identity combinations', use_color))
+        _print_breakdown('Breakdown by color identity:', self.by_identity, len(self.allcards), use_color, vsize=vsize)
+        _print_breakdown('Breakdown by identity count:', self.by_identity_count, len(self.allcards), use_color, vsize=vsize)
         print()
 
         print('  ' + color_line(str(len(self.by_cmc)) + ' different CMCs, ' +

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -758,6 +758,7 @@ def mtg_open_file(fname, verbose = False,
                   colors=None, cmcs=None,
                   pows=None, tous=None, loys=None,
                   mechanics=None,
+                  identities=None, id_counts=None,
                   shuffle=False, seed=None,
                   decklist_file=None,
                   stats=None, booster=0, box=0):
@@ -1076,7 +1077,7 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
-    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics:
+    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics or identities or id_counts:
         greps = [re.compile(p, re.IGNORECASE) for p in (grep if grep else [])]
         vgreps = [re.compile(p, re.IGNORECASE) for p in (vgrep if vgrep else [])]
         greps_name = [re.compile(p, re.IGNORECASE) for p in (grep_name if grep_name else [])]
@@ -1105,9 +1106,11 @@ def mtg_open_file(fname, verbose = False,
 
         target_colors = [c.upper() for c in colors] if colors else None
         target_mechanics = [m.lower() for m in mechanics] if mechanics else None
+        target_identities = [c.upper() for c in identities] if identities else None
 
         # Initialize NumericFilters
         cmc_filters = [utils.NumericFilter(f) for f in cmcs] if cmcs else []
+        id_count_filters = [utils.NumericFilter(f) for f in id_counts] if id_counts else []
         pow_filters = [utils.NumericFilter(f) for f in pows] if pows else []
         tou_filters = [utils.NumericFilter(f) for f in tous] if tous else []
         loy_filters = [utils.NumericFilter(f) for f in loys] if loys else []
@@ -1244,6 +1247,28 @@ def mtg_open_file(fname, verbose = False,
                         match_mechanic = True
                         break
                 if not match_mechanic:
+                    return False
+
+            # Identity filtering
+            if target_identities:
+                card_identity = card.color_identity
+                match_identity = False
+                for ti in target_identities:
+                    if ti in ['A', 'C']:
+                        if not card_identity: match_identity = True
+                    elif ti in card_identity:
+                        match_identity = True
+                if not match_identity:
+                    return False
+
+            # Identity Count filtering
+            if id_count_filters:
+                match_id_count = False
+                for f in id_count_filters:
+                    if f.evaluate(len(card.color_identity)):
+                        match_id_count = True
+                        break
+                if not match_id_count:
                     return False
 
             return True

--- a/lib/sortlib.py
+++ b/lib/sortlib.py
@@ -69,6 +69,8 @@ def sort_cards(cards, criterion, quiet=False):
         # Flatten the list of lists returned by sort_colors
         segments = sort_colors(cards, quiet=quiet)
         return [card for segment in segments for card in segment]
+    elif criterion == 'identity':
+        return sorted(cards, key=lambda c: (len(c.color_identity), c.color_identity, c.name.lower()))
     elif criterion == 'type':
         return sort_type(cards)
     elif criterion == 'rarity':

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -439,6 +439,7 @@ def main(fname, oname = None, verbose = False, dump = False,
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
+         identities=None, id_counts=None,
          shuffle = False, seed = None, quiet = False, decklist_file = None,
          booster = 0, sort = None, limit = 0, use_color = None, box = 0):
 
@@ -456,6 +457,7 @@ def main(fname, oname = None, verbose = False, dump = False,
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
                                   mechanics=mechanics,
+                                  identities=identities, id_counts=id_counts,
                                   shuffle=shuffle, seed=seed,
                                   decklist_file=decklist_file,
                                   booster=booster,
@@ -646,7 +648,7 @@ if __name__ == '__main__':
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards (shorthand for --shuffle --limit N).')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--booster', type=int, default=0,
                         help='Simulate opening N booster packs.')
@@ -689,6 +691,10 @@ if __name__ == '__main__':
                         help="Only include cards of specific rarities. Supports full names or shorthands (O, N, A, Y, I, L). Supports multiple rarities.")
     filter_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G, C/A). Supports multiple colors.")
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
     filter_group.add_argument('--cmc', action='append',
                         help='Only include cards with specific CMC values. Supports inequalities and ranges.')
     filter_group.add_argument('--pow', '--power', action='append', dest='pow',
@@ -735,6 +741,7 @@ if __name__ == '__main__':
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
+         identities=args.identity, id_counts=args.id_count,
          shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, decklist_file = args.deck,
          booster = args.booster, sort = args.sort, limit = args.limit, use_color = args.color, box = args.box)
     exit(0)

--- a/scripts/splitcards.py
+++ b/scripts/splitcards.py
@@ -45,7 +45,7 @@ def main():
                         help='Seed for the random number generator (Default: 1371367).')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --limit N). Shuffling is enabled unless --stable is used.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
                         help='Sort cards by a specific criterion (enables --stable).')
     proc_group.add_argument('--grep', action='append',
                         help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
@@ -81,6 +81,13 @@ def main():
                         help="Only include cards of specific rarities. Supports full names or shorthands (O, N, A, Y, I, L). Supports multiple rarities.")
     proc_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G, C/A). Supports multiple colors.")
+
+    # Group: Filtering Options
+    filter_group = parser.add_argument_group('Filtering Options')
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append', dest='id_count',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
     proc_group.add_argument('--cmc', action='append',
                         help='Only include cards with specific CMC values. Supports inequalities and ranges.')
     proc_group.add_argument('--pow', '--power', action='append', dest='pow',
@@ -143,6 +150,7 @@ def main():
                                   sets=args.set, rarities=args.rarity, colors=args.colors, cmcs=args.cmc,
                                   pows=args.pow, tous=args.tou, loys=args.loy,
                                   mechanics=args.mechanic,
+                                  identities=args.identity, id_counts=args.id_count,
                                   shuffle=not args.stable, seed=args.seed if args.seed is not None else 1371367,
                                   decklist_file=args.deck, booster=args.booster, box=args.box)
 

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -30,6 +30,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
+         identities=None, id_counts=None,
          shuffle = False, seed = None, quiet = False, oname = None, decklist_file = None,
          top = 10, booster = 0, sort = None, box = 0):
 
@@ -53,6 +54,7 @@ def main(fname, verbose = True, outliers = False, dump_all = False,
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
                                   mechanics=mechanics,
+                                  identities=identities, id_counts=id_counts,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
@@ -131,7 +133,7 @@ if __name__ == '__main__':
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --shuffle --limit N).')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--booster', type=int, default=0,
                         help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
@@ -174,6 +176,10 @@ if __name__ == '__main__':
                         help="Only include cards of specific rarities. Supports full names (e.g., 'common', 'mythic') or shorthands: O (Common), N (Uncommon), A (Rare), Y (Mythic), I (Special), L (Basic Land). Supports multiple rarities (OR logic).")
     filter_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
     filter_group.add_argument('--cmc', action='append',
                         help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
     filter_group.add_argument('--pow', '--power', action='append', dest='pow',
@@ -220,6 +226,7 @@ if __name__ == '__main__':
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
+         identities=args.identity, id_counts=args.id_count,
          shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, oname = args.outfile, decklist_file = args.deck,
          top = args.top, booster = args.booster, sort = args.sort, box = args.box)
     exit(0)

--- a/sortcards.py
+++ b/sortcards.py
@@ -254,6 +254,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
          sets = None, rarities = None, colors=None, cmcs=None,
          pows=None, tous=None, loys=None,
          mechanics=None,
+         identities=None, id_counts=None,
          shuffle = False, seed = None, decklist_file = None,
          booster = 0, box = 0):
 
@@ -288,6 +289,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                                   colors=colors, cmcs=cmcs,
                                   pows=pows, tous=tous, loys=loys,
                                   mechanics=mechanics,
+                                  identities=identities, id_counts=id_counts,
                                   exclude_sets=lambda x: False,
                                   exclude_types=lambda x: False,
                                   exclude_layouts=lambda x: False,
@@ -411,7 +413,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
     proc_group = parser.add_argument_group('Processing Options')
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Only process the first N cards.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--shuffle', action='store_true',
                         help='Randomize the order of cards before sorting.')
@@ -453,6 +455,13 @@ Supports any encoding format supported by encode.py/decode.py.""",
                         help="Only include cards of specific rarities. Supports full names (e.g., 'common', 'mythic') or shorthands: O (Common), N (Uncommon), A (Rare), Y (Mythic), I (Special), L (Basic Land). Supports multiple rarities (OR logic).")
     proc_group.add_argument('--colors', action='append',
                         help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+
+    # Group: Filtering Options
+    filter_group = parser.add_argument_group('Filtering Options')
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
     proc_group.add_argument('--cmc', action='append',
                         help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
     proc_group.add_argument('--pow', '--power', action='append', dest='pow',
@@ -521,6 +530,7 @@ Supports any encoding format supported by encode.py/decode.py.""",
          sets = args.set, rarities = args.rarity, colors=args.colors, cmcs=args.cmc,
          pows=args.pow, tous=args.tou, loys=args.loy,
          mechanics=args.mechanic,
+         identities=args.identity, id_counts=args.id_count,
          shuffle = args.shuffle, seed = args.seed, decklist_file = args.deck,
          booster = args.booster, box = args.box)
 


### PR DESCRIPTION
This PR implements full support for "Color Identity" across the entire toolkit.

### Key Features:
- **Automatic Calculation**: Color identity is derived from a card's mana cost, mana symbols in its rules text, and recursively from any additional faces (b-sides).
- **Advanced Filtering**: All core tools now support `--identity` (match colors within the identity) and `--id-count` (filter by number of colors in the identity).
- **Sorting**: Added `--sort identity` to order cards by the complexity and specific colors of their identity.
- **Reporting**: `summarize.py` now includes statistical breakdowns for identity combinations and counts, complete with visual bar charts.
- **Interoperability**: JSON exports now include the `colorIdentity` field.

### Robustness & Bug Fixes:
- Fixed a `NameError` in `sortcards.py` where the filtering group was incorrectly referenced.
- Resolved an `AttributeError` in `lib/cardlib.py` by ensuring property access is safe when rules text is not yet fully parsed.
- Fixed a scoping issue in `lib/datalib.py` regarding the bar chart utility function.
- Verified functionality using a custom test script on complex cards like Uthros and through the existing test suite.

---
*PR created automatically by Jules for task [7665471710251985039](https://jules.google.com/task/7665471710251985039) started by @RainRat*