### PR TITLE
Simplify redundant cardname assignment in Card.format()

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1202,10 +1202,7 @@ class Card:
         if for_html:
             outstr += '<div class="card-text">\n'
 
-        if gatherer:
-            cardname = titlecase(transforms.name_unpass_1_dashes(self.__dict__[field_name]))
-        else:
-            cardname = titlecase(transforms.name_unpass_1_dashes(self.__dict__[field_name]))
+        cardname = titlecase(transforms.name_unpass_1_dashes(self.__dict__[field_name]))
 
         if vdump and not cardname:
             cardname = '_NONAME_'


### PR DESCRIPTION
This pull request simplifies the `Card.format()` method in `lib/cardlib.py` by removing redundant conditional logic.

- **What:** Removed an `if gatherer:` block where both the `if` and `else` branches assigned the same value to the `cardname` variable.
- **Why:** The identical logic (`titlecase(transforms.name_unpass_1_dashes(self.__dict__[field_name]))`) makes the conditional check unnecessary. This simplification reduces code noise and improves maintainability.
- **Safety:** The change is non-breaking as it preserves the exact same logic for all input states. Verified by running the comprehensive test suite (`tests/test_cardlib.py` and `tests/test_card_format_comprehensive.py`), which all passed.

---
*PR created automatically by Jules for task [14870518586491562901](https://jules.google.com/task/14870518586491562901) started by @RainRat*