### PR TITLE
[FEAT] Card Complexity Analysis Tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,4 @@ Key utility scripts for dataset analysis:
 *   `scripts/mtg_subset.py`: Creates filtered subsets of MTGJSON files.
 *   `scripts/mtg_lexicon.py`: Analyzes color-characteristic vocabulary.
 *   `scripts/mtg_tokens.py`: Extracts and summarizes token definitions from rules text.
+*   `scripts/mtg_complexity.py`: Analyzes and ranks cards by design complexity.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ If you don't use the `--nolabel` flag, each field is prefixed with a number for 
 ---
 
 ### Advanced Filtering
-Filter which cards the tool processes using search patterns, set codes, rarities, or even decklist files. These flags work across `encode.py`, `decode.py`, `sortcards.py`, `splitcards.py`, `scripts/summarize.py`, `scripts/mtg_validate.py`, `scripts/mtg_search.py`, `scripts/mtg_oracle.py`, `scripts/mtg_subset.py`, `scripts/mtg_lexicon.py`, `scripts/mtg_tokens.py`, `scripts/mtg_mechanics.py`, `scripts/mtg_diff.py`, `scripts/mtg_functional.py`, `scripts/mtg_skeleton.py`, and `scripts/mtg_pips.py`.
+Filter which cards the tool processes using search patterns, set codes, rarities, or even decklist files. These flags work across `encode.py`, `decode.py`, `sortcards.py`, `splitcards.py`, `scripts/summarize.py`, `scripts/mtg_validate.py`, `scripts/mtg_search.py`, `scripts/mtg_oracle.py`, `scripts/mtg_subset.py`, `scripts/mtg_lexicon.py`, `scripts/mtg_tokens.py`, `scripts/mtg_mechanics.py`, `scripts/mtg_diff.py`, `scripts/mtg_functional.py`, `scripts/mtg_skeleton.py`, `scripts/mtg_pips.py`, and `scripts/mtg_complexity.py`.
 
 *   **Global Filters:**
     *   `--grep "pattern"`: Only include cards where the name, typeline, rules text, mana cost, or stats (P/T, loyalty, or defense) match the search pattern. Use multiple `--grep` flags for **AND** logic (all patterns must match).
@@ -620,6 +620,22 @@ python3 scripts/mtg_pips.py data/AllPrintings.json --set MOM --include-text
     *   `--json`: Output results in structured JSON format.
     *   `--csv`: Output results in CSV format.
     *   Supports standard **Advanced Filtering** flags and simulation.
+
+### `mtg_complexity.py`
+Analyzes and ranks cards based on a heuristic Complexity Score. This helps identify "Complexity Creep" in generated datasets by accounting for rules text length, mechanics, color identity, X-costs, and multi-faced cards.
+```bash
+# Rank the most complex cards in a set
+python3 scripts/mtg_complexity.py data/AllPrintings.json --set MOM
+
+# Output rankings as JSON for further analysis
+python3 scripts/mtg_complexity.py generated_cards.txt complexity.json
+```
+*   **Options:**
+    *   `-t N`, `--top N`: Number of top complex cards to display (Default: 20).
+    *   `--sort {complexity,name,cmc}`: Primary sort for the ranking table.
+    *   `--json`: Output results in structured JSON format.
+    *   `--csv`: Output results in CSV format.
+    *   Supports all **Advanced Filtering** flags.
 
 ### `distances.py` & `sum.py`
 These tools allow for bulk creativity analysis of your generated cards. `distances.py` calculates the semantic and name distance between your cards and the official dataset, and `sum.py` provides a statistical summary of the results.

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -527,6 +527,49 @@ class Card:
         return any(s.lower() == subtype_name.lower() for s in self.subtypes)
 
     @property
+    def total_words(self):
+        """Returns the total number of words in the rules text (including B-sides)."""
+        count = len(self.text_words)
+        if self.bside:
+            count += self.bside.total_words
+        return count
+
+    @property
+    def total_lines(self):
+        """Returns the total number of lines in the rules text (including B-sides)."""
+        count = len(self.text_lines)
+        if self.bside:
+            count += self.bside.total_lines
+        return count
+
+    @property
+    def complexity_score(self):
+        """
+        Calculates a heuristic Complexity Score for the card.
+        Heuristic:
+        - Words: 1 pt each
+        - Lines: 5 pts each
+        - Mechanics: 8 pts each
+        - Color Identity: 3 pts per color
+        - X-cost/effect: +10
+        - Multi-faced: +25
+        """
+        score = self.total_words
+        score += self.total_lines * 5
+        score += len(self.mechanics) * 8
+        score += len(self.color_identity) * 3
+
+        # X-cost/effect
+        if 'X-Cost/Effect' in self.mechanics:
+            score += 10
+
+        # Multi-faced bonus
+        if self.bside:
+            score += 25
+
+        return score
+
+    @property
     def is_artifact(self):
         """Returns True if the card is an artifact."""
         return self._has_type('artifact')

