### PR TITLE
[FEAT] Add Flavor Text support to Card objects and Search utility

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -67,6 +67,7 @@ field_subtypes = 'subtypes'
 field_loyalty = 'loyalty'
 field_pt = 'pt'
 field_text = 'text'
+field_flavor = 'flavor'
 field_other = 'other' # it's kind of a pseudo-field
 
 # Import the labels, because these do appear in the encoded text.
@@ -90,6 +91,7 @@ fieldnames = [
     field_loyalty,
     field_pt,
     field_text,
+    field_flavor,
 ]
 
 # Use shorthand: C, U, R, M, S, L
@@ -359,6 +361,10 @@ def fields_from_json(src_json, linetrans = True):
         mtext = Manatext(text_val, fmt = 'json')
         valid = valid and mtext.valid
         fields[field_text] = [(-1, mtext)]
+
+    flavor_val = src_json.get('flavorText', src_json.get('flavor', ''))
+    if flavor_val:
+        fields[field_flavor] = [(-1, utils.to_ascii(flavor_val))]
     
     # we don't need to worry about bsides because we handle that in the constructor
     return parsed, valid and fields_check_valid(fields), fields
@@ -776,6 +782,7 @@ class Card:
         setattr(self, field_pt + '_p', None)
         setattr(self, field_pt + '_t', None)
         setattr(self, field_text, Manatext(''))
+        setattr(self, field_flavor, '')
         setattr(self, field_text + '_lines', [])
         setattr(self, field_text + '_words', [])
         setattr(self, field_text + '_lines_words', [])
@@ -1055,6 +1062,8 @@ class Card:
             return True
         if self.search_loyalty(pattern):
             return True
+        if self.search_flavor(pattern):
+            return True
         return False
 
     def search_name(self, pattern):
@@ -1107,6 +1116,14 @@ class Card:
             return True
         if self.bside:
             return self.bside.search_loyalty(pattern)
+        return False
+
+    def search_flavor(self, pattern):
+        """Returns True if the pattern matches the card's flavor text."""
+        if self.flavor and pattern.search(self.flavor):
+            return True
+        if self.bside:
+            return self.bside.search_flavor(pattern)
         return False
 
     def summary(self, ansi_color=False):
@@ -1338,6 +1355,21 @@ class Card:
             elif for_md:
                 outstr += '_'
 
+        if self.flavor:
+            outstr += linebreak
+            flavor_display = self.flavor
+            if ansi_color:
+                flavor_display = utils.colorize(flavor_display, utils.Ansi.ITALIC)
+
+            if for_html:
+                outstr += '<i>' + flavor_display.replace('\n', '<br>') + '</i>'
+            elif for_forum:
+                outstr += '[i]' + flavor_display + '[/i]'
+            elif for_md:
+                outstr += '_' + flavor_display.replace('\n', '  \n') + '_'
+            else:
+                outstr += flavor_display
+
         if self.bside:
             outstr += linebreak
             if not for_html and not for_forum and not for_md:
@@ -1435,6 +1467,10 @@ class Card:
         if self.text.text:
             d['text'] = self.get_text(force_unpass=True)
 
+        # Flavor
+        if self.flavor:
+            d['flavorText'] = self.flavor
+
         # Mechanics
         face_mechanics = sorted(list(self.get_face_mechanics()))
         if face_mechanics:
@@ -1505,6 +1541,9 @@ class Card:
                 outstr += '\tpower: ' + ptstring[0] + '\n'
                 outstr += '\ttoughness: ' + ptstring[1] + '\n'
 
+        if self.flavor:
+            outstr += '\tflavor text: ' + self.flavor.replace('\n', ' ') + '\n'
+
         newtext = self.get_text(mse=True)
 
         # Annoying special case for bsides;
@@ -1548,6 +1587,9 @@ class Card:
             if newtext2:
                 newtext2 = newtext2.replace('\n', '\n\t\t')
                 outstr += '\trule text 2:\n\t\t' + newtext2 + '\n'
+
+            if self.bside.flavor:
+                outstr += '\tflavor text 2: ' + self.bside.flavor.replace('\n', ' ') + '\n'
 
         # Apply specific formatting for planeswalker cards.
         elif self.is_planeswalker:
@@ -1700,7 +1742,15 @@ class Card:
         if pt:
             xml_out += f"      <pt>{escape(pt)}</pt>\n"
         xml_out += f"      <tablerow>{tablerow}</tablerow>\n"
