### PR TITLE
[DOCS] Improve CLI help formatting in mtg_archetypes.py

### DIFF
--- a/scripts/mtg_archetypes.py
+++ b/scripts/mtg_archetypes.py
@@ -29,7 +29,8 @@ Usage Examples:
 
   # Compare mechanics of a generated dataset against archetypes
   python3 scripts/mtg_archetypes.py generated_cards.txt
-'''
+''',
+        formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
     # Group: Input / Output


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Updated the `argparse` configuration in `scripts/mtg_archetypes.py`.
* **Why:** Prevents multiline epilog text (like usage examples) from collapsing into a single paragraph in the terminal, making it easier to read.

---
*PR created automatically by Jules for task [11557862092038869380](https://jules.google.com/task/11557862092038869380) started by @RainRat*