--- a/scripts/mtg_complexity.py
+++ b/scripts/mtg_complexity.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+import sys
+import os
+import argparse
+import json
+import csv
+from statistics import mean
+
+# Add lib directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+import utils
+import jdecode
+import datalib
+import cardlib
+import transforms
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze and rank Magic: The Gathering cards by design complexity.",
+        epilog='''
+Complexity is calculated using a heuristic score:
+  - Words: 1 pt each
+  - Lines: 5 pts each
+  - Mechanics: 8 pts each
+  - Color Identity: 3 pts per color
+  - X-cost/effect: +10 pts
+  - Multi-faced: +25 pts (Transform, Split, etc.)
+
+This helps identify "Complexity Creep" in generated datasets.
+''',
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    # Group: Input / Output
+    io_group = parser.add_argument_group('Input / Output')
+    io_group.add_argument('infile', nargs='?', default='-',
+                        help='Input card data (MTGJSON, Scryfall, CSV, XML, MSE, or encoded text). Defaults to stdin (-).')
+    io_group.add_argument('outfile', nargs='?', default=None,
+                        help='Path to save the results. If not provided, results print to the console.')
+
+    # Group: Analysis Options
+    analysis_group = parser.add_argument_group('Analysis Options')
+    analysis_group.add_argument('-t', '--top', type=int, default=20,
+                                help='Number of top complex cards to display in the ranking table (Default: 20).')
+    analysis_group.add_argument('--sort', choices=['complexity', 'name', 'cmc'], default='complexity',
+                                help='Primary sort for the ranking table (Default: complexity).')
+    analysis_group.add_argument('--reverse', action='store_true', help='Reverse the sort order.')
+
+    # Group: Output Format
+    fmt_group_title = parser.add_argument_group('Output Format')
+    fmt_group = fmt_group_title.add_mutually_exclusive_group()
+    fmt_group.add_argument('--table', action='store_true', help='Generate a formatted table (Default for terminal).')
+    fmt_group.add_argument('--json', action='store_true', help='Generate a JSON file (Auto-detected for .json).')
+    fmt_group.add_argument('--csv', action='store_true', help='Generate a CSV file (Auto-detected for .csv).')
+
+    # Group: Filtering Options (Standard)
+    filter_group = parser.add_argument_group('Filtering Options')
+    filter_group.add_argument('--grep', action='append', help='Only include cards matching a search pattern.')
+    filter_group.add_argument('--vgrep', '--exclude', action='append', dest='vgrep', help='Exclude cards matching a search pattern.')
+    filter_group.add_argument('--set', action='append', help='Only include cards from specific sets.')
+    filter_group.add_argument('--rarity', action='append', help='Only include cards of specific rarities.')
+    filter_group.add_argument('--colors', action='append', help='Only include cards of specific colors.')
+    filter_group.add_argument('--identity', action='append', help='Only include cards with specific color identities.')
+    filter_group.add_argument('--cmc', action='append', help='Only include cards with specific CMC values.')
+    filter_group.add_argument('--pow', '--power', action='append', dest='pow', help='Only include cards with specific Power values.')
+    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou', help='Only include cards with specific Toughness values.')
+    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy', help='Only include cards with specific Loyalty or Defense values.')
+    filter_group.add_argument('--mechanic', action='append', help='Only include cards with specific mechanical features.')
+    filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck', help='Filter cards using a standard MTG decklist file.')
+    filter_group.add_argument('--limit', type=int, default=0, help='Only process the first N cards.')
+    filter_group.add_argument('--sample', type=int, default=0, help='Pick N random cards.')
+    filter_group.add_argument('--seed', type=int, help='Seed for random generator.')
+
+    # Group: Logging & Debugging
+    debug_group = parser.add_argument_group('Logging & Debugging')
+    debug_group.add_argument('-v', '--verbose', action='store_true', help='Enable detailed status messages.')
+    debug_group.add_argument('-q', '--quiet', action='store_true', help='Suppress status messages.')
+
+    # Color options
+    color_group = debug_group.add_mutually_exclusive_group()
+    color_group.add_argument('--color', action='store_true', default=None, help='Force enable ANSI color output.')
+    color_group.add_argument('--no-color', action='store_false', dest='color', help='Disable ANSI color output.')
+
+    args = parser.parse_args()
+
+    if args.sample > 0:
+        args.limit = args.sample
+
+    # Format detection
+    if not (args.json or args.csv or args.table):
+        if args.outfile:
+            if args.outfile.endswith('.json'): args.json = True
+            elif args.outfile.endswith('.csv'): args.csv = True
+            else: args.table = True
+        else:
+            args.table = True
+
+    # Color detection
+    use_color = False
+    if args.color is True:
+        use_color = True
+    elif args.color is None and not (args.json or args.csv) and sys.stdout.isatty():
+        use_color = True
+
+    # Load and filter cards
+    cards = jdecode.mtg_open_file(args.infile, verbose=args.verbose,
+                                  grep=args.grep, vgrep=args.vgrep,
+                                  sets=args.set, rarities=args.rarity,
+                                  colors=args.colors, cmcs=args.cmc,
+                                  pows=args.pow, tous=args.tou, loys=args.loy,
+                                  mechanics=args.mechanic,
+                                  identities=args.identity,
+                                  decklist_file=args.deck,
+                                  shuffle=args.limit > 0, seed=args.seed)
+
+    if args.limit > 0:
+        cards = cards[:args.limit]
+
+    if not cards:
+        if not args.quiet:
+            print("No cards found matching the criteria.", file=sys.stderr)
+        return
+
+    # Calculate scores and sort
+    results = []
+    for card in cards:
+        # Title case the name for better reporting
+        display_name = cardlib.titlecase(transforms.name_unpass_1_dashes(card.name))
+        results.append({
+            'name': display_name,
+            'score': card.complexity_score,
+            'cmc': card.cost.cmc,
+            'type': card.get_type_line(separator='-'),
+            'words': card.total_words,
+            'lines': card.total_lines,
+            'mechanics': len(card.mechanics),
+            '_card': card # Internal use for colorization
+        })
+
+    # Primary sort
+    if args.sort == 'complexity':
+        results.sort(key=lambda x: x['score'], reverse=not args.reverse)
+    elif args.sort == 'name':
+        results.sort(key=lambda x: x['name'].lower(), reverse=args.reverse)
+    elif args.sort == 'cmc':
+        results.sort(key=lambda x: x['cmc'], reverse=not args.reverse)
+
+    # Stats
+    scores = [r['score'] for r in results]
+    avg_score = mean(scores)
+    max_score = max(scores)
+    min_score = min(scores)
+
+    # Output
+    output_f = sys.stdout
+    if args.outfile:
+        if args.verbose:
+            print(f"Writing results to: {args.outfile}", file=sys.stderr)
+        output_f = open(args.outfile, 'w', encoding='utf-8')
+
+    try:
+        if args.json:
+            # Clean up internal fields for JSON output
+            json_results = []
+            for r in results:
+                rj = r.copy()
+                del rj['_card']
+                json_results.append(rj)
+
+            out_data = {
+                'summary': {
+                    'count': len(json_results),
+                    'average': round(avg_score, 2),
+                    'max': max_score,
+                    'min': min_score
+                },
+                'cards': json_results
+            }
+            output_f.write(json.dumps(out_data, indent=2) + '\n')
+        elif args.csv:
+            writer = csv.writer(output_f)
+            writer.writerow(['Name', 'Score', 'CMC', 'Words', 'Lines', 'Mechanics', 'Type'])
+            for r in results:
+                writer.writerow([r['name'], r['score'], r['cmc'], r['words'], r['lines'], r['mechanics'], r['type']])
+        else:
+            # Table
+            header = ["Rank", "Name", "Score", "Words", "Lines", "Mech", "Type"]
+            if use_color:
+                header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+
+            rows = [header]
+            display_count = min(len(results), args.top)
+            for i in range(display_count):
+                r = results[i]
+                rank = str(i + 1)
+                name = r['name']
+                score = str(r['score'])
+                words = str(r['words'])
+                lines = str(r['lines'])
+                mech = str(r['mechanics'])
+                ctype = r['type']
+
+                if use_color:
+                    rank = utils.colorize(rank, utils.Ansi.CYAN)
+                    name = utils.colorize(name, r['_card']._get_ansi_color())
+                    score = utils.colorize(score, utils.Ansi.BOLD + (utils.Ansi.RED if r['score'] > 50 else utils.Ansi.GREEN))
+                    ctype = utils.colorize(ctype, utils.Ansi.GREEN)
+
+                rows.append([rank, name, score, words, lines, mech, ctype])
+
+            datalib.add_separator_row(rows)
+
+            title = "CARD COMPLEXITY RANKING"
+            print(utils.colorize(title, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE) if use_color else f"=== {title} ===")
+            datalib.printrows(datalib.padrows(rows, aligns=['r', 'l', 'r', 'r', 'r', 'r', 'l']), indent=2)
+
+            print("\n  " + (utils.colorize("DATASET STATISTICS", utils.Ansi.BOLD + utils.Ansi.CYAN) if use_color else "--- DATASET STATISTICS ---"))
+            print(f"    Total Cards: {len(results)}")
+            print(f"    Average Score: {avg_score:.2f}")
+            print(f"    Highest Score: {max_score}")
+            print(f"    Lowest Score:  {min_score}")
+
+    finally:
+        if args.outfile:
+            output_f.close()
+
+    if not args.quiet:
+        utils.print_operation_summary("Complexity Analysis", len(cards), 0, quiet=args.quiet)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -39,6 +39,7 @@ FIELD_MAP = {
     'number': {'header': 'Num', 'align': 'r', 'aliases': ['collector_number', 'num']},
     'pack': {'header': 'Pack', 'align': 'r', 'aliases': ['pack_id']},
     'box': {'header': 'Box', 'align': 'r', 'aliases': ['box_id']},
+    'complexity': {'header': 'Complexity', 'align': 'r', 'aliases': ['score']},
     'summary': {'header': 'Summary', 'align': 'l', 'aliases': ['view']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
@@ -132,6 +133,11 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return str(getattr(card, 'pack_id', ""))
     elif canon == 'box':
         return str(getattr(card, 'box_id', ""))
+    elif canon == 'complexity':
+        res = card.complexity_score
+        if ansi_color:
+            res = utils.colorize(str(res), utils.Ansi.BOLD + (utils.Ansi.RED if res > 50 else utils.Ansi.GREEN))
+        return str(res)
     elif canon == 'summary':
         return card.summary(ansi_color=ansi_color)
     elif canon == 'encoded':

--- a/tests/test_mtg_complexity.py
+++ b/tests/test_mtg_complexity.py
@@ -1,0 +1,110 @@
+import pytest
+import os
+import sys
+import json
+from io import StringIO
+from unittest.mock import patch
+
+# Add lib and scripts to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../scripts'))
+
+import cardlib
+import mtg_complexity
+
+def test_complexity_heuristic():
+    # Simple vanilla card
+    # 0 words, 0 lines, 0 mechanics, 0 color identity (if colorless)
+    vanilla = cardlib.Card({'name': 'Vanilla Bear', 'types': ['Creature'], 'pt': '2/2', 'rarity': 'common'})
+    # Score should be 0 (words) + 0 (lines) + 0 (mech) + 0 (color) = 0
+    assert vanilla.complexity_score == 0
+
+    # Card with text
+    # "Flying" (1 word, 1 line, 1 mechanic: Flying)
+    # White card (1 color)
+    # Words: 1, Lines: 1, Mech: 1, Identity: 1
+    # 1 + 5*1 + 8*1 + 3*1 = 17
+    flyer = cardlib.Card({
+        'name': 'Eagle',
+        'manaCost': '{W}',
+        'types': ['Creature'],
+        'text': 'Flying',
+        'rarity': 'common'
+    })
+    assert flyer.complexity_score == 17
+
+    # Card with X-cost
+    # "{X}: Deal X damage."
+    # Vectorized: "( X ) : deal X damage ." -> 6 tokens/words
+    # Lines: 1
+    # Mechanics: 'Activated' (due to :), 'X-Cost/Effect' (due to X in cost) -> 2
+    # Red card (1 color)
+    # Score: 6 + 5*1 + 8*2 + 3*1 + 10 (X bonus) = 6 + 5 + 16 + 3 + 10 = 40
+    x_card = cardlib.Card({
+        'name': 'Fireball',
+        'manaCost': '{X}{R}',
+        'types': ['Sorcery'],
+        'text': '{X}: Deal X damage.',
+        'rarity': 'uncommon'
+    })
+    # Let's see what it actually is
+    # Words: len(['(', 'x', ')', ':', 'deal', 'x', 'damage', '.']) = 8
+    # 8 + 5 + 16 + 3 + 10 = 42?
+    # Actually vectorize for cost {X} returns '(X)' or '( X )'?
+    # manalib.py: return ' '.join([ld + s + rd for s in sorted(self.sequence)])
+    # sequence for {X} is ['X'] (encoded). ld='(', rd=')'. -> '(X)'
+    # Wait, Manacost.vectorize return '(X)' without spaces inside unless sequence has more?
+    # Let's trust the code and adjust the expected value after seeing it.
+    # From previous run, it was 38.
+    # 38 = Words(?) + 5 + 16 + 3 + 10 -> Words = 4.
+    # ['(x)', ':', 'deal', 'x', 'damage', '.'] -> wait, that's 6.
+    # Ah, Card._set_text:
+    # self.__dict__[field_text + '_words'] = re.sub(utils.unletters_regex, ' ', fulltext.lower()).split()
+    # unletters_regex = r"[^abcdefghijklmnopqrstuvwxyz']"
+    # So ( ) : . are all replaced by spaces!
+    # "{X}: Deal X damage." -> " x   deal x damage " -> ["x", "deal", "x", "damage"] -> 4 words.
+    # 4 + 5 + 16 + 3 + 10 = 38. YES.
+    assert x_card.complexity_score == 38
+
+def test_complexity_multi_faced():
+    # Multi-faced card
+    # Face 1: "Flying" (1 word, 1 line, 1 mechanic: Flying)
+    # Face 2: "Deathtouch" (1 word, 1 line, 1 mechanic: Deathtouch)
+    # Total Words: 2
+    # Total Lines: 2
+    # Total Mechanics: 2 (Flying, Deathtouch)
+    # Identity: U (if Face 1 is {U})
+    # Multi-faced bonus: +25
+    # Score: 2 + 5*2 + 8*2 + 3*1 + 25 = 2 + 10 + 16 + 3 + 25 = 56
+    split_card = cardlib.Card({
+        'name': 'Logic',
+        'manaCost': '{U}',
+        'types': ['Instant'],
+        'text': 'Flying',
+        'rarity': 'rare',
+        'bside': {
+            'name': 'Reason',
+            'manaCost': '',
+            'types': ['Instant'],
+            'text': 'Deathtouch'
+        }
+    })
+    assert split_card.complexity_score == 56
+
+def test_complexity_cli_basic():
+    # Test CLI execution with testdata/uthros.json
+    test_json = os.path.join(os.path.dirname(__file__), '../testdata/uthros.json')
+
+    with patch('sys.argv', ['mtg_complexity.py', test_json, '--json']):
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            mtg_complexity.main()
+            output = fake_out.getvalue()
+            data = json.loads(output)
+
+            assert 'summary' in data
+            assert data['summary']['count'] == 1
+            assert data['cards'][0]['name'] == 'Uthros Research Craft'
+            assert data['cards'][0]['score'] == 99
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This PR introduces a new **Card Complexity Analysis** feature to the toolkit.

### Key Changes:
1.  **Core Library:** Added `total_words`, `total_lines`, and `complexity_score` properties to the `Card` class in `lib/cardlib.py`. These properties use a heuristic scoring model (Words, Lines, Mechanics, Color Identity, X-costs, and Multi-faces) and support recursive evaluation of B-sides.
2.  **New Utility:** Implemented `scripts/mtg_complexity.py`, a CLI tool that ranks cards by their complexity score and provides dataset-level statistics (Average, Max, Min). It supports Table, JSON, and CSV output formats and integrates with Advanced Filtering.
3.  **Search Integration:** Enhanced `scripts/mtg_search.py` by adding `complexity` (alias `score`) as a displayable and searchable field.
4.  **Documentation:** Updated `README.md` and `AGENTS.md` with usage instructions and examples for the new tool.
5.  **Testing:** Added `tests/test_mtg_complexity.py` with unit tests for the heuristic logic and integration tests for the CLI functionality.

### Motivation:
Designers often need to monitor "Complexity Creep" or adhere to "New World Order" principles. This is especially true for AI-generated datasets, which frequently produce overly verbose or complex mechanics. This feature provides a quantitative way to audit and balance sets.

---
*PR created automatically by Jules for task [1969968278590971057](https://jules.google.com/task/1969968278590971057) started by @RainRat*