### PR TITLE
[DOCS] Add documentation for mtg_sets.py to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,24 @@ python3 scripts/mtg_validate.py data/AllPrintings.json --dump
     *   `-q`, `--quiet`: Suppress the progress bar.
     *   Supports all **Advanced Filtering** flags.
 
+### `mtg_sets.py`
+Lists and filters sets in an MTGJSON file. This is useful for seeing which sets are available in a large dataset like `AllPrintings.json`.
+```bash
+# List all sets in a dataset
+python3 scripts/mtg_sets.py data/AllPrintings.json
+
+# Find sets with "Masters" in their name or code
+python3 scripts/mtg_sets.py data/AllPrintings.json --grep "Masters"
+```
+*   **Options:**
+    *   `-n LIMIT`, `--limit LIMIT`: Only process the first N sets.
+    *   `--shuffle`: Randomize the order of sets before listing.
+    *   `--sample N`: Pick N random sets (shorthand for `--shuffle --limit N`).
+    *   `--sort {code,name,type,date,count}`: Sort sets by a specific criterion (Default: date).
+    *   `--reverse`: Reverse the sort order.
+    *   `--grep PATTERN`: Only include sets matching a search pattern (checks name and code). Use multiple times for AND logic.
+    *   `--color` / `--no-color`: Enable or disable ANSI color output.
+
 ### `mtg_diff.py`
 Compares two card datasets and identifies additions, removals, and modifications. It highlights changes in cost, type, stats, text, and rarity.
 ```bash


### PR DESCRIPTION
This PR improves the project documentation by adding a new section for the `mtg_sets.py` utility script in the root `README.md`. 

The added documentation:
- Explains the script's purpose (listing and filtering MTG sets).
- Provides practical usage examples (listing all sets, filtering by name/code).
- Details available CLI options (`--limit`, `--shuffle`, `--sample`, `--sort`, `--reverse`, `--grep`).
- Adheres to the 'Plain English' and simplicity guidelines for better accessibility.

The `mtg_sets.py` script was previously undocumented in the README, making it difficult for users to discover and use effectively.

---
*PR created automatically by Jules for task [7647373176246568804](https://jules.google.com/task/7647373176246568804) started by @RainRat*