### PR TITLE
Centralize table separator logic

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -360,9 +360,7 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
             # We keep it left aligned by default.
 
             # Insert a separator row of dashes
-            col_widths = datalib.get_col_widths(rows)
-            separator = ['-' * w for w in col_widths]
-            rows.insert(1, separator)
+            datalib.add_separator_row(rows)
 
             for row in datalib.padrows(rows, aligns=aligns):
                 writer.write('  ' + row + '\n')

--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -20,6 +20,17 @@ def get_col_widths(rows):
                 col_widths.append(length)
     return col_widths
 
+def add_separator_row(rows, index=1):
+    """
+    Calculates column widths for the provided rows and inserts a separator
+    row of dashes at the specified index.
+    """
+    if not rows:
+        return
+    col_widths = get_col_widths(rows)
+    separator = ['-' * w for w in col_widths]
+    rows.insert(index, separator)
+
 # Format a list of rows of data into nice columns.
 # Note that it's the columns that are nice, not this code.
 def padrows(rows, aligns=None):
@@ -219,9 +230,7 @@ def _print_breakdown(title, index, total, use_color, vsize=None, sort_key=None, 
         ])
 
     # Insert a separator row of dashes
-    col_widths = get_col_widths(rows)
-    separator = ['-' * w for w in col_widths]
-    rows.insert(1, separator)
+    add_separator_row(rows)
 
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'l']), indent=4)
 
@@ -268,9 +277,7 @@ def _print_mechanical_profile(mechanical_stats, total, use_color, vsize=None):
         rows.append(row)
 
     # Insert a separator row of dashes
-    col_widths = get_col_widths(rows)
-    separator = ['-' * w for w in col_widths]
-    rows.insert(1, separator)
+    add_separator_row(rows)
 
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'l', 'r', 'r']), indent=4)
 
@@ -320,9 +327,7 @@ def _print_color_pie(pie_groups, pie_mechanics, all_mechanics, use_color, vsize=
         rows.append(row)
 
     # Insert a separator row of dashes
-    col_widths = get_col_widths(rows)
-    separator = ['-' * w for w in col_widths]
-    rows.insert(1, separator)
+    add_separator_row(rows)
 
     printrows(padrows(rows, aligns=['l', 'r', 'r', 'r', 'r', 'r', 'r', 'r']), indent=4)
 

--- a/scripts/mtg_compare.py
+++ b/scripts/mtg_compare.py
@@ -332,9 +332,7 @@ def main():
     # Print Table
     print(utils.colorize("DATASET COMPARISON", utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE) if use_color else "=== DATASET COMPARISON ===")
 
-    col_widths = datalib.get_col_widths(rows)
-    separator = ['-' * w for w in col_widths]
-    rows.insert(1, separator)
+    datalib.add_separator_row(rows)
 
     aligns = ['l'] + ['r'] * (len(header) - 1)
     datalib.printrows(datalib.padrows(rows, aligns=aligns), indent=2)

--- a/scripts/mtg_lexicon.py
+++ b/scripts/mtg_lexicon.py
@@ -229,9 +229,7 @@ def main():
 
         rows.append([label, word_str, vocab_size])
 
-    col_widths = datalib.get_col_widths(rows)
-    separator = ['-' * w for w in col_widths]
-    rows.insert(1, separator)
+    datalib.add_separator_row(rows)
 
     datalib.printrows(datalib.padrows(rows, aligns=['l', 'l', 'r']), indent=2)
 

--- a/scripts/mtg_mechanics.py
+++ b/scripts/mtg_mechanics.py
@@ -261,9 +261,7 @@ def main():
         aligns = ['l', 'r', 'r', 'l']
 
     # Get column widths and add a separator
-    col_widths = datalib.get_col_widths(rows)
-    separator = ['-' * w for w in col_widths]
-    rows.insert(1, separator)
+    datalib.add_separator_row(rows)
 
     print(utils.colorize(title, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE) if use_color else f"=== {title} ===")
     datalib.printrows(datalib.padrows(rows, aligns=aligns), indent=2)

--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -436,9 +436,7 @@ Usage Examples:
                     aligns.append(FIELD_MAP.get(canon, {}).get('align', 'l'))
 
                 # Add separator row
-                col_widths = datalib.get_col_widths(rows)
-                separator = ['-' * w for w in col_widths]
-                rows.insert(1, separator)
+                datalib.add_separator_row(rows)
 
                 for row in datalib.padrows(rows, aligns=aligns):
                     output_f.write("  " + row + '\n')

--- a/scripts/mtg_sets.py
+++ b/scripts/mtg_sets.py
@@ -92,9 +92,7 @@ def display_sets(sets, use_color=False):
         rows.append([code, name, stype, date, count])
 
     # Get column widths and add a separator
-    col_widths = datalib.get_col_widths(rows)
-    separator = ['-' * w for w in col_widths]
-    rows.insert(1, separator)
+    datalib.add_separator_row(rows)
 
     datalib.printrows(datalib.padrows(rows, aligns=['l', 'l', 'l', 'l', 'r']), indent=2)
 

--- a/scripts/mtg_tokens.py
+++ b/scripts/mtg_tokens.py
@@ -235,9 +235,7 @@ Example Usage:
 
             rows.append([name, pt, color, stype, abilities, count])
 
-        col_widths = datalib.get_col_widths(rows)
-        separator = ['-' * w for w in col_widths]
-        rows.insert(1, separator)
+        datalib.add_separator_row(rows)
 
         datalib.printrows(datalib.padrows(rows, aligns=['l', 'r', 'l', 'l', 'l', 'r']), indent=2)
 

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -563,9 +563,7 @@ def main(fname, oname = None, verbose = False, dump = False,
                     rows.append([label_colored, count_colored, f"{percent:5.1f}%", bar])
 
                 # Insert a separator row of dashes
-                col_widths = datalib.get_col_widths(rows)
-                separator = ['-' * w for w in col_widths]
-                rows.insert(1, separator)
+                datalib.add_separator_row(rows)
 
                 datalib.printrows(datalib.padrows(rows, aligns=['l', 'r', 'r', 'l']), indent=2)
                 print()
@@ -610,9 +608,7 @@ def main(fname, oname = None, verbose = False, dump = False,
                         ])
 
                 # Insert a separator row of dashes
-                col_widths = datalib.get_col_widths(b_rows)
-                separator = ['-' * w for w in col_widths]
-                b_rows.insert(1, separator)
+                datalib.add_separator_row(b_rows)
 
                 datalib.printrows(datalib.padrows(b_rows, aligns=['l', 'r', 'r', 'r', 'r', 'l']), indent=2)
 


### PR DESCRIPTION
This PR addresses significant code duplication across the toolkit by centralizing the table separator row logic. Previously, a three-line block was repeated in over a dozen places to calculate column widths and insert a dash-based separator row into lists of table rows. 

I've introduced a new helper function `datalib.add_separator_row(rows, index=1)` and refactored the following files to use it:
- `lib/datalib.py` (internal functions)
- `decode.py`
- `scripts/mtg_search.py`
- `scripts/mtg_validate.py`
- `scripts/mtg_sets.py`
- `scripts/mtg_compare.py`
- `scripts/mtg_mechanics.py`
- `scripts/mtg_lexicon.py`
- `scripts/mtg_tokens.py`

This change is non-breaking and maintains identical external behavior while improving code hygiene.

---
*PR created automatically by Jules for task [6808876331282831413](https://jules.google.com/task/6808876331282831413) started by @RainRat*