### PR TITLE
[UI/UX] Standardize terminal table output in decode.py

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -297,6 +297,11 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
 
         if for_table:
             import datalib
+            header_text = 'DECODED CARDS'
+            if use_color:
+                header_text = utils.colorize(header_text, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE)
+            writer.write(header_text + '\n')
+
             rows = []
             header = ["Name", "Cost", "CMC", "Type", "Stats", "Rarity", "Mechanics"]
             if booster > 0 or box > 0:
@@ -360,7 +365,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
             rows.insert(1, separator)
 
             for row in datalib.padrows(rows, aligns=aligns):
-                writer.write(row + '\n')
+                writer.write('  ' + row + '\n')
             return success_count, fail_count
 
         first = True


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** The `--table` output in `decode.py` lacked a clear header and a left margin, making it inconsistent with other diagnostic and reporting tools in the repository (like `mtg_sets.py` or `mtg_validate.py`) which use a standardized visual hierarchy.
* **Solution:** Added a colorized "DECODED CARDS" header (Bold Cyan Underline) and implemented a 2-space indentation for all table rows. This improves visual hierarchy and ensures a consistent "stock" look across the entire toolkit.

---
*PR created automatically by Jules for task [17061031795235497308](https://jules.google.com/task/17061031795235497308) started by @RainRat*