### PR TITLE
Consolidate redundant sorting logic in sortlib.py

### DIFF
--- a/lib/sortlib.py
+++ b/lib/sortlib.py
@@ -94,9 +94,7 @@ def sort_cards(cards, criterion, quiet=False):
         return sorted(cards, key=lambda c: _get_numeric_sort_key(c.pt_t))
     elif criterion == 'loyalty':
         return sorted(cards, key=lambda c: _get_numeric_sort_key(c.loyalty))
-    elif criterion == 'pack':
-        return sorted(cards, key=lambda c: (getattr(c, 'box_id', 0), getattr(c, 'pack_id', 0), c.name.lower()))
-    elif criterion == 'box':
+    elif criterion in ['pack', 'box']:
         return sorted(cards, key=lambda c: (getattr(c, 'box_id', 0), getattr(c, 'pack_id', 0), c.name.lower()))
     elif criterion == 'set':
         def get_set_key(card):


### PR DESCRIPTION
* **What:** Merged identical `elif` branches for the 'pack' and 'box' sorting criteria in `lib/sortlib.py` into a single condition using `elif criterion in ['pack', 'box']:`.
* **Why:** This reduces code duplication and improves maintainability. The sorting logic for both criteria was identical (sorting by `box_id`, then `pack_id`, then name), so consolidating them into one block is safer and cleaner. No breaking changes were introduced, and all tests passed.

---
*PR created automatically by Jules for task [10905370135026822055](https://jules.google.com/task/10905370135026822055) started by @RainRat*