### PR TITLE
[TEST] Add coverage for datalib.add_separator_row

### DIFF
--- a/tests/test_qa_datalib_add_separator.py
+++ b/tests/test_qa_datalib_add_separator.py
@@ -1,0 +1,43 @@
+
+import pytest
+import sys
+import os
+
+# Ensure lib is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib')))
+
+from datalib import add_separator_row
+
+def test_add_separator_row_empty():
+    """Verify that add_separator_row handles empty input gracefully."""
+    rows = []
+    add_separator_row(rows)
+    assert rows == []
+
+def test_add_separator_row_default_index():
+    """Verify that add_separator_row inserts a separator at the default index 1."""
+    rows = [
+        ['Header1', 'Header2'],
+        ['Data1', 'Data2']
+    ]
+    add_separator_row(rows)
+    # col widths: 7, 7
+    assert len(rows) == 3
+    assert rows[0] == ['Header1', 'Header2']
+    assert rows[1] == ['-------', '-------']
+    assert rows[2] == ['Data1', 'Data2']
+
+def test_add_separator_row_custom_index():
+    """Verify that add_separator_row inserts a separator at a custom index."""
+    rows = [
+        ['Header1', 'Header2'],
+        ['Data1', 'Data2'],
+        ['Total1', 'Total2']
+    ]
+    # Insert at end
+    add_separator_row(rows, index=len(rows))
+    assert len(rows) == 4
+    assert rows[0] == ['Header1', 'Header2']
+    assert rows[1] == ['Data1', 'Data2']
+    assert rows[2] == ['Total1', 'Total2']
+    assert rows[3] == ['-------', '-------']


### PR DESCRIPTION
This PR improves the test suite by adding targeted unit tests for the `add_separator_row` function in `lib/datalib.py`.

### Changes
- Created `tests/test_qa_datalib_add_separator.py` containing three new test cases:
    - `test_add_separator_row_empty`: Verifies that empty row sets are handled gracefully.
    - `test_add_separator_row_default_index`: Verifies that a separator row is correctly inserted at the default index (1).
    - `test_add_separator_row_custom_index`: Verifies that a separator row can be inserted at a user-specified index.

### Why
The `add_separator_row` function was previously uncovered. These tests ensure its reliability and prevent regressions in table formatting logic used across multiple CLI tools in the repository.

Verified via `pytest --cov=lib` that line 30 in `lib/datalib.py` is now covered.

---
*PR created automatically by Jules for task [4827036941693955619](https://jules.google.com/task/4827036941693955619) started by @RainRat*