### PR TITLE
[DOCS] Improve mtg_search.py internal help strings and examples

### DIFF
--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -154,13 +154,13 @@ def main():
         epilog='''
 Available Fields (aliases in parentheses):
   Basic Metadata:
-    name, cost (mana), cmc (mv), rarity, set (code), number (num)
+    name, cost (mana, mana_cost), cmc (mv, mana_value), rarity, set (code), number (num)
   Types & Text:
-    type (typeline), text (rules), mechanics (keywords), supertypes, types, subtypes
+    type (typeline), text (rules, oracle), mechanics (keywords), supertypes, types, subtypes
   Stats:
-    stats (Smart P/T or Loyalty), pt, power (pow), toughness (tou), loyalty (def)
+    stats (Smart field: P/T, Loyalty, or Defense), pt (pow_tou), power (pow), toughness (tou), loyalty (def, defense)
   Color Info:
-    colors, identity (ci), id_count
+    colors, identity (ci, color_identity), id_count (identity_count)
   Simulation & Encoding:
     pack, box, encoded
 
@@ -170,6 +170,9 @@ Usage Examples:
 
   # Find all mythic rares with CMC > 7 and save to a JSON file
   python3 scripts/mtg_search.py data/AllPrintings.json --rarity mythic --cmc ">7" mythics.json
+
+  # Find all 5-color cards (cards with color identity count of 5)
+  python3 scripts/mtg_search.py data/AllPrintings.json --id-count 5
 
   # Export all legendary creatures to a CSV file
   python3 scripts/mtg_search.py data/AllPrintings.json --grep "Legendary" --grep "Creature" --fields "name,mana,type,stats,rarity" legends.csv


### PR DESCRIPTION
Improved the CLI help text for the `mtg_search.py` utility.

The update includes:
- **Full Alias List:** Documented previously hidden aliases like `mana_value` (official MTG term for CMC) and `oracle` (rules text).
- **Smart Field Description:** Explained the logic of the `stats` field (P/T, Loyalty, or Defense).
- **New Example:** Added a clear example for filtering by color identity count (e.g., finding 5-color cards).

Verified the output via `--help` and ensured the script remains functional by running the full test suite (625/625 passing).

---
*PR created automatically by Jules for task [18373011769292280992](https://jules.google.com/task/18373011769292280992) started by @RainRat*