### PR TITLE
Simplify alignment logic in lib/datalib.py:padrows

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -41,16 +41,14 @@ def padrows(rows, aligns=None):
             vis_len = utils.visible_len(s)
             diff = col_widths[i] - vis_len
 
-            if aligns and i < len(aligns):
-                if aligns[i] == 'r':
-                    cell_str = (' ' * diff) + s
-                elif aligns[i] == 'c':
-                    left = diff // 2
-                    right = diff - left
-                    cell_str = (' ' * left) + s + (' ' * right)
-                else: # 'l'
-                    cell_str = s + (' ' * diff)
-            else:
+            align = aligns[i] if (aligns and i < len(aligns)) else 'l'
+            if align == 'r':
+                cell_str = (' ' * diff) + s
+            elif align == 'c':
+                left = diff // 2
+                right = diff - left
+                cell_str = (' ' * left) + s + (' ' * right)
+            else: # 'l'
                 cell_str = s + (' ' * diff)
 
             padded_cells.append(cell_str)


### PR DESCRIPTION
This pull request refactors the `padrows` function in `lib/datalib.py` to simplify its column alignment logic. By using a default value for the `align` variable, we eliminate a redundant `else` block that was implementing the same left-alignment behavior as the case where no alignment was provided. This results in cleaner, more maintainable code while preserving the existing functionality, as confirmed by the project's test suite.

---
*PR created automatically by Jules for task [2533528783453644202](https://jules.google.com/task/2533528783453644202) started by @RainRat*