### PR TITLE
[FEAT] Mechanical Similarity Discovery in mtg_oracle.py

### DIFF
--- a/lib/namediff.py
+++ b/lib/namediff.py
@@ -35,25 +35,29 @@ def list_flatten(l):
 
 
 # isolated logic for multiprocessing
-def f_nearest(name, matchers, n):
-    if not matchers:
+def f_nearest(source, matchers_with_labels, n, exact_shortcut=False):
+    if not matchers_with_labels:
         return []
     ratios = []
-    for m in matchers:
-        m.set_seq1(name)
-        ratios.append((m.ratio(), m.b))
+    for label, m in matchers_with_labels:
+        m.set_seq1(source)
+        ratios.append((m.ratio(), label))
     ratios.sort(reverse=True)
-    return ratios[:1] if ratios[0][0] >= 1 else ratios[:n]
+    if exact_shortcut and ratios[0][0] >= 1.0:
+        return ratios[:1]
+    return ratios[:n]
 
 def f_nearest_per_thread(workitem):
-    (worknames, names, n) = workitem
-    # each thread (well, process) needs to generate its own matchers
-    matchers = [difflib.SequenceMatcher(b=name, autojunk=False) for name in names]
-    return [f_nearest(name, matchers, n) for name in worknames]
+    (work_sources, target_items, n, exact_shortcut) = workitem
+    # target_items is [(label, string), ...]
+    matchers_with_labels = [(label, difflib.SequenceMatcher(b=string, autojunk=False))
+                            for label, string in target_items]
+    return [f_nearest(src, matchers_with_labels, n, exact_shortcut) for src in work_sources]
 
 class Namediff:
     def __init__(self, verbose = True,
-                 json_fname = os.path.join(datadir, 'AllSets.json')):
+                 json_fname = os.path.join(datadir, 'AllSets.json'),
+                 cards = None):
         self.verbose = verbose
         self.names = {}
         self.codes = {}
@@ -62,63 +66,90 @@ class Namediff:
         if self.verbose:
             print('Setting up namediff...')
 
-        if self.verbose:
-            print('  Reading names from: ' + json_fname)
-        json_srcs, _ = jdecode.mtg_open_json(json_fname, verbose)
-        namecount = 0
+        if cards:
+            if self.verbose:
+                print('  Initializing from provided card list.')
 
-        def process_card(card, jcard):
-            nonlocal namecount
-            name = card.name
-            if name in self.names:
-                if self.verbose:
-                    print('  Duplicate name ' + name + ', ignoring.')
-            else:
-                self.names[name] = jcard['name']
-                self.cardstrings[name] = card.encode()
-                jcode = jcard.get(utils.json_field_info_code)
-                jnum = jcard.get('number', '')
-                if jcode and jnum:
-                    self.codes[name] = jcode + '/' + jnum + '.jpg'
+            def process_card_obj(card):
+                name = card.name
+                if name not in self.names:
+                    self.names[name] = cardlib.titlecase(cardlib.transforms.name_unpass_1_dashes(name))
+                    self.cardstrings[name] = card.encode()
+                    jcode = getattr(card, 'set_code', '')
+                    jnum = getattr(card, 'number', '')
+                    if jcode and jnum:
+                        self.codes[name] = str(jcode) + '/' + str(jnum) + '.jpg'
+                    else:
+                        self.codes[name] = ''
+
+                if card.bside:
+                    process_card_obj(card.bside)
+
+            for card in cards:
+                process_card_obj(card)
+
+            namecount = len(self.names)
+
+        else:
+            if self.verbose:
+                print('  Reading names from: ' + json_fname)
+            json_srcs, _ = jdecode.mtg_open_json(json_fname, verbose)
+            namecount = 0
+
+            def process_card(card, jcard):
+                nonlocal namecount
+                name = card.name
+                if name in self.names:
+                    if self.verbose:
+                        print('  Duplicate name ' + name + ', ignoring.')
                 else:
-                    self.codes[name] = ''
-                namecount += 1
+                    self.names[name] = jcard['name']
+                    self.cardstrings[name] = card.encode()
+                    jcode = jcard.get(utils.json_field_info_code)
+                    jnum = jcard.get('number', '')
+                    if jcode and jnum:
+                        self.codes[name] = jcode + '/' + jnum + '.jpg'
+                    else:
+                        self.codes[name] = ''
+                    namecount += 1
 
-            if card.bside:
-                # For bsides in MTGJSON, they are often nested.
-                # card.bside is a Card object.
-                # We need the jcard for the bside too.
-                jbside = jcard.get(utils.json_field_bside)
-                if jbside:
-                    process_card(card.bside, jbside)
+                if card.bside:
+                    # For bsides in MTGJSON, they are often nested.
+                    # card.bside is a Card object.
+                    # We need the jcard for the bside too.
+                    jbside = jcard.get(utils.json_field_bside)
+                    if jbside:
+                        process_card(card.bside, jbside)
 
