### PR TITLE
[DOCS] Synchronize CLI documentation and shorthands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,17 @@ Options for formatting the output. While primarily used for AI output, this tool
 
 *   `-g`, `--gatherer`: Formats text like the official Gatherer website (Default). This applies modern wording and capitalization.
 *   `--raw`: Shows raw text without special formatting.
-*   `--table`: Creates a formatted table for terminal view.
-*   `--html`: Creates a webpage with card images.
+*   `-t`, `--table`: Creates a formatted table for terminal view.
+*   `-H`, `--html`: Creates a webpage with card images.
 *   `--deck`: Creates a standard MTG decklist.
 *   `--xml`: Creates a Cockatrice-compatible XML card database.
 *   `--mse`: Creates a file for Magic Set Editor.
-*   `--json`: Creates a structured JSON file.
+*   `-j`, `--json`: Creates a structured JSON file.
 *   `--jsonl`: Creates a JSON Lines file (one card per line).
 *   `--csv`: Creates a spreadsheet file.
-*   `--md`: Creates a Markdown document.
+*   `-M`, `--md`: Creates a Markdown document.
 *   `--md-table`: Creates a Markdown table.
-*   `--summary`: Creates a compact one-line summary for each card.
+*   `-S`, `--summary`: Creates a compact one-line summary for each card.
 *   `--color` / `--no-color`: Manually enable or disable ANSI color output in your terminal.
 *   `--shuffle`: Randomizes the order of cards (the tool does not shuffle cards by default for decoding).
 *   `--sort`: Sorts cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, or `box`.
@@ -346,8 +346,8 @@ python3 sortcards.py data/AllPrintings.json sorted_output.txt
 python3 sortcards.py encoded_output.txt sorted_sample.txt --sample 50 --grep "Elf"
 ```
 *   **Options:** Supports `--encoding`, `--limit`, `--shuffle`, `--sample`, `--booster`, `--box`, and all **Advanced Filtering** flags.
-*   `--summary`: Output compact card summaries instead of full text.
-*   `--md`: Output in Markdown format with collapsible sections.
+*   `-S`, `--summary`: Output compact card summaries instead of full text.
+*   `--md` (or `--markdown`): Output in Markdown format with collapsible sections.
 *   `--color` / `--no-color`: Enable or disable ANSI color output.
 
 ### `summarize.py`
@@ -494,8 +494,9 @@ python3 scripts/mtg_search.py data/AllPrintings.json --grep "Goblin" --fields "n
 # Find all mythic rares with CMC > 7 and output as JSON
 python3 scripts/mtg_search.py data/AllPrintings.json --rarity mythic --cmc ">7" --json
 ```
-*   **Fields:** `name`, `cost`, `cmc`, `colors`, `type`, `stats`, `supertypes`, `types`, `subtypes`, `pt`, `power`, `toughness`, `loyalty`, `text`, `rarity`, `mechanics`, `identity`, `id_count`, `set`, `number`, `pack`, `box`, `encoded`.
-*   **Output Formats:** Plain text (default), `--table`, `--md-table`, `--json`, `--jsonl`, `--csv`.
+*   **Fields:** `name`, `cost`, `cmc`, `colors`, `type`, `stats`, `supertypes`, `types`, `subtypes`, `pt`, `power`, `toughness`, `loyalty`, `text`, `rarity`, `mechanics`, `identity`, `id_count`, `set`, `number`, `pack`, `box`, `summary` (alias `view`), `encoded`.
+*   **Output Formats:** Plain text (default), `-t`, `--table`, `--md-table` (or `--mdt`), `-j`, `--json`, `--jsonl`, `--csv`, `-S`, `--summary`.
+*   **Shorthands:** `-f` (for `--fields`), `-g` (for `--grep`).
 *   Supports all **Advanced Filtering** flags, sorting, and booster/box simulation.
 
 ### `mtg_subset.py`


### PR DESCRIPTION
This PR synchronizes the `README.md` documentation with the actual implementation of the toolkit's CLI utilities. 

### Key Improvements:
* **Shorthand Aliases:** Added missing shorthand flags for `decode.py` (`-t`, `-H`, `-M`, `-j`, `-S`), `sortcards.py` (`-S`, `--markdown`), and `mtg_search.py` (`-S`, `-f`, `-g`).
* **Field Documentation:** Included the `summary` (alias `view`) field in the `mtg_search.py` documentation, which was previously missing from the primary field list.
* **Output Formats:** Clarified available output formats and their respective shorthands for search results.
* **Style:** Maintained Plain English and a professional yet accessible tone in accordance with project guidelines.

These changes make the toolkit more accessible to power users and ensure that the documentation serves as an accurate reference for the codebase.

---
*PR created automatically by Jules for task [15053349624559454257](https://jules.google.com/task/15053349624559454257) started by @RainRat*