### PR TITLE
[FEAT] Mechanical Profile Comparison for Datasets

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -11,6 +11,16 @@ import nltk.data
 
 from titlecase import titlecase
 
+# List of all mechanics recognized by get_face_mechanics()
+RECOGNIZED_MECHANICS = [
+    'Activated', 'Triggered', 'ETB Effect', 'Modal/Choice', 'X-Cost/Effect',
+    'Kicker', 'Uncast', 'Equipment', 'Leveler', 'Counters',
+    'Flying', 'Trample', 'Lifelink', 'Haste', 'Deathtouch', 'Vigilance',
+    'Ward', 'Prowess', 'Menace', 'Reach', 'Flash', 'Indestructible',
+    'Defender', 'Scry', 'Draw A Card', 'Mill', 'Exile', 'Token',
+    'Discard', 'Cycling', 'Convoke'
+]
+
 sent_tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
 # This could be made smarter - MSE will capitalize for us after :,
 # but we still need to capitalize the first english component of an activation

--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -38,12 +38,20 @@ def padrows(rows, aligns=None):
         padded_cells = []
         for i, cell in enumerate(row):
             s = str(cell)
-            pad = ' ' * (col_widths[i] - utils.visible_len(s))
+            vis_len = utils.visible_len(s)
+            diff = col_widths[i] - vis_len
 
-            if aligns and i < len(aligns) and aligns[i] == 'r':
-                cell_str = pad + s
+            if aligns and i < len(aligns):
+                if aligns[i] == 'r':
+                    cell_str = (' ' * diff) + s
+                elif aligns[i] == 'c':
+                    left = diff // 2
+                    right = diff - left
+                    cell_str = (' ' * left) + s + (' ' * right)
+                else: # 'l'
+                    cell_str = s + (' ' * diff)
             else:
-                cell_str = s + pad
+                cell_str = s + (' ' * diff)
 
             padded_cells.append(cell_str)
 

--- a/scripts/mtg_mechanics.py
+++ b/scripts/mtg_mechanics.py
@@ -11,16 +11,8 @@ sys.path.append(libdir)
 import utils
 import jdecode
 import datalib
-
-# List of all mechanics recognized by lib/cardlib.py
-RECOGNIZED_MECHANICS = [
-    'Activated', 'Triggered', 'ETB Effect', 'Modal/Choice', 'X-Cost/Effect',
-    'Kicker', 'Uncast', 'Equipment', 'Leveler', 'Counters',
-    'Flying', 'Trample', 'Lifelink', 'Haste', 'Deathtouch', 'Vigilance',
-    'Ward', 'Prowess', 'Menace', 'Reach', 'Flash', 'Indestructible',
-    'Defender', 'Scry', 'Draw A Card', 'Mill', 'Exile', 'Token',
-    'Discard', 'Cycling', 'Convoke'
-]
+import cardlib
+from cardlib import RECOGNIZED_MECHANICS
 
 def main():
     parser = argparse.ArgumentParser(description="List all recognized mechanical keywords and optionally count their frequency in a dataset.")
@@ -29,21 +21,86 @@ def main():
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default=None,
                         help='Input card data (MTGJSON, Scryfall, CSV, etc.) to count mechanics. If not provided, just lists recognized mechanics.')
+    io_group.add_argument('--compare', '-c',
+                        help='Optional second dataset to compare against the primary input.')
+
+    # Group: Content Formatting
+    enc_group = parser.add_argument_group('Content Formatting')
+    enc_group.add_argument('--nolabel', action='store_true',
+                        help="Remove field labels (like '|cost|' or '|text|') from the input.")
+    enc_group.add_argument('--nolinetrans', action='store_true',
+                        help='Input file does not use automatic line reordering.')
 
     # Group: Data Processing
     proc_group = parser.add_argument_group('Data Processing')
     proc_group.add_argument('--sort', choices=['name', 'count'], default='name',
                         help='Sort mechanics by name or frequency count (Default: name).')
     proc_group.add_argument('--reverse', action='store_true', help='Reverse the sort order.')
-    proc_group.add_argument('--limit', type=int, default=0, help='Only show the top N mechanics.')
+    proc_group.add_argument('-n', '--max-cards', type=int, default=0, help='Only process the first N cards.')
+    proc_group.add_argument('-t', '--top', '--limit', dest='top', type=int, default=0, help='Only show the top N mechanics in the output.')
 
     # Group: Filtering Options (Standard across tools)
     filter_group = parser.add_argument_group('Filtering Options')
