### PR TITLE
Inline single-use private method `NumericFilter._parse`

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -749,9 +749,7 @@ class NumericFilter:
         self.op = None   # '>', '<', '>=', '<=', '!=', '=='
         self.val = None
         self.val2 = None # for range
-        self._parse()
 
-    def _parse(self):
         s = self.filter_str
         # Check for range
         range_match = re.match(r'^([-+]?\d*\.?\d+)\s*-\s*([-+]?\d*\.?\d+)$', s)


### PR DESCRIPTION
* **What:** Inlined the logic of the private `_parse` method into the `__init__` method of the `NumericFilter` class in `lib/utils.py` and removed the now-redundant method definition.
* **Why:** This simplifies the class structure by removing an unnecessary layer of indirection (Premature Abstraction). The external behavior of the `NumericFilter` class remains identical, as confirmed by existing tests.

---
*PR created automatically by Jules for task [900214771524894605](https://jules.google.com/task/900214771524894605) started by @RainRat*