### PR TITLE
Standardize CLI search result headers and pluralization

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -708,7 +708,8 @@ def print_operation_summary(op_name, success_count, fail_count, quiet=False):
     use_color = sys.stderr.isatty()
 
     if fail_count == 0:
-        summary = f">> {op_name} complete: {success_count} cards processed."
+        noun = "card" if success_count == 1 else "cards"
+        summary = f">> {op_name} complete: {success_count} {noun} processed."
         if use_color:
             summary = colorize(summary, Ansi.BOLD + Ansi.GREEN)
         print('\n' + summary, file=sys.stderr)

--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -460,7 +460,7 @@ Usage Examples:
                     if displayed_matches < total_matches:
                         match_count = f" (Showing {displayed_matches} of {total_matches} matches)"
                     else:
-                        match_count = f" ({total_matches} matches)"
+                        match_count = f" ({total_matches} {'match' if total_matches == 1 else 'matches'})"
 
                     header_title = "SEARCH RESULTS"
                     header_text = header_title + match_count

--- a/scripts/mtg_sets.py
+++ b/scripts/mtg_sets.py
@@ -57,10 +57,19 @@ def display_sets(sets, use_color=False):
     if not sets:
         return
 
-    header_text = 'AVAILABLE SETS'
+    header_title = "AVAILABLE SETS"
+    match_count = f" ({len(sets)} {'match' if len(sets) == 1 else 'matches'})"
+    header_text = header_title + match_count
+
     if use_color:
-        header_text = utils.colorize(header_text, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE)
-    print(header_text)
+        header_main = utils.colorize(header_title, utils.Ansi.BOLD + utils.Ansi.CYAN)
+        header_count = utils.colorize(match_count, utils.Ansi.CYAN)
+        print("  " + header_main + header_count)
+    else:
+        print("  " + header_text)
+
+    # Always use a visible separator line for better visual hierarchy
+    print("  " + "=" * len(header_text))
 
     header = ["Code", "Name", "Type", "Release Date", "Count"]
     if use_color:
@@ -193,11 +202,6 @@ def main():
     try:
         with redirect_stdout(output_f):
             display_sets(sets, use_color=use_color)
-
-            summary = f"\nFound {len(sets)} sets matching criteria."
-            if use_color:
-                summary = utils.colorize(summary, utils.Ansi.BOLD + utils.Ansi.GREEN)
-            print(summary)
 
             if (args.summarize or args.view) and sets:
                 set_codes = [s['code'] for s in sets]


### PR DESCRIPTION
**PR Title:** [UI/UX] Standardize CLI Search Result Headers and Pluralization

**Description:**
* **Context:** CLI
* **Problem:** The toolkit's CLI output suffered from minor visual inconsistencies and grammatical friction. Specifically, `mtg_sets.py` had a misaligned header compared to the data table, and its header style differed from the primary `mtg_search.py` tool. Additionally, both tools incorrectly used plural forms (e.g., "1 matches", "1 cards processed") even when a single result was found.
* **Solution:** I standardized the search result headers across `mtg_search.py` and `mtg_sets.py` to ensure consistent alignment (2-space indent), color-coded feedback (Cyan), and clear visual hierarchy (separator lines). I also updated the match count and final operation summary logic (`lib/utils.py`) to handle singular and plural nouns correctly, improving the professional polish of the interface.

**Changes:**
- Modified `scripts/mtg_search.py` to use singular "match" for exact 1-match results.
- Modified `scripts/mtg_sets.py` to align its header with the table, adopt the Cyan "AVAILABLE SETS (X matches)" format, add a separator line, and remove redundant trailing output.
- Modified `lib/utils.py`'s `print_operation_summary` to use singular "card" when only one card is processed.

---
*PR created automatically by Jules for task [15238050913334649410](https://jules.google.com/task/15238050913334649410) started by @RainRat*