### PR TITLE
Inline private method NumericFilter._parse into constructor

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -744,15 +744,13 @@ class NumericFilter:
     - Ranges: "2-4", "0.5-1.5"
     """
     def __init__(self, filter_str):
-        self.filter_str = filter_str.strip()
+        s = filter_str.strip()
+        self.filter_str = s
         self.mode = None # 'exact', 'inequality', 'range'
         self.op = None   # '>', '<', '>=', '<=', '!=', '=='
         self.val = None
         self.val2 = None # for range
-        self._parse()
 
-    def _parse(self):
-        s = self.filter_str
         # Check for range
         range_match = re.match(r'^([-+]?\d*\.?\d+)\s*-\s*([-+]?\d*\.?\d+)$', s)
         if range_match:


### PR DESCRIPTION
This change addresses a case of "Premature Abstraction" by inlining the `_parse` private method into the `__init__` method of the `NumericFilter` class in `lib/utils.py`.

**Changes:**
- Moved logic from `NumericFilter._parse` directly into `NumericFilter.__init__`.
- Removed the `_parse` method definition.
- Ensured proper handling of the local variable `s` (the stripped filter string) within the constructor.

**Verification:**
- Successfully ran the full test suite (`PYTHONPATH=.:lib python3 -m pytest`), with all 646 tests passing.
- Verified that the logic remains functional and no breaking changes were introduced to the class's behavior.

---
*PR created automatically by Jules for task [9636075041145308900](https://jules.google.com/task/9636075041145308900) started by @RainRat*