### PR TITLE
[DOCS] Harmonize mtg_search.py CLI documentation with toolkit capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ python3 scripts/mtg_search.py data/AllPrintings.json --grep "Goblin" --fields "n
 # Find all mythic rares with CMC > 7 and output as JSON
 python3 scripts/mtg_search.py data/AllPrintings.json --rarity mythic --cmc ">7" --json
 ```
-*   **Fields:** `name`, `cost`, `cmc`, `supertypes`, `types`, `subtypes`, `pt`, `power`, `toughness`, `loyalty`, `text`, `rarity`, `mechanics`, `identity`, `id_count`, `set`, `number`, `pack`, `box`, `encoded`.
+*   **Fields:** `name`, `cost`, `cmc`, `type`, `supertypes`, `types`, `subtypes`, `pt`, `power`, `toughness`, `loyalty`, `text`, `rarity`, `mechanics`, `identity`, `id_count`, `set`, `number`, `pack`, `box`, `encoded`.
 *   **Output Formats:** Plain text (default), `--table`, `--md-table`, `--json`, `--jsonl`.
-*   Supports all **Advanced Filtering** flags and booster/box simulation.
+*   Supports all **Advanced Filtering** flags, sorting, and booster/box simulation.
 
 ### `mtg_subset.py`
 Creates a filtered subset of an MTGJSON file while preserving its structure. This is useful for creating specialized training datasets or lightweight card databases without losing set-level metadata.

--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -93,7 +93,7 @@ Available Fields:
   Basic Metadata:
     name, cost, cmc, rarity, set, number
   Types & Text:
-    supertypes, types, subtypes, text, mechanics
+    type, supertypes, types, subtypes, text, mechanics
   Stats:
     pt (Power/Toughness), power, toughness, loyalty (Loyalty or Defense)
   Color Info:
@@ -123,7 +123,7 @@ Usage Examples:
     # Group: Input / Output
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('infile', nargs='?', default='-',
-                        help='Input card data (JSON, CSV, XML, encoded text, or directory). Defaults to stdin (-).')
+                        help='Input card data (MTGJSON, Scryfall, CSV, XML, MSE, JSONL, ZIP, or Decklist), encoded text, or directory. Defaults to stdin (-).')
     io_group.add_argument('--fields', default='name,cost,cmc,type,pt,rarity',
                         help='Comma-separated list of fields to output (Default: name,cost,cmc,type,pt,rarity).')
     io_group.add_argument('--delimiter', default=' | ',
@@ -151,13 +151,13 @@ Usage Examples:
                         help='Shuffle the cards before processing.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards (shorthand for --shuffle --limit N).')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box'],
                         help='Sort cards by a specific criterion.')
 
     # Group: Filtering Options (Standard across tools)
     filter_group = parser.add_argument_group('Filtering Options')
     filter_group.add_argument('--grep', action='append',
-                        help='Only include cards matching a search pattern (checks name, type, and text). Use multiple times for AND logic.')
+                        help='Only include cards matching a search pattern (checks name, typeline, text, cost, and stats). Use multiple times for AND logic.')
     filter_group.add_argument('--grep-name', action='append',
                         help='Only include cards whose name matches a search pattern.')
     filter_group.add_argument('--grep-type', action='append',
@@ -171,7 +171,7 @@ Usage Examples:
     filter_group.add_argument('--grep-loyalty', action='append',
                         help='Only include cards whose loyalty/defense matches a search pattern.')
     filter_group.add_argument('--vgrep', '--exclude', action='append',
-                        help='Skip cards matching a search pattern. Use multiple times for OR logic.')
+                        help='Skip cards matching a search pattern (checks name, typeline, text, cost, and stats). Use multiple times for OR logic.')
     filter_group.add_argument('--exclude-name', action='append',
                         help='Exclude cards whose name matches a search pattern.')
     filter_group.add_argument('--exclude-type', action='append',


### PR DESCRIPTION
* **Type:** Internal Help / Documentation
* **What:** Updated `scripts/mtg_search.py` internal help strings and the main `README.md`.
* **Why:** The documentation for `mtg_search.py` was missing several supported features. This change adds the `type` field to the available fields list, explicitly enables and documents `pack` and `box` sorting, clarifies the fields searched by `--grep`, and expands the list of supported input formats in the help text. This ensures users are aware of the full capabilities of the search tool and provides a more consistent experience across the toolkit.

---
*PR created automatically by Jules for task [10224454856124933569](https://jules.google.com/task/10224454856124933569) started by @RainRat*