-        for json_cardname in sorted(json_srcs.keys()):
-            if len(json_srcs[json_cardname]) > 0:
-                jcards = json_srcs[json_cardname]
-                # just use the first one
-                idx = 0
-                card = cardlib.Card(jcards[idx])
-                process_card(card, jcards[idx])
+            for json_cardname in sorted(json_srcs.keys()):
+                if len(json_srcs[json_cardname]) > 0:
+                    jcards = json_srcs[json_cardname]
+                    # just use the first one
+                    idx = 0
+                    card = cardlib.Card(jcards[idx])
+                    process_card(card, jcards[idx])
 
         if self.verbose:
             print('  Read ' + str(namecount) + ' unique cardnames')
             print('  Building SequenceMatcher objects.')
 
-        self.matchers = [difflib.SequenceMatcher(
-            b=n, autojunk=False) for n in self.names]
-        self.card_matchers = [difflib.SequenceMatcher(
-            b=self.cardstrings[n], autojunk=False) for n in self.cardstrings]
+        self.matchers = [(n, difflib.SequenceMatcher(
+            b=n, autojunk=False)) for n in self.names]
+        self.card_matchers = [(n, difflib.SequenceMatcher(
+            b=self.cardstrings[n], autojunk=False)) for n in self.cardstrings]
 
         if self.verbose:
             print('... Done.')
     
     def nearest(self, name, n=3):
-        return f_nearest(name, self.matchers, n)
+        return f_nearest(name, self.matchers, n, exact_shortcut=True)
 
     def nearest_par(self, names, n=3, threads=cores, quiet=False):
         with multiprocessing.Pool(threads) as workpool:
             proto_worklist = list_split(names, threads)
-            worklist = [(x, self.names, n) for x in proto_worklist]
+            # Pass (label, string) pairs for matcher construction in thread
+            target_items = [(n, n) for n in self.names]
+            worklist = [(x, target_items, n, True) for x in proto_worklist]
 
             try:
                 from tqdm import tqdm
@@ -134,12 +165,24 @@ class Namediff:
         return list_flatten(donelist)
 
     def nearest_card(self, card, n=5):
-        return f_nearest(card.encode(), self.card_matchers, n)
+        return f_nearest(card.encode(), self.card_matchers, n, exact_shortcut=False)
 
-    def nearest_card_par(self, cards, n=5, threads=cores):
+    def nearest_card_par(self, cards, n=5, threads=cores, quiet=False):
         with multiprocessing.Pool(threads) as workpool:
             proto_worklist = list_split(cards, threads)
-            worklist = [([c.encode() for c in x], list(
-                self.cardstrings.values()), n) for x in proto_worklist]
-            donelist = workpool.map(f_nearest_per_thread, worklist)
+            # Pass (label, string) pairs for card strings
+            target_items = [(n, self.cardstrings[n]) for n in self.cardstrings]
+            worklist = [([c.encode() for c in x], target_items, n, False) for x in proto_worklist]
+
+            try:
+                from tqdm import tqdm
+                iterator = tqdm(workpool.imap(f_nearest_per_thread, worklist),
+                              total=len(worklist),
+                              disable=quiet,
+                              desc="Matching cards",
+                              unit="chunk")
+            except ImportError:
+                iterator = workpool.imap(f_nearest_per_thread, worklist)
+
+            donelist = list(iterator)
         return list_flatten(donelist)

--- a/scripts/mtg_oracle.py
+++ b/scripts/mtg_oracle.py
@@ -4,6 +4,7 @@ import os
 import argparse
 import difflib
 import re
+import random
 
 # Add lib directory to path
 libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
@@ -12,6 +13,7 @@ sys.path.append(libdir)
 import utils
 import jdecode
 import cardlib
+import namediff
 
 def main():
     parser = argparse.ArgumentParser(
@@ -25,6 +27,9 @@ Example Usage:
 
   # Find all rares in a set matching a keyword
   python3 scripts/mtg_oracle.py data/AllPrintings.json --set MOM --rarity rare --grep "Battle"
+
+  # Find cards mechanically similar to a specific card
+  python3 scripts/mtg_oracle.py data/AllPrintings.json "Giant Growth" --similar
 
   # Use fuzzy matching for misspelled names
   python3 scripts/mtg_oracle.py data/AllPrintings.json "Grizly Beers"
@@ -46,6 +51,8 @@ Example Usage:
                         help="Input file does not have field labels (like '|cost|' or '|text|').")
     enc_group.add_argument('--nolinetrans', action='store_true',
                         help='Input file does not use automatic line reordering.')
+    enc_group.add_argument('--similar', action='store_true',
+                        help='Find and display cards mechanically similar to the results.')
 
     # Group: Filtering Options (Standard across tools)
     filter_group = parser.add_argument_group('Filtering Options')
@@ -192,6 +199,17 @@ Example Usage:
     if not args.quiet:
         utils.print_header("SEARCH RESULTS", count=total_matches, use_color=use_color)
 
