### PR TITLE
[UI/UX] [CLI] Polish mtg_search.py with smart defaults and expanded metadata

### DIFF
--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -125,8 +125,8 @@ Usage Examples:
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
                         help='Input card data (JSON, CSV, XML, encoded text, or directory). Defaults to stdin (-).')
-    io_group.add_argument('--fields', default='name,cost,type,rarity',
-                        help='Comma-separated list of fields to output (Default: name,cost,type,rarity).')
+    io_group.add_argument('--fields', default='name,cost,cmc,type,pt,rarity',
+                        help='Comma-separated list of fields to output (Default: name,cost,cmc,type,pt,rarity).')
     io_group.add_argument('--delimiter', default=' | ',
                         help='The separator used between fields in text output (Default: " | ").')
 
@@ -258,7 +258,10 @@ Usage Examples:
 
     # Set default format if none chosen
     if not (args.text or args.table or args.md_table or args.json or args.jsonl):
-        args.text = True
+        if sys.stdout.isatty():
+            args.table = True
+        else:
+            args.text = True
 
     # Determine if we should use color
     use_color = False
@@ -316,8 +319,12 @@ Usage Examples:
                 print("| " + " | ".join(escaped_row) + " |")
         else:
             # Terminal table output
+            header_text = "SEARCH RESULTS"
             if use_color:
-                print(utils.colorize("SEARCH RESULTS", utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE))
+                print(utils.colorize(header_text, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE))
+            else:
+                print(header_text)
+                print("=" * len(header_text))
 
             aligns = []
             for field in field_list:


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** The `mtg_search.py` tool defaults to a limited set of fields (`name,cost,type,rarity`) and always outputs plain text, which is less readable for interactive users. Users often have to manually specify `--table` and `--fields` to get a useful overview of card stats like CMC and P/T.
* **Solution:** 
    * Expanded default fields to `name,cost,cmc,type,pt,rarity` to provide essential stats by default.
    * Implemented "Smart Defaulting" for output format: automatically switches to `--table` when outputting to an interactive terminal, while preserving `--text` for pipes/redirects.
    * Improved visual hierarchy by adding a consistent "SEARCH RESULTS" header to table output, using an underline fallback for non-color terminals.
* **Changes:** Modified `scripts/mtg_search.py`.

---
*PR created automatically by Jules for task [8746925004962574710](https://jules.google.com/task/8746925004962574710) started by @RainRat*