### PR TITLE
[TEST] Increase namediff coverage and fix resource leak

### DIFF
--- a/lib/namediff.py
+++ b/lib/namediff.py
@@ -116,30 +116,30 @@ class Namediff:
         return f_nearest(name, self.matchers, n)
 
     def nearest_par(self, names, n=3, threads=cores, quiet=False):
-        workpool = multiprocessing.Pool(threads)
-        proto_worklist = list_split(names, threads)
-        worklist = [(x, self.names, n) for x in proto_worklist]
+        with multiprocessing.Pool(threads) as workpool:
+            proto_worklist = list_split(names, threads)
+            worklist = [(x, self.names, n) for x in proto_worklist]
 
-        try:
-            from tqdm import tqdm
-            iterator = tqdm(workpool.imap(f_nearest_per_thread, worklist),
-                          total=len(worklist),
-                          disable=quiet,
-                          desc="Matching names",
-                          unit="chunk")
-        except ImportError:
-            iterator = workpool.imap(f_nearest_per_thread, worklist)
+            try:
+                from tqdm import tqdm
+                iterator = tqdm(workpool.imap(f_nearest_per_thread, worklist),
+                              total=len(worklist),
+                              disable=quiet,
+                              desc="Matching names",
+                              unit="chunk")
+            except ImportError:
+                iterator = workpool.imap(f_nearest_per_thread, worklist)
 
-        donelist = list(iterator)
+            donelist = list(iterator)
         return list_flatten(donelist)
 
     def nearest_card(self, card, n=5):
         return f_nearest(card.encode(), self.card_matchers, n)
 
     def nearest_card_par(self, cards, n=5, threads=cores):
-        workpool = multiprocessing.Pool(threads)
-        proto_worklist = list_split(cards, threads)
-        worklist = [([c.encode() for c in x], list(
-            self.cardstrings.values()), n) for x in proto_worklist]
-        donelist = workpool.map(f_nearest_per_thread, worklist)
+        with multiprocessing.Pool(threads) as workpool:
+            proto_worklist = list_split(cards, threads)
+            worklist = [([c.encode() for c in x], list(
+                self.cardstrings.values()), n) for x in proto_worklist]
+            donelist = workpool.map(f_nearest_per_thread, worklist)
         return list_flatten(donelist)

--- a/tests/test_namediff_gaps.py
+++ b/tests/test_namediff_gaps.py
@@ -1,0 +1,147 @@
+import unittest
+import os
+import json
+import tempfile
+import sys
+from unittest.mock import patch, MagicMock
+
+# Ensure lib is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib')))
+
+import namediff
+import cardlib
+import utils
+
+class TestNamediffGaps(unittest.TestCase):
+    def test_f_nearest_no_matchers(self):
+        """Test f_nearest with empty matchers list (line 40)."""
+        self.assertEqual(namediff.f_nearest("name", [], 3), [])
+
+    def test_namediff_verbose_and_duplicates(self):
+        """Test Namediff with verbose=True and duplicate card names (lines 63, 66, 74-75, 104-105, 113)."""
+        # Trigger duplicate name branch (line 74-75) via bside with same name
+        test_data = {
+            "data": {
+                "TST": {
+                    "name": "Test Set",
+                    "code": "TST",
+                    "type": "core",
+                    "cards": [
+                        {
+                            "name": "Fire",
+                            "number": "1a",
+                            "types": ["Instant"],
+                            "bside": {
+                                "name": "Fire", # Same name as parent
+                                "number": "1b",
+                                "types": ["Instant"]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        fd, tmp_path = tempfile.mkstemp(suffix='.json', text=True)
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(test_data, f)
+
+            # Capture stdout to verify verbose logging
+            from io import StringIO
+            captured_output = StringIO()
+            original_stdout = sys.stdout
+            try:
+                sys.stdout = captured_output
+                nd = namediff.Namediff(verbose=True, json_fname=tmp_path)
+            finally:
+                sys.stdout = original_stdout
+
+            output = captured_output.getvalue()
+
+            self.assertIn("Setting up namediff...", output)
+            self.assertIn("Reading names from:", output)
+            self.assertIn("Duplicate name fire, ignoring.", output)
+            self.assertIn("Read 1 unique cardnames", output)
+            self.assertIn("Building SequenceMatcher objects.", output)
+            self.assertIn("... Done.", output)
+
+            self.assertEqual(len(nd.names), 1)
+            self.assertIn("fire", nd.names)
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_namediff_codes_mapping(self):
+        """Test that codes are correctly mapped (line 82)."""
+        # Line 82: if jcode and jnum: self.codes[name] = jcode + '/' + jnum + '.jpg'
+
+        # We need the cards to be INSIDE a set in MTGJSON format
+        # for jdecode to set the magicCardsInfoCode on each card.
+        test_data = {
+            "data": {
+                "TST": {
+                    "name": "Test Set",
+                    "code": "TST",
+                    "type": "core",
+                    "magicCardsInfoCode": "tstcode",
+                    "cards": [
+                        {
+                            "name": "Fireball",
+                            "number": "1",
+                            "types": ["Sorcery"]
+                        }
+                    ]
+                }
+            }
+        }
+
+        fd, tmp_path = tempfile.mkstemp(suffix='.json', text=True)
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(test_data, f)
+
+            nd = namediff.Namediff(verbose=False, json_fname=tmp_path)
+
+            self.assertIn("fireball", nd.codes)
+            self.assertEqual(nd.codes["fireball"], "tstcode/1.jpg")
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_nearest_par_tqdm_fallback(self):
+        """Test nearest_par when tqdm is not available (line 131)."""
+        test_data = {
+            "data": {
+                "TST": {
+                    "name": "Test Set",
+                    "code": "TST",
+                    "type": "core",
+                    "cards": [
+                        {"name": "Fireball", "number": "1", "types": ["Sorcery"]}
+                    ]
+                }
+            }
+        }
+
+        fd, tmp_path = tempfile.mkstemp(suffix='.json', text=True)
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(test_data, f)
+
+            nd = namediff.Namediff(verbose=False, json_fname=tmp_path)
+
+            # Refined mock for tqdm ImportError
+            with patch.dict(sys.modules, {'tqdm': None}):
+                res = nd.nearest_par(["firebal"], n=1, threads=1)
+                self.assertEqual(len(res), 1)
+                self.assertEqual(res[0][0][1], "fireball")
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR increases the test coverage for the `namediff` library module to 100% and fixes a resource leak in its parallel processing methods.

**Changes:**
1.  **New Coverage:** Created `tests/test_namediff_gaps.py` which addresses previously untested branches in `lib/namediff.py`:
    *   Empty matcher lists in `f_nearest`.
    *   Verbose logging and duplicate card name handling in `Namediff.__init__`.
    *   Mapping of `magicCardsInfoCode` to `self.codes`.
    *   Fallback logic when `tqdm` is not installed (mocked).
2.  **Bug Fix:** Modified `nearest_par` and `nearest_card_par` in `lib/namediff.py` to use a context manager (`with` statement) for `multiprocessing.Pool`. This ensures that worker processes are properly terminated and joined after use, preventing potential resource leaks.

**Verification:**
- Ran `PYTHONPATH=lib python3 -m pytest --cov=namediff tests/test_namediff.py tests/test_namediff_gaps.py`.
- Result: 100% coverage, all 12 tests passed.

---
*PR created automatically by Jules for task [18404349823624176169](https://jules.google.com/task/18404349823624176169) started by @RainRat*