-        xml_out += f"      <text>{escape(text)}</text>\n"
+
+        full_text = text
+        if self.flavor:
+            full_text += "\n\n" + self.flavor
+        if self.bside and self.bside.flavor:
+            # Note: bside rules text is already appended to 'text' in the helper
+            full_text += "\n\n" + self.bside.flavor
+
+        xml_out += f"      <text>{escape(full_text)}</text>\n"
         xml_out += "    </card>"
 
         return xml_out

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -21,7 +21,7 @@ def _split_csv_row(row):
     a nested dictionary structure for multi-faced cards.
     """
     # Canonical CSV fields
-    fields = ['name', 'mana_cost', 'type', 'subtypes', 'text', 'pt', 'rarity']
+    fields = ['name', 'mana_cost', 'type', 'subtypes', 'text', 'pt', 'rarity', 'flavor']
 
     # Normalize row keys (support manaCost vs mana_cost)
     normalized_row = {
@@ -32,6 +32,7 @@ def _split_csv_row(row):
         'text': row.get('text', ''),
         'pt': row.get('pt', ''),
         'rarity': row.get('rarity', ''),
+        'flavor': row.get('flavor', row.get('flavor_text', '')),
     }
 
     # Handle explicit power/toughness/loyalty/defense columns if present
@@ -74,6 +75,7 @@ def _csv_row_to_dict(row):
         'manaCost': row.get('mana_cost', ''),
         'text': row.get('text', '').replace('\\n', '\n'),
         'rarity': row.get('rarity', ''),
+        'flavorText': row.get('flavor', ''),
     }
 
     # Split type into supertypes and types
@@ -152,6 +154,7 @@ def _map_scryfall_face(face, d):
     if 'name' in face: d['name'] = face['name']
     if 'mana_cost' in face: d['manaCost'] = face['mana_cost']
     if 'oracle_text' in face: d['text'] = face['oracle_text']
+    if 'flavor_text' in face: d['flavorText'] = face['flavor_text']
     if 'type_line' in face:
         d['type'] = face['type_line']
         s, t, sub = utils.parse_type_line(face['type_line'])
@@ -184,7 +187,7 @@ def _normalize_scryfall_card(card):
         if len(faces) >= 2:
             # Map the second face to the 'bside' field.
             # This follows the linking logic used for double-faced/split cards.
-            bside = {'rarity': card.get('rarity', '')}
+            bside = {'rarity': card.get('rarity', ''), 'flavorText': card.get('flavorText', '')}
             _map_scryfall_face(faces[1], bside)
             card[utils.json_field_bside] = bside
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -638,6 +638,7 @@ def parse_type_line(type_line):
 class Ansi:
     RESET = '\033[0m'
     BOLD = '\033[1m'
+    ITALIC = '\033[3m'
     RED = '\033[91m'
     GREEN = '\033[92m'
     YELLOW = '\033[93m'

--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -30,6 +30,7 @@ FIELD_MAP = {
     'loyalty': {'header': 'Loyalty', 'align': 'r', 'aliases': ['loy', 'defense', 'def']},
     'text': {'header': 'Rules Text', 'align': 'l', 'aliases': ['oracle', 'rules']},
     'rarity': {'header': 'Rarity', 'align': 'l', 'aliases': []},
+    'flavor': {'header': 'Flavor Text', 'align': 'l', 'aliases': ['flavor_text']},
     'mechanics': {'header': 'Mechanics', 'align': 'l', 'aliases': ['keywords']},
     'identity': {'header': 'Identity', 'align': 'l', 'aliases': ['color_identity', 'ci']},
     'id_count': {'header': 'ID', 'align': 'r', 'aliases': ['identity_count']},
@@ -104,6 +105,10 @@ def get_field_value(card, field, ansi_color=False):
             res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'text':
         res = card.get_text(force_unpass=True, ansi_color=ansi_color)
+    elif canon == 'flavor':
+        res = card.flavor
+        if ansi_color and res:
+            res = utils.colorize(res, utils.Ansi.ITALIC)
     elif canon == 'rarity':
         res = card.rarity_name
         if ansi_color and res:
@@ -142,7 +147,7 @@ def get_field_value(card, field, ansi_color=False):
 
         b_res = get_field_value(card.bside, field, ansi_color)
         if res and b_res:
-            sep = "\n\n" if canon in ['text', 'encoded'] else " // "
+            sep = "\n\n" if canon in ['text', 'flavor', 'encoded'] else " // "
             return f"{res}{sep}{b_res}"
         return str(res or b_res)
 
@@ -156,7 +161,7 @@ Available Fields (aliases in parentheses):
   Basic Metadata:
     name, cost (mana), cmc (mv), rarity, set (code), number (num)
   Types & Text:
-    type (typeline), text (rules), mechanics (keywords), supertypes, types, subtypes
+    type (typeline), text (rules), flavor (flavor_text), mechanics (keywords), supertypes, types, subtypes
   Stats:
     stats (Smart P/T or Loyalty), pt, power (pow), toughness (tou), loyalty (def)
   Color Info:


### PR DESCRIPTION
This change implements flavor text support across the entire toolkit. It updates the `Card` library to load flavor text from MTGJSON and Scryfall sources, stores it in the `Card` object, and exposes it in human-readable formats (Oracle view), JSON exports, MSE set files, and the `mtg_search.py` utility.

Key additions:
- Card objects now have a `.flavor` attribute.
- Flavor text is loaded from MTGJSON (`flavorText`) and Scryfall (`flavor_text`).
- Searching by flavor text is supported via `Card.search_flavor()`.
- Oracle view (`mtg_oracle.py`) and terminal output now include italicized flavor text.
- `mtg_search.py` supports the `flavor` field (alias `flavor_text`) for extraction.
- Export formats (JSON, MSE, XML) now include flavor text.

---
*PR created automatically by Jules for task [2473404411303438848](https://jules.google.com/task/2473404411303438848) started by @RainRat*