### PR TITLE
Inline `NumericFilter._parse` to reduce premature abstraction

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -744,15 +744,13 @@ class NumericFilter:
     - Ranges: "2-4", "0.5-1.5"
     """
     def __init__(self, filter_str):
-        self.filter_str = filter_str.strip()
+        s = filter_str.strip()
+        self.filter_str = s
         self.mode = None # 'exact', 'inequality', 'range'
         self.op = None   # '>', '<', '>=', '<=', '!=', '=='
         self.val = None
         self.val2 = None # for range
-        self._parse()
 
-    def _parse(self):
-        s = self.filter_str
         # Check for range
         range_match = re.match(r'^([-+]?\d*\.?\d+)\s*-\s*([-+]?\d*\.?\d+)$', s)
         if range_match:


### PR DESCRIPTION
**PR Title:** Inline `NumericFilter._parse` to reduce premature abstraction

**Description:**
* **What:** Inlined the private `_parse` method into the `__init__` method of the `NumericFilter` class in `lib/utils.py`.
* **Why:** The `_parse` method was only used once within the class, making it a case of premature abstraction. Inlining it simplifies the class structure and improves readability while maintaining identical external behavior.
* **Verification:** Successfully ran all relevant test suites (`tests/test_numeric_filters.py`, `tests/test_utils_coverage_ext.py`, and `tests/test_utils_gaps.py`), with all 32 tests passing.

---
*PR created automatically by Jules for task [15035529925926709338](https://jules.google.com/task/15035529925926709338) started by @RainRat*