### PR TITLE
[DOCS] Clarify custom card CSV format and improve newline handling

### DIFF
--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -37,9 +37,9 @@ Create a CSV file with your custom cards. You can start with this [Google Sheet 
     *   **Mana Cost**: Use brackets for symbols (e.g., `{1}{W}{B}`).
     *   **Type**: Supertypes and Types (e.g., `Legendary Creature`).
     *   **Subtypes**: (e.g., `Elf Warrior`).
-    *   **Text**: Rules text. Use `\n` for new lines.
+    *   **Text**: Rules text. Use `\n` or literal newlines for new lines.
     *   **P/T, Loyalty, or Defense**: Use `3/3` for creatures, or a single number for Planeswalker loyalty or Battle defense.
-    *   **Rarity**: Use shorthands: `C` (Common), `U` (Uncommon), `R` (Rare), `M` (Mythic).
+    *   **Rarity**: Use shorthands: `C` (Common), `U` (Uncommon), `R` (Rare), `M` (Mythic), `L` (Basic Land), `I` (Special).
 3.  Click **File -> Download -> Comma Separated Values (.csv)**.
 4.  Save it as `custom.csv`.
 

--- a/scripts/csv2json.py
+++ b/scripts/csv2json.py
@@ -30,9 +30,9 @@ CSV Format (7 columns in this order):
   2. Mana Cost: The mana symbols in braces (e.g., "{G}" or "{1}{W}{B}").
   3. Types: Supertypes and card types (e.g., "Legendary Creature").
   4. Subtypes: Subtypes separated by spaces (e.g., "Elf Warrior").
-  5. Text: Rules text. Use "\\\\" for new lines.
+  5. Text: Rules text. Use "\\n" or literal newlines for new lines.
   6. Stats: Power/Toughness (3/3), Loyalty (5), or Defense (3).
-  7. Rarity: Short marker (C, U, R, M) or full name (common, rare, etc.).
+  7. Rarity: Short marker (C, U, R, M, L, I) or full name (common, rare, etc.).
 
 Note: The first row is ignored if the first column is exactly "name".
 ''',
@@ -42,7 +42,7 @@ parser.add_argument('csv_file', help='Path to the input CSV file.')
 parser.add_argument('json_output', help='Path to the output JSON file.')
 args = parser.parse_args()
 
-rarity_mapping = {"R": "rare", "U": "uncommon", "C": "common", "M": "mythic"}
+rarity_mapping = {"R": "rare", "U": "uncommon", "C": "common", "M": "mythic", "L": "basic land", "I": "special"}
 
 with open(args.csv_file) as csvfile, open(args.json_output, 'w') as jsonfile:
     reader = csv.reader(csvfile)
@@ -60,7 +60,7 @@ with open(args.csv_file) as csvfile, open(args.json_output, 'w') as jsonfile:
             "name": row[0],
             "rarity": temprarity,
             "setCode": "CUS",
-            "text": row[4],
+            "text": row[4].replace("\\n", "\n"),
         }
         # supertypes, types, subtypes
         supertypes, types = utils.split_types(row[2])

--- a/tests/test_csv2json.py
+++ b/tests/test_csv2json.py
@@ -22,9 +22,9 @@ def test_csv2json_escaping():
 
         card = data['data']['CUS']['cards'][0]
         assert card['name'] == '"Giant" Growth'
-        # We expect the text to be exactly as in CSV (after csv.reader parsing)
-        # "He said ""Hello"".\\nNew line." in CSV -> He said "Hello".\nNew line. (literal \ and n)
-        assert card['text'] == 'He said "Hello".\\nNew line.'
+        # We expect the text to have \\n replaced by actual newline
+        # "He said ""Hello"".\\nNew line." in CSV -> He said "Hello".\nNew line.
+        assert card['text'] == 'He said "Hello".\nNew line.'
 
 def test_csv2json_newlines():
     # Test with actual newlines in CSV cells (requires quoting)


### PR DESCRIPTION
This PR improves the documentation and utility for creating custom cards. 

**Key Changes:**
1.  **Documentation:** `CUSTOM.md` and the `csv2json.py` help text now consistently recommend using `\n` for newlines in card text, which is more intuitive for most users than previous instructions.
2.  **Rarity Support:** Added support for `L` (Basic Land) and `I` (Special) rarity shorthands in both documentation and the conversion script.
3.  **Functional Improvement:** The `csv2json.py` script now automatically converts the string sequence `\n` into actual newline characters, ensuring that "Truth First" documentation matches the tool's behavior.
4.  **Tests:** Updated existing tests to verify the new newline handling logic.
5.  **Cleanliness:** Removed temporary test artifacts created during development.

---
*PR created automatically by Jules for task [11146757826408121263](https://jules.google.com/task/11146757826408121263) started by @RainRat*