### PR TITLE
[DOCS] Add documentation for mtg_functional.py utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ If you don't use the `--nolabel` flag, each field is prefixed with a number for 
 ---
 
 ### Advanced Filtering
-Filter which cards the tool processes using search patterns, set codes, rarities, or even decklist files. These flags work across `encode.py`, `decode.py`, `sortcards.py`, `splitcards.py`, `scripts/summarize.py`, `scripts/mtg_validate.py`, `scripts/mtg_search.py`, `scripts/mtg_oracle.py`, `scripts/mtg_subset.py`, `scripts/mtg_lexicon.py`, `scripts/mtg_tokens.py`, `scripts/mtg_mechanics.py`, `scripts/mtg_diff.py`, `scripts/mtg_skeleton.py`, and `scripts/mtg_pips.py`.
+Filter which cards the tool processes using search patterns, set codes, rarities, or even decklist files. These flags work across `encode.py`, `decode.py`, `sortcards.py`, `splitcards.py`, `scripts/summarize.py`, `scripts/mtg_validate.py`, `scripts/mtg_search.py`, `scripts/mtg_oracle.py`, `scripts/mtg_subset.py`, `scripts/mtg_lexicon.py`, `scripts/mtg_tokens.py`, `scripts/mtg_mechanics.py`, `scripts/mtg_diff.py`, `scripts/mtg_functional.py`, `scripts/mtg_skeleton.py`, and `scripts/mtg_pips.py`.
 
 *   **Global Filters:**
     *   `--grep "pattern"`: Only include cards where the name, typeline, rules text, mana cost, or stats (P/T, loyalty, or defense) match the search pattern. Use multiple `--grep` flags for **AND** logic (all patterns must match).
@@ -450,6 +450,25 @@ python3 scripts/mtg_compare.py --set MOM --set ONE data/AllPrintings.json
     *   `--shuffle`: Randomize cards before analysis.
     *   `--sample N`: Pick N random cards (shorthand for `--shuffle --limit N`).
     *   `--color` / `--no-color`: Enable or disable ANSI color output.
+    *   Supports standard **Advanced Filtering** flags.
+
+### `mtg_functional.py`
+Identifies and groups 'functional reprints' (cards with different names but identical mana costs, types, stats, and rules text).
+```bash
+# List all functional reprints in a dataset
+python3 scripts/mtg_functional.py data/AllPrintings.json
+
+# Create a deduplicated dataset (one card per functional group)
+python3 scripts/mtg_functional.py data/AllPrintings.json --dedupe unique_cards.json
+
+# Find functional reprints of Goblins
+python3 scripts/mtg_functional.py data/AllPrintings.json --grep "Goblin"
+```
+*   **Options:**
+    *   `--table`: Display groups in a formatted table (Default).
+    *   `--json`: Output groups as JSON.
+    *   `--csv`: Output groups as CSV.
+    *   `--dedupe`: Output a JSON file containing the full dataset with functional duplicates removed.
     *   Supports standard **Advanced Filtering** flags.
 
 ### `json2csv.py`, `csv2json.py` & `combinejson.py`


### PR DESCRIPTION
This pull request adds missing documentation for the `scripts/mtg_functional.py` utility tool to the `README.md`. 

### Changes:
*   **Advanced Filtering:** Included `scripts/mtg_functional.py` in the summary list of tools that support global and field-specific filtering flags.
*   **Utility Tools:** Added a new section for `mtg_functional.py` with:
    *   A concise description of its purpose (identifying cards with identical mechanics but different names).
    *   Clear usage examples for common tasks like grouping reprints and creating a deduplicated dataset.
    *   A breakdown of its unique options (`--table`, `--json`, `--csv`, `--dedupe`).

This improvement makes the tool more accessible to users and ensures the project documentation remains synchronized with the available scripts. The changes follow the project's Plain English and simplicity guidelines.

---
*PR created automatically by Jules for task [5453037858555781974](https://jules.google.com/task/5453037858555781974) started by @RainRat*