### PR TITLE
Fix word tokenization logic bug in Card class

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -864,9 +864,9 @@ class Card:
                                                                     fulltext.split(utils.newline)))
                     self.__dict__[field_text + '_words'] = re.sub(utils.unletters_regex,
                                                                   ' ',
-                                                                  fulltext).split()
+                                                                  fulltext.lower()).split()
                     self.__dict__[field_text + '_lines_words'] = [re.sub(
-                        utils.unletters_regex, ' ', line).split() for line in fulltext.split(utils.newline)]
+                        utils.unletters_regex, ' ', line.lower()).split() for line in fulltext.split(utils.newline)]
             else:
                 self.valid = False
                 self.__dict__[field_other] += [(idx, '<text> ' + str(value))]


### PR DESCRIPTION
This PR resolves a logic bug in `lib/cardlib.py` where the word tokenization process was stripping the first letter of capitalized words.

**What:**
- Modified the `_set_text` method in `lib/cardlib.py` to call `.lower()` on the rules text (`fulltext` and `line`) before applying `re.sub(utils.unletters_regex, ' ', ...)`.

**Why:**
- The `utils.unletters_regex` (defined as `r"[^abcdefghijklmnopqrstuvwxyz']"`) only allows lowercase characters. 
- When processing card data with capitalized rules text (common in many formats), words like "Flying" were being transformed into " lying", leading to incorrect token lists in `self.text_words` and `self.text_lines_words`.
- Lowercasing the text first preserves the characters and ensures consistent tokenization.
- This is a non-breaking change that only affects derived metadata used for internal analysis and search.

**Verification:**
- Verified the fix with a reproduction script using encoded text input.
- Confirmed that "Flying" now correctly tokenizes to "flying".
- Ran the full test suite (`pytest tests/`), and all 574 tests passed.

---
*PR created automatically by Jules for task [18369482552056089515](https://jules.google.com/task/18369482552056089515) started by @RainRat*