### PR TITLE
Simplify mana_alt logic

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -317,10 +317,7 @@ mana_symall = mana_syms + mana_symalt
 def mana_alt(sym):
     if sym not in mana_symall:
         raise ValueError('invalid mana symbol for mana_alt(): ' + repr(sym))
-    if len(sym) < 2:
-        return sym
-    else:
-        return sym[::-1]
+    return sym[::-1]
 
 # produce intended neural net output format
 def mana_sym_to_encoding(sym):


### PR DESCRIPTION
Removed redundant length check in mana_alt function. Python's slice notation [::-1] handles strings of any length correctly, returning single-character strings as-is. Verified by running the full test suite (614 passed).

---
*PR created automatically by Jules for task [2441907867568419825](https://jules.google.com/task/2441907867568419825) started by @RainRat*