### PR TITLE
[Refactor] Robust, case-insensitive card type properties in cardlib.py

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -511,42 +511,42 @@ class Card:
     @property
     def is_artifact(self):
         """Returns True if the card is an artifact."""
-        return 'artifact' in self.types
+        return any(t.lower() == 'artifact' for t in self.types)
 
     @property
     def is_creature(self):
         """Returns True if the card is a creature or a vehicle."""
-        return 'creature' in self.types or 'vehicle' in self.subtypes
+        return any(t.lower() == 'creature' for t in self.types) or any(s.lower() == 'vehicle' for s in self.subtypes)
 
     @property
     def is_planeswalker(self):
         """Returns True if the card is a planeswalker."""
-        return 'planeswalker' in self.types
+        return any(t.lower() == 'planeswalker' for t in self.types)
 
     @property
     def is_battle(self):
         """Returns True if the card is a battle."""
-        return 'battle' in self.types
+        return any(t.lower() == 'battle' for t in self.types)
 
     @property
     def is_land(self):
         """Returns True if the card is a land."""
-        return 'land' in self.types
+        return any(t.lower() == 'land' for t in self.types)
 
     @property
     def is_enchantment(self):
         """Returns True if the card is an enchantment."""
-        return 'enchantment' in self.types
+        return any(t.lower() == 'enchantment' for t in self.types)
 
     @property
     def is_instant(self):
         """Returns True if the card is an instant."""
-        return 'instant' in self.types
+        return any(t.lower() == 'instant' for t in self.types)
 
     @property
     def is_sorcery(self):
         """Returns True if the card is a sorcery."""
-        return 'sorcery' in self.types
+        return any(t.lower() == 'sorcery' for t in self.types)
 
     @property
     def color_identity(self):
@@ -777,7 +777,7 @@ class Card:
         else:
             # Colorless / Artifacts
             # Lands are typically just BOLD, non-land colorless are CYAN
-            if 'land' not in [t.lower() for t in self.types]:
+            if not self.is_land:
                 return utils.Ansi.get_color_color('A')
             return utils.Ansi.BOLD
 
@@ -1628,12 +1628,11 @@ class Card:
         # Determine tablerow
         # 0: Land, 1: Other, 2: Creature, 3: Spells
         tablerow = 1
-        types_lower = [t.lower() for t in self.types]
-        if 'land' in types_lower:
+        if self.is_land:
             tablerow = 0
-        elif 'creature' in types_lower:
+        elif any(t.lower() == 'creature' for t in self.types):
             tablerow = 2
-        elif 'instant' in types_lower or 'sorcery' in types_lower:
+        elif self.is_instant or self.is_sorcery:
             tablerow = 3
 
         xml_out = "    <card>\n"

--- a/tests/test_type_properties_robustness.py
+++ b/tests/test_type_properties_robustness.py
@@ -1,0 +1,39 @@
+from lib.cardlib import Card
+
+def test_type_properties_case_insensitivity():
+    # Create a card with mixed-case types
+    card_json = {
+        "name": "Mixed Case Card",
+        "types": ["Creature", "Artifact"],
+        "subtypes": ["Vehicle"]
+    }
+    card = Card(card_json)
+
+    # In this project, Card initialization from JSON currently converts types to lowercase
+    # So we should also test by manually setting types to mixed case
+    card.types = ["Creature", "Artifact"]
+    card.subtypes = ["Vehicle"]
+
+    assert card.is_creature
+    assert card.is_artifact
+    assert not card.is_land
+
+    card.types = ["Land"]
+    card.subtypes = [] # Clear subtypes
+    assert card.is_land
+    assert not card.is_creature
+
+    card.types = ["Instant"]
+    assert card.is_instant
+
+    card.types = ["Sorcery"]
+    assert card.is_sorcery
+
+    card.types = ["Planeswalker"]
+    assert card.is_planeswalker
+
+    card.types = ["Battle"]
+    assert card.is_battle
+
+    card.types = ["Enchantment"]
+    assert card.is_enchantment


### PR DESCRIPTION
* **What:** Updated the `is_artifact`, `is_creature`, `is_planeswalker`, `is_battle`, `is_land`, `is_enchantment`, `is_instant`, and `is_sorcery` properties in the `Card` class to perform case-insensitive checks on `self.types` and `self.subtypes`. Additionally, refactored `_get_ansi_color` and `to_cockatrice_xml` to use these properties instead of re-implementing manual type checks.
* **Why:** This improvement centralizes type-checking logic, making the `Card` class more robust to data variations (e.g., when card types are not normalized to lowercase) and reducing code duplication. No breaking changes were introduced; existing behavior, including the exclusion of non-creature Vehicles from the Cockatrice creature tablerow, was preserved.

---
*PR created automatically by Jules for task [10518788055258790343](https://jules.google.com/task/10518788055258790343) started by @RainRat*