### PR TITLE
[UI/UX] Reorder card table columns for better visual hierarchy

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -221,10 +221,10 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
         if for_md_table:
             if booster > 0:
-                writer.write("| Pack | Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |\n")
+                writer.write("| Pack | Name | Cost | CMC | Type | Stats | Rarity | Mechanics | Rules Text |\n")
                 writer.write("| ---: | :--- | :--- | ---: | :--- | ---: | :--- | :--- | :--- |\n")
             else:
-                writer.write("| Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |\n")
+                writer.write("| Name | Cost | CMC | Type | Stats | Rarity | Mechanics | Rules Text |\n")
                 writer.write("| :--- | :--- | ---: | :--- | ---: | :--- | :--- | :--- |\n")
         if for_mse:
             # have to prepend a massive chunk of formatting info
@@ -298,7 +298,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         if for_table:
             import datalib
             rows = []
-            header = ["Name", "Cost", "CMC", "Type", "Stats", "Mechanics", "Rarity"]
+            header = ["Name", "Cost", "CMC", "Type", "Stats", "Rarity", "Mechanics"]
             if booster > 0 or box > 0:
                 header.insert(0, "Pack")
             if box > 0:

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1552,7 +1552,7 @@ class Card:
         name, cost, cmc, typeline, stats, text, rarity, mechanics = self._get_display_data(include_text=True)
 
         # Escape pipe characters and ensure no actual newlines break the row
-        fields = [name, cost, cmc, typeline, stats, mechanics, text, rarity]
+        fields = [name, cost, cmc, typeline, stats, rarity, mechanics, text]
         fields = [f.replace('|', '\\|').replace('\n', ' ') for f in fields]
 
         return f"| {' | '.join(fields)} |"
@@ -1561,7 +1561,7 @@ class Card:
         """Returns a list of strings representing the card's fields for a terminal table."""
         name, cost, cmc, typeline, stats, _, rarity, mechanics = self._get_display_data(ansi_color=ansi_color)
 
-        return [name, cost, cmc, typeline, stats, mechanics, rarity]
+        return [name, cost, cmc, typeline, stats, rarity, mechanics]
 
     def vectorize(self):
         """Vectorizes the card data into a string format suitable for machine learning.

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -45,14 +45,14 @@ def test_markdown_table_format():
     card = cardlib.Card(src)
     row = card.to_markdown_row()
     # Mechanics "Lifelink" is now present
-    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | Lifelink | common |" in row
+    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | common | Lifelink | Lifelink |" in row
 
 def test_markdown_table_split_card():
     src = "|1Fire|5Sorcery|3{RR}|9Fire deals &^^ damage to any target.\n|1Ice|5Sorcery|3{^}{UU}|9Draw a card."
     card = cardlib.Card(src)
     row = card.to_markdown_row()
     # Mechanics "Draw A Card" is now present for Ice
-    assert "| Fire // Ice | {R} // {1}{U} | 1 // 2 | Sorcery // Sorcery |  | Draw A Card | Fire deals 2 damage to any target.<br>---<br>Draw a card. |  |" in row
+    assert "| Fire // Ice | {R} // {1}{U} | 1 // 2 | Sorcery // Sorcery |  |  | Draw A Card | Fire deals 2 damage to any target.<br>---<br>Draw a card. |" in row
 
 def test_decode_markdown_table_cli(tmp_path):
     infile = tmp_path / "input.txt"
@@ -63,8 +63,8 @@ def test_decode_markdown_table_cli(tmp_path):
     decode.main(str(infile), str(outfile), quiet=True, verbose=False)
 
     content = outfile.read_text(encoding="utf-8")
-    assert "| Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |" in content
-    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | Lifelink | Lifelink | common |" in content
+    assert "| Name | Cost | CMC | Type | Stats | Rarity | Mechanics | Rules Text |" in content
+    assert "| Table Card | {W} | 1 | Creature — Human | 1/1 | common | Lifelink | Lifelink |" in content
 
 def test_decode_markdown_table_flag(tmp_path):
     infile = tmp_path / "input.txt"
@@ -75,5 +75,5 @@ def test_decode_markdown_table_flag(tmp_path):
     decode.main(str(infile), str(outfile), md_table_out=True, quiet=True, verbose=False)
 
     content = outfile.read_text(encoding="utf-8")
-    assert "| Name | Cost | CMC | Type | Stats | Mechanics | Rules Text | Rarity |" in content
-    assert "| Flag Card | {G} | 1 | Sorcery |  |  | Add {G}. | rare |" in content
+    assert "| Name | Cost | CMC | Type | Stats | Rarity | Mechanics | Rules Text |" in content
+    assert "| Flag Card | {G} | 1 | Sorcery |  | rare |  | Add {G}. |" in content

--- a/tests/test_table_output.py
+++ b/tests/test_table_output.py
@@ -22,7 +22,7 @@ def test_to_table_row():
     print(f"Row: {row}")
     # Rarity is lowercase from MTGJSON if not in map, but Card(card_json) uses fields_from_json
     # which uses utils.json_rarity_map if available.
-    assert row == ["Grizzly Bears", "{1}{G}", "2", "Creature \u2014 Bear", "2/2", "", "common"]
+    assert row == ["Grizzly Bears", "{1}{G}", "2", "Creature \u2014 Bear", "2/2", "common", ""]
 
 def test_to_table_row_bside():
     card_json = {
@@ -41,7 +41,7 @@ def test_to_table_row_bside():
     card = Card(card_json)
     row = card.to_table_row(ansi_color=False)
     print(f"Bside Row: {row}")
-    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "2 // 2", "Instant // Instant", "", "Draw A Card", "uncommon"]
+    assert row == ["Fire // Ice", "{1}{R} // {1}{U}", "2 // 2", "Instant // Instant", "", "uncommon", "Draw A Card"]
 
 def test_cli_table():
     # Encode a sample card and decode it with --table


### PR DESCRIPTION
Improved the visual hierarchy of the card data tables (terminal and Markdown) by reordering the columns.

Currently, 'Rarity' is placed at the end of the row, after 'Mechanics' and 'Rules Text'. Since 'Mechanics' and 'Rules Text' can be quite long, 'Rarity' is often pushed far to the right, making it difficult to scan.

The new order is: Name, Cost, CMC, Type, Stats, **Rarity**, Mechanics, [Rules Text].

This groups all short metadata fields together at the beginning of the row and leaves the long text fields for the end, which is a standard UX best practice for data tables.

Changes:
- Modified `lib/cardlib.py`: Updated `to_table_row` and `to_markdown_row` to return fields in the new order.
- Modified `decode.py`: Updated table headers for both terminal (`--table`) and Markdown (`--md-table`) outputs.
- Updated `tests/test_markdown_output.py` and `tests/test_table_output.py` to match the new expected output format.
- Removed a temporary test file `2cards.txt`.

---
*PR created automatically by Jules for task [4198303485698458563](https://jules.google.com/task/4198303485698458563) started by @RainRat*