### PR TITLE
[DOCS] Add 'type' field to mtg_search.py help documentation

### DIFF
--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -93,7 +93,7 @@ Available Fields:
   Basic Metadata:
     name, cost, cmc, rarity, set, number
   Types & Text:
-    supertypes, types, subtypes, text, mechanics
+    supertypes, types, subtypes, type, text, mechanics
   Stats:
     pt (Power/Toughness), power, toughness, loyalty (Loyalty or Defense)
   Color Info:


### PR DESCRIPTION
**PR Title:** [DOCS] Add 'type' field to mtg_search.py help documentation

**Description:**
* **Type:** Internal Help
* **What:** The `epilog` help string in `scripts/mtg_search.py` was updated to include the `type` field under the 'Types & Text' section.
* **Why:** This change ensures that users are aware they can use the `type` field to search for or display the full card type line, which was previously omitted from the `--help` list despite being fully supported by the code.

---
*PR created automatically by Jules for task [2540964518021707218](https://jules.google.com/task/2540964518021707218) started by @RainRat*