### PR TITLE
Inline single-use private method `_has_subtype` in `Card` class

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -522,10 +522,6 @@ class Card:
         """Returns True if the card has the specified type (case-insensitive)."""
         return any(t.lower() == type_name.lower() for t in self.types)
 
-    def _has_subtype(self, subtype_name):
-        """Returns True if the card has the specified subtype (case-insensitive)."""
-        return any(s.lower() == subtype_name.lower() for s in self.subtypes)
-
     @property
     def is_artifact(self):
         """Returns True if the card is an artifact."""
@@ -534,7 +530,7 @@ class Card:
     @property
     def is_creature(self):
         """Returns True if the card is a creature or a vehicle."""
-        return self._has_type('creature') or self._has_subtype('vehicle')
+        return self._has_type('creature') or any(s.lower() == 'vehicle' for s in self.subtypes)
 
     @property
     def is_planeswalker(self):


### PR DESCRIPTION
Inlined the private method `_has_subtype` into the `is_creature` property within `lib/cardlib.py` and removed the method definition.

* **What:** Inlined the private method `_has_subtype` into the `is_creature` property and removed the redundant method.
* **Why:** To improve code quality by removing premature abstraction. The method was private and used only once.
* **Impact:** Non-breaking change. Behavioral logic is preserved. All 664 tests passed.

---
*PR created automatically by Jules for task [7673609630473258530](https://jules.google.com/task/7673609630473258530) started by @RainRat*