-    filter_group.add_argument('--set', action='append', help='Only include cards from specific sets.')
-    filter_group.add_argument('--rarity', action='append', help='Only include cards of specific rarities.')
-    filter_group.add_argument('--grep', action='append', help='Only include cards matching a search pattern.')
-    filter_group.add_argument('--colors', action='append', help='Only include cards of specific colors.')
-    filter_group.add_argument('--cmc', action='append', help='Only include cards with specific CMC values.')
+    filter_group.add_argument('--grep', action='append',
+                        help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
+    filter_group.add_argument('--grep-name', action='append',
+                        help='Only include cards whose name matches a search pattern.')
+    filter_group.add_argument('--grep-type', action='append',
+                        help='Only include cards whose typeline matches a search pattern.')
+    filter_group.add_argument('--grep-text', action='append',
+                        help='Only include cards whose rules text matches a search pattern.')
+    filter_group.add_argument('--grep-cost', action='append',
+                        help='Only include cards whose mana cost matches a search pattern.')
+    filter_group.add_argument('--grep-pt', action='append',
+                        help='Only include cards whose power/toughness matches a search pattern.')
+    filter_group.add_argument('--grep-loyalty', action='append',
+                        help='Only include cards whose loyalty/defense matches a search pattern.')
+    filter_group.add_argument('--vgrep', '--exclude', action='append',
+                        help='Exclude cards matching a search pattern (checks name, type, and text). Use multiple times for OR logic.')
+    filter_group.add_argument('--exclude-name', action='append',
+                        help='Exclude cards whose name matches a search pattern.')
+    filter_group.add_argument('--exclude-type', action='append',
+                        help='Exclude cards whose typeline matches a search pattern.')
+    filter_group.add_argument('--exclude-text', action='append',
+                        help='Exclude cards whose rules text matches a search pattern.')
+    filter_group.add_argument('--exclude-cost', action='append',
+                        help='Exclude cards whose mana cost matches a search pattern.')
+    filter_group.add_argument('--exclude-pt', action='append',
+                        help='Exclude cards whose power/toughness matches a search pattern.')
+    filter_group.add_argument('--exclude-loyalty', action='append',
+                        help='Exclude cards whose loyalty/defense matches a search pattern.')
+    filter_group.add_argument('--set', action='append',
+                        help='Only include cards from specific sets (e.g., MOM, MRD). Supports multiple sets (OR logic).')
+    filter_group.add_argument('--rarity', action='append',
+                        help="Only include cards of specific rarities. Supports full names or shorthands (O, N, A, Y, I, L). Supports multiple rarities.")
+    filter_group.add_argument('--colors', action='append',
+                        help="Only include cards of specific colors (W, U, B, R, G, C/A). Supports multiple colors.")
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
+    filter_group.add_argument('--cmc', action='append',
+                        help='Only include cards with specific CMC values. Supports inequalities and ranges.')
+    filter_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities and ranges.')
+    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
+    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
+    filter_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities. Supports multiple values.')
+    filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
+                        help='Filter cards using a standard MTG decklist file.')
+    filter_group.add_argument('--booster', type=int, default=0,
+                        help='Simulate opening N booster packs.')
+    filter_group.add_argument('--box', type=int, default=0,
+                        help='Simulate opening N booster boxes (36 packs each).')
+    filter_group.add_argument('--shuffle', action='store_true',
+                        help='Randomize the order of cards.')
+    filter_group.add_argument('--sample', type=int, default=0,
+                        help='Pick N random cards.')
+    filter_group.add_argument('--seed', type=int,
+                        help='Seed for the random number generator.')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')
@@ -56,6 +113,11 @@ def main():
     color_group.add_argument('--no-color', action='store_false', dest='color', help='Disable ANSI color output.')
 
     args = parser.parse_args()
+
+    # Handle --sample
+    if args.sample > 0:
+        args.shuffle = True
+        args.max_cards = args.sample
 
     # Determine if we should use color
     use_color = False
@@ -73,67 +135,141 @@ def main():
         return
 
     # Load cards and count mechanics
-    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose,
-                                  sets=args.set, rarities=args.rarity,
-                                  grep=args.grep, colors=args.colors, cmcs=args.cmc)
+    def load_and_count(path):
+        if not path:
+            return None, None
 
