### PR TITLE
[DOCS] [Internal Help] Un-suppress and document advanced filtering flags in mtg_compare.py

### DIFF
--- a/scripts/mtg_compare.py
+++ b/scripts/mtg_compare.py
@@ -95,35 +95,59 @@ def main():
     # Group: Filtering Options
     filter_group = parser.add_argument_group('Filtering Options')
     filter_group.add_argument('--booster', type=int, default=0,
-                        help='Simulate opening N booster packs.')
+                        help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land. Shuffles by default.')
     filter_group.add_argument('--box', type=int, default=0,
-                        help='Simulate opening N booster boxes.')
+                        help='Simulate opening N booster boxes (36 packs each). Shuffles by default.')
     filter_group.add_argument('--grep', action='append',
-                        help='Only include cards matching a search pattern.')
-    filter_group.add_argument('--grep-name', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--exclude-name', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--grep-type', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--exclude-type', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--grep-text', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--exclude-text', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--grep-cost', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--exclude-cost', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--grep-pt', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--exclude-pt', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--grep-loyalty', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--exclude-loyalty', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--vgrep', '--exclude', action='append', dest='vgrep', help=argparse.SUPPRESS)
-    filter_group.add_argument('--set', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--rarity', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--colors', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--identity', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--id-count', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--cmc', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--pow', '--power', action='append', dest='pow', help=argparse.SUPPRESS)
-    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou', help=argparse.SUPPRESS)
-    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy', help=argparse.SUPPRESS)
-    filter_group.add_argument('--mechanic', action='append', help=argparse.SUPPRESS)
-    filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck', help=argparse.SUPPRESS)
+                        help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
+    filter_group.add_argument('--grep-name', action='append',
+                        help='Only include cards whose name matches a search pattern.')
+    filter_group.add_argument('--exclude-name', action='append',
+                        help='Exclude cards whose name matches a search pattern.')
+    filter_group.add_argument('--grep-type', action='append',
+                        help='Only include cards whose typeline matches a search pattern.')
+    filter_group.add_argument('--exclude-type', action='append',
+                        help='Exclude cards whose typeline matches a search pattern.')
+    filter_group.add_argument('--grep-text', action='append',
+                        help='Only include cards whose rules text matches a search pattern.')
+    filter_group.add_argument('--exclude-text', action='append',
+                        help='Exclude cards whose rules text matches a search pattern.')
+    filter_group.add_argument('--grep-cost', action='append',
+                        help='Only include cards whose mana cost matches a search pattern.')
+    filter_group.add_argument('--exclude-cost', action='append',
+                        help='Exclude cards whose mana cost matches a search pattern.')
+    filter_group.add_argument('--grep-pt', action='append',
+                        help='Only include cards whose power/toughness matches a search pattern.')
+    filter_group.add_argument('--exclude-pt', action='append',
+                        help='Exclude cards whose power/toughness matches a search pattern.')
+    filter_group.add_argument('--grep-loyalty', action='append',
+                        help='Only include cards whose loyalty/defense matches a search pattern.')
+    filter_group.add_argument('--exclude-loyalty', action='append',
+                        help='Exclude cards whose loyalty/defense matches a search pattern.')
+    filter_group.add_argument('--vgrep', '--exclude', action='append', dest='vgrep',
+                        help='Exclude cards matching a search pattern (checks name, type, and text). Use multiple times for OR logic.')
+    filter_group.add_argument('--set', action='append',
+                        help='Only include cards from specific sets (e.g., MOM, MRD). Supports multiple sets (OR logic).')
+    filter_group.add_argument('--rarity', action='append',
+                        help="Only include cards of specific rarities. Supports full names (e.g., 'common', 'mythic') or shorthands: O (Common), N (Uncommon), A (Rare), Y (Mythic), I (Special), L (Basic Land). Supports multiple rarities (OR logic).")
+    filter_group.add_argument('--colors', action='append',
+                        help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple colors (OR logic).")
+    filter_group.add_argument('--id-count', action='append',
+                        help='Only include cards with specific color identity counts. Supports inequalities and ranges.')
+    filter_group.add_argument('--cmc', action='append',
+                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
+    filter_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities and ranges.')
+    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities and ranges.')
+    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities and ranges.')
+    filter_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
+    filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
+                        help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
 
     # Group: Logging & Debugging
     debug_group = parser.add_argument_group('Logging & Debugging')


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Updated `scripts/mtg_compare.py` to un-suppress and provide descriptive help text for 23 CLI arguments in the 'Filtering Options' group.
* **Why:** This change makes the full capabilities of the comparison tool discoverable and understandable for users, bringing it into parity with other primary tools in the toolkit. It clarifies the logic (AND/OR) for multi-pattern searches and documents supported formats for numeric filters (inequalities, ranges).

---
*PR created automatically by Jules for task [8289624560733873390](https://jules.google.com/task/8289624560733873390) started by @RainRat*