### PR TITLE
[UI/UX] Standardize report header and feedback in mtg_functional.py

### DIFF
--- a/scripts/mtg_functional.py
+++ b/scripts/mtg_functional.py
@@ -193,10 +193,7 @@ Usage Examples:
                     print("No functional reprints found.", file=sys.stderr)
                 return
 
-            header_text = 'FUNCTIONAL REPRINT GROUPS'
-            if use_color:
-                header_text = utils.colorize(header_text, utils.Ansi.BOLD + utils.Ansi.CYAN + utils.Ansi.UNDERLINE)
-            output_f.write(header_text + '\n')
+            utils.print_header("FUNCTIONAL REPRINT GROUPS", count=len(reprint_groups), file=output_f, use_color=use_color)
 
             rows = []
             header = ["Names", "Cost", "Type", "Stats"]
@@ -230,10 +227,8 @@ Usage Examples:
             output_f.close()
 
     if not args.quiet:
-        summary = f"\nFound {len(reprint_groups)} groups of functional reprints ({len(cards)} total cards processed)."
-        if use_color:
-            summary = utils.colorize(summary, utils.Ansi.BOLD + utils.Ansi.GREEN)
-        print(summary, file=sys.stderr)
+        utils.print_operation_summary("Functional check", len(reprint_groups), 0)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_mtg_functional.py
+++ b/tests/test_mtg_functional.py
@@ -1,0 +1,89 @@
+import subprocess
+import json
+import csv
+import io
+import os
+import pytest
+
+def test_functional_basic(tmp_path):
+    """Test basic functional reprint detection."""
+    d = tmp_path / "subdir"
+    d.mkdir()
+    test_file = d / "test_functional.json"
+
+    with open(test_file, "w") as f:
+        json.dump([
+            {
+                "name": "Card A",
+                "manaCost": "{1}{W}",
+                "types": ["Creature"],
+                "subtypes": ["Human"],
+                "power": "2",
+                "toughness": "2",
+                "text": "First strike",
+                "rarity": "Common"
+            },
+            {
+                "name": "Card B",
+                "manaCost": "{1}{W}",
+                "types": ["Creature"],
+                "subtypes": ["Human"],
+                "power": "2",
+                "toughness": "2",
+                "text": "First strike",
+                "rarity": "Common"
+            }
+        ], f)
+
+    cmd = ["python3", "scripts/mtg_functional.py", str(test_file), "--no-color"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "FUNCTIONAL REPRINT GROUPS (1 match)" in result.stdout
+    assert "Card A, Card B" in result.stdout
+    # Standardized summary in stderr
+    assert "Functional check complete" in result.stderr
+
+def test_functional_no_match(tmp_path):
+    """Test output when no functional reprints are found."""
+    test_file = tmp_path / "test_no_functional.json"
+    with open(test_file, "w") as f:
+        json.dump([
+            {
+                "name": "Card A",
+                "manaCost": "{1}{W}",
+                "types": ["Creature"],
+                "subtypes": ["Human"],
+                "power": "2",
+                "toughness": "2",
+                "text": "First strike",
+                "rarity": "Common"
+            },
+            {
+                "name": "Card C",
+                "manaCost": "{U}",
+                "types": ["Instant"],
+                "text": "Draw a card.",
+                "rarity": "Common"
+            }
+        ], f)
+
+    cmd = ["python3", "scripts/mtg_functional.py", str(test_file), "--no-color"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert "No functional reprints found." in result.stderr
+
+def test_functional_json_output(tmp_path):
+    """Test JSON output format."""
+    test_file = tmp_path / "test_functional_json.json"
+    with open(test_file, "w") as f:
+        json.dump([
+            {"name": "A", "manaCost": "{W}", "types": ["Creature"], "power": "1", "toughness": "1"},
+            {"name": "B", "manaCost": "{W}", "types": ["Creature"], "power": "1", "toughness": "1"}
+        ], f)
+
+    cmd = ["python3", "scripts/mtg_functional.py", str(test_file), "--json"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert len(data) == 1
+    assert "A" in data[0]['names']
+    assert "B" in data[0]['names']


### PR DESCRIPTION
**PR Title:** [UI/UX] Standardize report header and feedback in mtg_functional.py 
 
**Description:** 
* **Context:** CLI 
* **Problem:** The `mtg_functional.py` script used a manual, non-standard implementation for its report header and outputted a redundant summary to stderr that overlapped with information in the table header. This created visual noise and lacked consistency with other tools in the toolkit.
* **Solution:** Standardized the report header by using the centralized `utils.print_header` function, which includes the match count and follows the "Invisible Design" visual guidelines (indented, Bold Cyan). Consistently with other tools like `mtg_search.py`, the detailed summary was replaced with a standard `utils.print_operation_summary` call on stderr to provide high-level processing feedback without cluttering the main report.
 
**Changes:** 
- Modified `scripts/mtg_functional.py` to use `utils.print_header` and `utils.print_operation_summary`.
- Added `tests/test_mtg_functional.py` to ensure correctness and prevent regressions.

---
*PR created automatically by Jules for task [357155632412366475](https://jules.google.com/task/357155632412366475) started by @RainRat*