-    if not cards:
-        print("No cards found matching criteria.", file=sys.stderr)
+        cards = jdecode.mtg_open_file(path, verbose=args.verbose,
+                                      linetrans=not args.nolinetrans,
+                                      fmt_labeled=None if args.nolabel else cardlib.fmt_labeled_default,
+                                      grep=args.grep, vgrep=args.vgrep,
+                                      grep_name=args.grep_name, vgrep_name=args.exclude_name,
+                                      grep_types=args.grep_type, vgrep_types=args.exclude_type,
+                                      grep_text=args.grep_text, vgrep_text=args.exclude_text,
+                                      grep_cost=args.grep_cost, vgrep_cost=args.exclude_cost,
+                                      grep_pt=args.grep_pt, vgrep_pt=args.exclude_pt,
+                                      grep_loyalty=args.grep_loyalty, vgrep_loyalty=args.exclude_loyalty,
+                                      sets=args.set, rarities=args.rarity,
+                                      colors=args.colors, cmcs=args.cmc,
+                                      pows=args.pow, tous=args.tou, loys=args.loy,
+                                      mechanics=args.mechanic,
+                                      identities=args.identity, id_counts=args.id_count,
+                                      decklist_file=args.deck, booster=args.booster, box=args.box,
+                                      shuffle=args.shuffle, seed=args.seed)
+        if args.max_cards > 0:
+            cards = cards[:args.max_cards]
+
+        if not cards:
+            return None, 0
+
+        counts = Counter()
+        for card in cards:
+            for m in card.mechanics:
+                counts[m] += 1
+        return counts, len(cards)
+
+    counts1, total1 = load_and_count(args.infile)
+    if not counts1:
+        print(f"No cards found in {args.infile} matching criteria.", file=sys.stderr)
         return
 
-    counts = Counter()
-    for card in cards:
-        for m in card.mechanics:
-            counts[m] += 1
+    counts2, total2 = load_and_count(args.compare)
 
     # Prepare data for display
-    total_cards = len(cards)
-    results = []
-    for m in RECOGNIZED_MECHANICS:
-        count = counts.get(m, 0)
-        results.append({'name': m, 'count': count})
+    all_mechanics = set(counts1.keys())
+    if counts2:
+        all_mechanics.update(counts2.keys())
 
-    # Add any other mechanics found (though get_face_mechanics only returns from our list)
-    for m in counts:
-        if m not in RECOGNIZED_MECHANICS:
-            results.append({'name': m, 'count': counts[m]})
+    # We prioritize recognized mechanics then others
+    ordered_mechanics = [m for m in RECOGNIZED_MECHANICS if m in all_mechanics]
+    ordered_mechanics += sorted([m for m in all_mechanics if m not in RECOGNIZED_MECHANICS])
+
+    results = []
+    for m in ordered_mechanics:
+        c1 = counts1.get(m, 0)
+        p1 = (c1 / total1 * 100) if total1 > 0 else 0
+
+        res = {'name': m, 'count1': c1, 'percent1': p1}
+
+        if counts2:
+            c2 = counts2.get(m, 0)
+            p2 = (c2 / total2 * 100) if total2 > 0 else 0
+            res.update({'count2': c2, 'percent2': p2, 'delta': p2 - p1})
+
+        results.append(res)
 
     # Sorting
     if args.sort == 'name':
         results.sort(key=lambda x: x['name'].lower(), reverse=args.reverse)
-    else:
-        results.sort(key=lambda x: x['count'], reverse=not args.reverse)
+    elif args.sort == 'count':
+        # Default to base dataset count for sorting
+        results.sort(key=lambda x: x['count1'], reverse=not args.reverse)
 
-    if args.limit > 0:
-        results = results[:args.limit]
+    if args.top > 0:
+        results = results[:args.top]
 
     # Display results
-    header = ["Mechanic", "Count", "Percent", "Frequency"]
-    if use_color:
-        header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+    if counts2:
+        header = ["Mechanic", f"% {os.path.basename(args.infile)[:15]}", f"% {os.path.basename(args.compare)[:15]}", "Delta", "Indicator"]
+        if use_color:
+            header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
 