+    nd = None
+    if args.similar:
+        # Load full dataset for similarity context
+        if args.verbose and not args.quiet:
+            print("Loading similarity context...", file=sys.stderr)
+
+        full_cards = jdecode.mtg_open_file(args.infile, verbose=False,
+                                          linetrans=not args.nolinetrans,
+                                          fmt_labeled=None if args.nolabel else cardlib.fmt_labeled_default)
+        nd = namediff.Namediff(verbose=args.verbose and not args.quiet, cards=full_cards)
+
     # Display the cards
     for i, card in enumerate(display_cards):
         if i > 0:
@@ -200,6 +218,31 @@ Example Usage:
         formatted_card = card.format(gatherer=args.gatherer, ansi_color=use_color)
         indented_card = "\n".join(["  " + line for line in formatted_card.split("\n")])
         print(indented_card)
+
+        if nd:
+            print()
+            sim_header = "  SIMILAR CARDS (Mechanical Similarity)"
+            if use_color:
+                sim_header = utils.colorize(sim_header, utils.Ansi.BOLD + utils.Ansi.CYAN)
+            print(sim_header)
+            print("  " + "-" * 40)
+
+            # nearest_card returns (ratio, name)
+            # card.name is the internal lowercase name
+            results = nd.nearest_card(card, n=6)
+            # Filter out the card itself
+            similar = [r for r in results if r[1] != card.name][:5]
+
+            if similar:
+                for ratio, name in similar:
+                    # name in nd.names is already titlecased
+                    display_name = nd.names.get(name, cardlib.titlecase(name))
+                    ratio_str = f"{ratio*100:3.0f}%"
+                    if use_color:
+                        ratio_str = utils.colorize(ratio_str, utils.Ansi.GREEN)
+                    print(f"    {ratio_str}  {display_name}")
+            else:
+                print("    No similar cards found.")
 
     if not args.quiet:
         utils.print_operation_summary("Search", total_matches, 0)

--- a/tests/test_namediff.py
+++ b/tests/test_namediff.py
@@ -45,9 +45,9 @@ class TestNamediff(unittest.TestCase):
     def test_f_nearest_per_thread(self):
         """Test the worker function for parallel processing."""
         worknames = ["apple", "banana"]
-        candidates = ["apple", "apricot", "banana", "bandana"]
-        # workitem tuple structure: (worknames, names, n)
-        workitem = (worknames, candidates, 1)
+        candidates = [("apple", "apple"), ("apricot", "apricot"), ("banana", "banana"), ("bandana", "bandana")]
+        # workitem tuple structure: (work_sources, target_items, n, exact_shortcut)
+        workitem = (worknames, candidates, 1, True)
 
         results = namediff.f_nearest_per_thread(workitem)
 
@@ -69,16 +69,21 @@ class TestNamediff(unittest.TestCase):
 
     def test_f_nearest(self):
         name = "Dragon"
-        candidates = ["Dragon", "Drogon", "Wagon", "Apple"]
-        matchers = [difflib.SequenceMatcher(b=c, autojunk=False) for c in candidates]
+        candidates = [("Dragon", "Dragon"), ("Drogon", "Drogon"), ("Wagon", "Wagon"), ("Apple", "Apple")]
+        matchers = [(label, difflib.SequenceMatcher(b=c, autojunk=False)) for label, c in candidates]
 
-        result = namediff.f_nearest(name, matchers, n=3)
+        # Test with exact shortcut
+        result = namediff.f_nearest(name, matchers, n=3, exact_shortcut=True)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][1], "Dragon")
         self.assertEqual(result[0][0], 1.0)
 
+        # Test without exact shortcut
+        result = namediff.f_nearest(name, matchers, n=3, exact_shortcut=False)
+        self.assertEqual(len(result), 3)
+
         name = "Drago"
-        result = namediff.f_nearest(name, matchers, n=2)
+        result = namediff.f_nearest(name, matchers, n=2, exact_shortcut=True)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0][1], "Dragon")
 


### PR DESCRIPTION
This PR introduces a new "Mechanical Similarity Discovery" feature to the `mtg_oracle.py` tool, allowing users to find cards with similar rules text and stats.

### What:
- **`lib/namediff.py`**: Refactored the `Namediff` class to support initialization from a list of `Card` objects and updated the similarity logic to return a configurable number of results even when exact matches are found.
- **`scripts/mtg_oracle.py`**: Added a new `--similar` flag. When enabled, the tool loads the full dataset context and identifies the 5 most mechanically similar cards for each result in the user's search.
- **`tests/test_namediff.py`**: Updated existing tests to reflect the new similarity engine signatures and behavior.

### Why:
Users often want to find functional alternatives or mechanically related cards when looking up an oracle entry. By integrating the existing mechanical similarity engine directly into the oracle lookup tool, we enable immediate discovery of related designs without requiring separate complex workflows.

### Usage:
```bash
# Find cards similar to Grizzly Bears
python3 scripts/mtg_oracle.py data/AllPrintings.json "Grizzly Bears" --similar
```

---
*PR created automatically by Jules for task [3440517260779768660](https://jules.google.com/task/3440517260779768660) started by @RainRat*