### PR TITLE
Fix card rarity parsing logic for internal markers

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -290,11 +290,14 @@ def fields_from_json(src_json, linetrans = True):
 
     if 'rarity' in src_json:
         # Use lowercase for robust rarity lookup
-        rarity_key = src_json['rarity'].lower() if hasattr(src_json['rarity'], 'lower') else src_json['rarity']
+        rarity_val = src_json['rarity']
+        rarity_key = rarity_val.lower() if hasattr(rarity_val, 'lower') else rarity_val
         if rarity_key in utils.json_rarity_map:
             fields[field_rarity] = [(-1, utils.json_rarity_map[rarity_key])]
+        elif rarity_val in utils.json_rarity_unmap:
+            fields[field_rarity] = [(-1, rarity_val)]
         else:
-            fields[field_rarity] = [(-1, src_json['rarity'])]
+            fields[field_rarity] = [(-1, rarity_val)]
             parsed = False
     else:
         parsed = False


### PR DESCRIPTION
This PR fixes a logic bug in `lib/cardlib.py` where card rarity values that were already correctly mapped to internal markers (like 'O' for Common) were being treated as unparsed during JSON import.

The `fields_from_json` function now validates the rarity value against `utils.json_rarity_unmap` if it is not found in the primary `utils.json_rarity_map`. This ensures that cards imported from formats that already use these markers are accepted as valid.

Verification:
- Created a reproduction script that demonstrated rarity 'O' being flagged with `[!]` (unparsed) in the summary.
- Verified that after the fix, rarity 'O' is treated correctly (no `[!]` marker).
- Ran the full test suite (`PYTHONPATH=. python3 -m pytest`), and all 512 tests passed.

---
*PR created automatically by Jules for task [3388163970807427917](https://jules.google.com/task/3388163970807427917) started by @RainRat*