### PR TITLE
Fix ZeroDivisionError in mtg_archetypes.py when using --min-cards 0

### DIFF
--- a/scripts/mtg_archetypes.py
+++ b/scripts/mtg_archetypes.py
@@ -124,7 +124,7 @@ Usage Examples:
             pass
 
     # Filter out empty archetypes or those with too few cards
-    active_pairs = [p for p in pairs if len(archetypes[p]) >= args.min_cards]
+    active_pairs = [p for p in pairs if len(archetypes[p]) >= max(1, args.min_cards)]
 
     if not active_pairs:
         if not args.quiet:


### PR DESCRIPTION
* **What:** Updated the `active_pairs` filtering logic in `scripts/mtg_archetypes.py` to ensure that even when `--min-cards 0` is specified, only color pairs containing at least one card are profiled.
* **Why:** This prevents multiple `ZeroDivisionError` crashes when calculating average CMC, creature percentages, and mechanical distinctiveness for empty archetypes. The external behavior remains identical for non-empty archetypes, and it correctly handles the edge case of empty datasets or highly specific filters.

---
*PR created automatically by Jules for task [1401107441606124553](https://jules.google.com/task/1401107441606124553) started by @RainRat*