### PR TITLE
[TEST] Fix ZeroDivisionError in mtg_archetypes.py and add coverage

### DIFF
--- a/scripts/mtg_archetypes.py
+++ b/scripts/mtg_archetypes.py
@@ -124,7 +124,8 @@ Usage Examples:
             pass
 
     # Filter out empty archetypes or those with too few cards
-    active_pairs = [p for p in pairs if len(archetypes[p]) >= args.min_cards]
+    # We enforce a minimum of 1 card regardless of args.min_cards to avoid ZeroDivisionError
+    active_pairs = [p for p in pairs if len(archetypes[p]) >= max(1, args.min_cards)]
 
     if not active_pairs:
         if not args.quiet:

--- a/tests/test_mtg_archetypes.py
+++ b/tests/test_mtg_archetypes.py
@@ -1,0 +1,58 @@
+import pytest
+import subprocess
+import json
+import os
+
+def test_archetypes_zero_division_bug(tmp_path):
+    # Minimal dataset: only one multicolored card.
+    # WU (Azorius) will be populated with "UW" identity.
+    # Others like "BU" (Dimir) will be empty.
+    data = [
+        {
+            "name": "WU Card",
+            "manaCost": "{W}{U}",
+            "types": ["Creature"],
+            "power": "1",
+            "toughness": "1",
+            "rarity": "Common"
+        }
+    ]
+    infile = tmp_path / "test_cards.json"
+    with open(infile, 'w') as f:
+        json.dump(data, f)
+
+    # Run the script with --min-cards 0
+    # After the fix, active_pairs will only include WU, preventing ZeroDivisionError.
+    result = subprocess.run(
+        ['python3', 'scripts/mtg_archetypes.py', str(infile), '--min-cards', '0'],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 0
+    assert "ARCHETYPE PROFILING" in result.stdout
+    assert "WU (Azorius)" in result.stdout
+    assert "UB (Dimir)" not in result.stdout
+
+def test_archetypes_basic_functionality(tmp_path):
+    # Minimal dataset with enough cards to profile one archetype correctly
+    data = [
+        {"name": "W", "manaCost": "{W}", "types": ["Creature"], "power": "1", "toughness": "1", "rarity": "Common"},
+        {"name": "U", "manaCost": "{U}", "types": ["Creature"], "power": "1", "toughness": "1", "rarity": "Common"},
+        {"name": "WU", "manaCost": "{W}{U}", "types": ["Creature"], "power": "1", "toughness": "1", "rarity": "Uncommon"},
+        {"name": "WU2", "manaCost": "{1}{W}{U}", "types": ["Instant"], "rarity": "Common"},
+        {"name": "WU3", "manaCost": "{2}{W}{U}", "types": ["Enchantment"], "rarity": "Common"}
+    ]
+    infile = tmp_path / "functional_cards.json"
+    with open(infile, 'w') as f:
+        json.dump(data, f)
+
+    result = subprocess.run(
+        ['python3', 'scripts/mtg_archetypes.py', str(infile), '--min-cards', '1'],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 0
+    assert "ARCHETYPE PROFILING" in result.stdout
+    assert "WU (Azorius)" in result.stdout


### PR DESCRIPTION
This PR fixes a `ZeroDivisionError` in the `mtg_archetypes.py` script. The error occurred when the `--min-cards 0` flag was used with a dataset where one or more of the 10 standard two-color pairs had no matching cards. In such cases, the script would attempt to calculate curve statistics (Average CMC and Creature %) by dividing by zero.

The fix ensures that an archetype must have at least one card to be considered "active" and thus profiled, regardless of the `--min-cards` value.

Additionally, this PR introduces a new test suite `tests/test_mtg_archetypes.py` which:
1.  Reproduces the `ZeroDivisionError` in unpatched versions.
2.  Verifies the fix and ensures the script handles empty archetypes gracefully.
3.  Provides basic functional coverage for the archetype profiling logic.

---
*PR created automatically by Jules for task [2953310154785473551](https://jules.google.com/task/2953310154785473551) started by @RainRat*