### PR TITLE
[DOCS] Improve mtg_search.py CLI help text

### DIFF
--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -155,7 +155,7 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Search card data and extract specific fields. It works with all supported formats (JSON, CSV, XML, or encoded text).",
+        description="Search card data and extract specific fields. It works with all supported formats (JSON, JSONL, CSV, XML, MSE, ZIP, or Decklist), encoded text, or directory.",
         epilog='''
 Available Fields (aliases in parentheses):
   Basic Metadata:
@@ -166,8 +166,8 @@ Available Fields (aliases in parentheses):
     stats (Smart field: P/T, Loyalty, or Defense), pt (pow_tou), power (pow), toughness (tou), loyalty (def, defense)
   Color Info:
     colors, identity (ci, color_identity), id_count (identity_count)
-  Simulation & Encoding:
-    pack, box, encoded
+  Display & Simulation:
+    summary (view), encoded, pack, box
 
 Usage Examples:
   # List names and costs of all Goblins in a table


### PR DESCRIPTION
**PR Title:** [DOCS] Improve mtg_search.py CLI help text

**Description:**
* **Type:** Internal Help
* **What:** Updated the `argparse` configuration in `scripts/mtg_search.py`.
* **Why:** The existing help text was incomplete. This change expands the description to include all supported input formats (JSON, JSONL, CSV, XML, MSE, ZIP, and Decklist) and directory support. It also documents the `summary` field (alias `view`), which was previously missing from the field list, and improves the organization of the epilog.

---
*PR created automatically by Jules for task [6786180287305467156](https://jules.google.com/task/6786180287305467156) started by @RainRat*