### PR TITLE
Inline single-use private method `_compute_colors` in `Manacost` class

### DIFF
--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -10,17 +10,6 @@ COLOR_STRIP_CHARS = {'2', 'P', 'S', 'X', 'C', 'E'}
 class Manacost:
     '''mana cost representation with data'''
     
-    # hardcoded to be dependent on the symbol structure... ah well
-    def _compute_colors(self):
-        colors = set()
-        for sym, count in self.symbols.items():
-            if count > 0:
-                for char in sym:
-                    if char not in COLOR_STRIP_CHARS:
-                        colors.add(char)
-        # sort so the order is always consistent
-        return ''.join(sorted(colors))
-
     def __init__(self, src, fmt = ''):
         # source fields, exactly one will be set
         self.raw = None
@@ -95,7 +84,13 @@ class Manacost:
                         idx += 1
                         self.valid = False
 
-        self.colors = self._compute_colors()
+        colors = set()
+        for sym, count in self.symbols.items():
+            if count > 0:
+                for char in sym:
+                    if char not in COLOR_STRIP_CHARS:
+                        colors.add(char)
+        self.colors = ''.join(sorted(colors))
 
     def __str__(self):
         return self.format()


### PR DESCRIPTION
This PR inlines the single-use private method `_compute_colors` into the `Manacost.__init__` method in `lib/manalib.py`. This refactoring simplifies the class structure by removing an unnecessary abstraction that was only utilized at the end of the constructor.

Key changes:
- Removed `_compute_colors` method definition from `Manacost` class.
- Moved the logic for identifying and sorting colors from `_compute_colors` directly into the end of `Manacost.__init__`.
- Verified the fix by running the full test suite (all 661 tests passed).

---
*PR created automatically by Jules for task [3468078959444373821](https://jules.google.com/task/3468078959444373821) started by @RainRat*