-    rows = [header]
-    for r in results:
-        name = r['name']
-        count = r['count']
-        percent = (count / total_cards * 100) if total_cards > 0 else 0
-        bar = datalib.get_bar_chart(percent, use_color, color=utils.Ansi.CYAN)
+        rows = [header]
+        for r in results:
+            name_str = utils.colorize(r['name'], utils.Ansi.CYAN) if use_color else r['name']
+            p1_str = f"{r['percent1']:5.1f}%"
+            p2_str = f"{r['percent2']:5.1f}%"
 
-        name_str = utils.colorize(name, utils.Ansi.CYAN) if use_color else name
-        count_str = datalib.color_count(count, use_color, utils.Ansi.BOLD + utils.Ansi.GREEN) if use_color else str(count)
+            delta = r['delta']
+            delta_str = f"{delta:+6.1f}%"
+            indicator = ""
+            if delta > 0.1:
+                indicator = "▲"
+                if use_color:
+                    delta_str = utils.colorize(delta_str, utils.Ansi.BOLD + utils.Ansi.GREEN)
+                    indicator = utils.colorize(indicator, utils.Ansi.BOLD + utils.Ansi.GREEN)
+            elif delta < -0.1:
+                indicator = "▼"
+                if use_color:
+                    delta_str = utils.colorize(delta_str, utils.Ansi.BOLD + utils.Ansi.RED)
+                    indicator = utils.colorize(indicator, utils.Ansi.BOLD + utils.Ansi.RED)
+            else:
+                indicator = "•"
 
-        rows.append([name_str, count_str, f"{percent:5.1f}%", bar])
+            rows.append([name_str, p1_str, p2_str, delta_str, indicator])
+
+        title = f"MECHANICAL COMPARISON ({total1} vs {total2} cards)"
+        aligns = ['l', 'r', 'r', 'r', 'c']
+    else:
+        header = ["Mechanic", "Count", "Percent", "Frequency"]
+        if use_color:
+            header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+
+        rows = [header]
+        for r in results:
+            name = r['name']
+            count = r['count1']
+            percent = r['percent1']
+            bar = datalib.get_bar_chart(percent, use_color, color=utils.Ansi.CYAN)
+
+            name_str = utils.colorize(name, utils.Ansi.CYAN) if use_color else name
+            count_str = datalib.color_count(count, use_color, utils.Ansi.BOLD + utils.Ansi.GREEN) if use_color else str(count)
+
+            rows.append([name_str, count_str, f"{percent:5.1f}%", bar])
+
+        title = f"MECHANICAL FREQUENCY (Total Cards: {total1})"
+        aligns = ['l', 'r', 'r', 'l']
 
     # Get column widths and add a separator
     col_widths = datalib.get_col_widths(rows)
     separator = ['-' * w for w in col_widths]
     rows.insert(1, separator)
 
-    print(utils.colorize(f"MECHANICAL FREQUENCY (Total Cards: {total_cards})", utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE) if use_color else f"=== MECHANICAL FREQUENCY (Total Cards: {total_cards}) ===")
-    datalib.printrows(datalib.padrows(rows, aligns=['l', 'r', 'r', 'l']), indent=2)
+    print(utils.colorize(title, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE) if use_color else f"=== {title} ===")
+    datalib.printrows(datalib.padrows(rows, aligns=aligns), indent=2)
 
     # Provide clear feedback on operation completion
-    utils.print_operation_summary("Analysis", total_cards, 0, quiet=args.quiet)
+    utils.print_operation_summary("Analysis", total1 + (total2 if total2 else 0), 0, quiet=args.quiet)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I have implemented a side-by-side mechanical comparison feature in the toolkit. This fills a gap in the analytical tools, allowing users to compare the distribution of mechanics (like Flying, ETB Effect, Activated, etc.) between two datasets (e.g., an AI-generated set and its training data).

Highlights:
- **Centralized Mechanics Knowledge:** Moved the master list of mechanics to `lib/cardlib.py`.
- **Comparative Analysis:** `mtg_mechanics.py` can now take a `--compare` file and generate a table with delta percentages and visual indicators (▲/▼).
- **Consistency:** Standardized filtering and formatting flags across `mtg_mechanics.py` to match the rest of the toolkit.
- **Improved UI:** Added center alignment support to the core table renderer.
- **Safe Implementation:** Maintained backward compatibility for existing CLI flags.

All 520 existing tests passed, ensuring no regressions in core card parsing or mechanical extraction logic.

---
*PR created automatically by Jules for task [14445000669316007360](https://jules.google.com/task/14445000669316007360) started by @RainRat*