### PR TITLE
[UI/UX] Add formatted table output to mtg_search.py

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -153,10 +153,10 @@ def mtg_open_json_obj(jobj, verbose = False):
 
     if is_mtgjson_format:
         for set_data in jobj.values():
-            setname = set_data['name']
+            setname = set_data.get('name', 'Unknown')
             # flag sets that should be excluded by default, like funny and art card sets
-            if (set_data['type'] in ['funny', 'memorabilia', 'alchemy']):
-                bad_sets.add(set_data['code'])
+            if (set_data.get('type') in ['funny', 'memorabilia', 'alchemy']):
+                bad_sets.add(set_data.get('code'))
             codename = set_data.get('magicCardsInfoCode', '')
 
             for card in set_data['cards']:

--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -11,6 +11,7 @@ sys.path.append(libdir)
 import utils
 import jdecode
 import cardlib
+import datalib
 from titlecase import titlecase
 
 def get_field_value(card, field, ansi_color=False):
@@ -84,7 +85,7 @@ Available Fields:
   Basic Metadata:
     name, cost, cmc, rarity, set, number
   Types & Text:
-    supertypes, types, subtypes, text, mechanics
+    type, supertypes, types, subtypes, text, mechanics
   Stats:
     pt (Power/Toughness), loyalty (Loyalty or Defense)
   Color Info:
@@ -116,6 +117,8 @@ Usage Examples:
                         help='Comma-separated list of fields to output (Default: name,cost,type,rarity).')
     io_group.add_argument('--delimiter', default=' | ',
                         help='The separator used between fields in text output (Default: " | ").')
+    io_group.add_argument('-t', '--table', action='store_true',
+                        help='Generate a formatted table for terminal view.')
     io_group.add_argument('--json', action='store_true',
                         help='Format results as a JSON list of objects.')
 
@@ -241,18 +244,52 @@ Usage Examples:
     # Process output
     field_list = [f.strip() for f in args.fields.split(',')]
 
-    results = []
-    for card in cards:
-        card_data = {}
-        for field in field_list:
-            card_data[field] = get_field_value(card, field, ansi_color=use_color)
-        results.append(card_data)
-
     if args.json:
+        results = []
+        for card in cards:
+            card_data = {}
+            for field in field_list:
+                card_data[field] = get_field_value(card, field, ansi_color=use_color)
+            results.append(card_data)
         print(json.dumps(results, indent=2))
+    elif args.table:
+        header_text = 'SEARCH RESULTS'
+        if use_color:
+            header_text = utils.colorize(header_text, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE)
+        print(header_text)
+
+        header = [titlecase(f) for f in field_list]
+        if use_color:
+            header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+
+        rows = [header]
+        for card in cards:
+            row = []
+            for field in field_list:
+                row.append(get_field_value(card, field, ansi_color=use_color))
+            rows.append(row)
+
+        # Get column widths and add a separator
+        col_widths = datalib.get_col_widths(rows)
+        separator = ['-' * w for w in col_widths]
+        rows.insert(1, separator)
+
+        # Determine alignments: right-align for numeric fields
+        aligns = []
+        right_align_fields = ['cmc', 'id_count', 'pt', 'loyalty', 'pack', 'box', 'number']
+        for field in field_list:
+            if field.lower() in right_align_fields:
+                aligns.append('r')
+            else:
+                aligns.append('l')
+
+        datalib.printrows(datalib.padrows(rows, aligns=aligns), indent=2)
     else:
-        for card_data in results:
-            output_line = args.delimiter.join(str(card_data[f]) for f in field_list)
+        for card in cards:
+            row = []
+            for field in field_list:
+                row.append(get_field_value(card, field, ansi_color=use_color))
+            output_line = args.delimiter.join(str(val) for val in row)
             print(output_line)
 
     if not args.quiet:


### PR DESCRIPTION
This PR introduces a significant UI/UX improvement to the `mtg_search.py` CLI tool by adding a formatted table output mode.

Previously, search results were output as delimiter-separated plain text, which could be difficult to scan. The new `--table` mode provides a polished, aligned table that matches the "Invisible Design" language of the rest of the toolkit.

Key improvements:
1. **Efficiency & Scannability:** Columns are perfectly aligned, making it easy to compare stats, costs, and types across multiple cards.
2. **Visual Hierarchy:** Added a standardized header and 2-space indentation, consistent with `mtg_sets.py` and `decode.py`.
3. **Smart Alignment:** Numerical fields like CMC, Power/Toughness, and Pack/Box IDs are automatically right-aligned for better readability.
4. **Robustness:** Fixed a bug in the JSON loading logic that caused crashes when processing partial datasets (like custom card subsets).
5. **Discoverability:** Documented the missing `type` field in the CLI help text.

---
*PR created automatically by Jules for task [14583462835269292434](https://jules.google.com/task/14583462835269292434) started by @RainRat*