### PR TITLE
Remove redundant validation in Card.color_identity

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -562,10 +562,9 @@ class Card:
     def color_identity(self):
         """Returns the color identity of the card (mana cost + rules text symbols)."""
         colors = set(self.cost.colors)
-        if hasattr(self.text, 'costs'):
-            for cost in self.text.costs:
-                for char in cost.colors:
-                    colors.add(char)
+        for cost in self.text.costs:
+            for char in cost.colors:
+                colors.add(char)
 
         if self.bside:
             for char in self.bside.color_identity:


### PR DESCRIPTION
* **What:** Removed the redundant `hasattr(self.text, 'costs')` check in the `Card.color_identity` property in `lib/cardlib.py`.
* **Why:** `self.text` is guaranteed to be a `Manatext` object (initialized in `_init_defaults`), which always has a `costs` attribute. Removing this check makes the code cleaner and more consistent with other attribute accesses in the same class. No breaking changes were introduced, as verified by the full test suite (549 tests passed).

---
*PR created automatically by Jules for task [7710062231161249543](https://jules.google.com/task/7710062231161249543) started by @RainRat*