### PR TITLE
Consolidate 'pack' and 'box' sorting criteria in sortlib.py

### DIFF
--- a/lib/sortlib.py
+++ b/lib/sortlib.py
@@ -94,9 +94,7 @@ def sort_cards(cards, criterion, quiet=False):
         return sorted(cards, key=lambda c: _get_numeric_sort_key(c.pt_t))
     elif criterion == 'loyalty':
         return sorted(cards, key=lambda c: _get_numeric_sort_key(c.loyalty))
-    elif criterion == 'pack':
-        return sorted(cards, key=lambda c: (getattr(c, 'box_id', 0), getattr(c, 'pack_id', 0), c.name.lower()))
-    elif criterion == 'box':
+    elif criterion in ['pack', 'box']:
         return sorted(cards, key=lambda c: (getattr(c, 'box_id', 0), getattr(c, 'pack_id', 0), c.name.lower()))
     elif criterion == 'set':
         def get_set_key(card):


### PR DESCRIPTION
* **What:** Combined the identical `elif` blocks for `'pack'` and `'box'` sorting criteria into a single condition using `elif criterion in ['pack', 'box']:`.
* **Why:** This reduces code duplication and improves maintainability by centralizing the identical sorting logic for both criteria. No functional changes were introduced, and all tests pass.

---
*PR created automatically by Jules for task [2148668039291982992](https://jules.google.com/task/2148668039291982992) started by @RainRat*