### PR TITLE
Inline single-use private helper _find_best_candidate in jdecode.py

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -655,17 +655,6 @@ def default_exclude_layouts(layout):
     return layout in ['token', 'planar', 'scheme', 'phenomenon', 'vanguard']
 
 # centralized logic for opening files of cards, either encoded or json
-def _find_best_candidate(jcards, exclude_sets, linetrans):
-    # look for a normal rarity version, in a set we can use
-    for idx, jcard in enumerate(jcards):
-        card = cardlib.Card(jcard, linetrans=linetrans)
-        if (card.rarity != utils.rarity_special_marker and
-            not exclude_sets(jcard.get(utils.json_field_set_name))):
-            return idx, card
-
-    # if there isn't one, settle with index 0
-    return 0, cardlib.Card(jcards[0], linetrans=linetrans)
-
 def _check_parsing_quality(cards, report_fobj):
     good_count = 0
     bad_count = 0
@@ -710,11 +699,18 @@ def _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
         if json_cardname in json_srcs and len(json_srcs[json_cardname]) > 0:
             jcards = json_srcs[json_cardname]
 
-            idx, card = _find_best_candidate(jcards, exclude_sets, linetrans)
+            # Look for a normal rarity version in a set we can use
+            idx, card = 0, cardlib.Card(jcards[0], linetrans=linetrans)
+            for i, jcard in enumerate(jcards):
+                c = cardlib.Card(jcard, linetrans=linetrans)
+                if (c.rarity != utils.rarity_special_marker and
+                    not exclude_sets(jcard.get(utils.json_field_set_name))):
+                    idx, card = i, c
+                    break
 
             skip = False
             # Check exclusions
-            # Note: _find_best_candidate returns a cardlib.Card object, but we also check jcards[idx] for raw fields
+            # Note: the candidate selection above returns a cardlib.Card object, but we also check jcards[idx] for raw fields
             # Checking set name and layout from raw json
             if (exclude_sets(jcards[idx].get(utils.json_field_set_name))
                 or exclude_layouts(jcards[idx].get('layout'))

--- a/tests/test_jdecode_coverage_final.py
+++ b/tests/test_jdecode_coverage_final.py
@@ -82,19 +82,15 @@ class TestJDecodeCoverageFinal(unittest.TestCase):
 
     def test_process_json_srcs_invalid_logging(self):
         # Line 739-741: print invalid card
-        card = MagicMock(spec=cardlib.Card)
-        card.valid = False
-        card.parsed = True
-        card.types = []
+        # A card with types but no P/T (if creature) is invalid but parsed.
+        # It also needs a rarity or it will set parsed=False in cardlib.py
+        json_srcs = {"bad card": [{"name": "bad card", "types": ["Creature"], "rarity": "Common"}]}
 
-        json_srcs = {"bad card": [{"name": "bad card"}]}
-
-        with patch('lib.jdecode._find_best_candidate', return_value=(0, card)):
-            with patch('sys.stderr', new=io.StringIO()) as fake_err:
-                jdecode._process_json_srcs(json_srcs, set(), verbose=True, linetrans=True,
-                                           exclude_sets=lambda x: False, exclude_types=lambda x: False,
-                                           exclude_layouts=lambda x: False, report_fobj=None)
-                self.assertIn("Invalid card: bad card", fake_err.getvalue())
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            jdecode._process_json_srcs(json_srcs, set(), verbose=True, linetrans=True,
+                                       exclude_sets=lambda x: False, exclude_types=lambda x: False,
+                                       exclude_layouts=lambda x: False, report_fobj=None)
+            self.assertIn("Invalid card: bad card", fake_err.getvalue())
 
     def test_mtg_open_file_verbose_formats(self):
         # Lines 995, 1005, 1015: Verbose output for specific formats


### PR DESCRIPTION
Identified and resolved a "Premature Abstraction" issue in `lib/jdecode.py` by inlining the `_find_best_candidate` private helper function, which was only used once. The logic remains identical, ensuring no breaking changes. Updated associated tests in `tests/test_jdecode_coverage_final.py` to align with the structural changes and improve test hygiene by using real card data for validation.

---
*PR created automatically by Jules for task [2364760680186279996](https://jules.google.com/task/2364760680186279996) started by @RainRat*