### PR TITLE
Refactor: Inline premature abstractions in lib/utils.py

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -349,26 +349,20 @@ def mana_sym_to_forum(sym):
         return mana_json_open_delimiter + sym + mana_json_close_delimiter
 
 # forward symbol tables for encoding
-def _build_sym_map(symbols, transform_func):
-    return {sym: transform_func(sym) for sym in symbols}
-
-mana_syms_encode = _build_sym_map(mana_syms, mana_sym_to_encoding)
-mana_symalt_encode = _build_sym_map(mana_symalt, mana_sym_to_encoding)
-mana_symall_encode = _build_sym_map(mana_symall, mana_sym_to_encoding)
-mana_syms_jencode = _build_sym_map(mana_syms, mana_sym_to_json)
-mana_symalt_jencode = _build_sym_map(mana_symalt, mana_sym_to_json)
-mana_symall_jencode = _build_sym_map(mana_symall, mana_sym_to_json)
+mana_syms_encode = {sym: mana_sym_to_encoding(sym) for sym in mana_syms}
+mana_symalt_encode = {sym: mana_sym_to_encoding(sym) for sym in mana_symalt}
+mana_symall_encode = {sym: mana_sym_to_encoding(sym) for sym in mana_symall}
+mana_syms_jencode = {sym: mana_sym_to_json(sym) for sym in mana_syms}
+mana_symalt_jencode = {sym: mana_sym_to_json(sym) for sym in mana_symalt}
+mana_symall_jencode = {sym: mana_sym_to_json(sym) for sym in mana_symall}
 
 # reverse symbol tables for decoding
-def _build_reverse_sym_map(symbols, transform_func):
-    return {transform_func(sym): sym for sym in symbols}
-
-mana_syms_decode = _build_reverse_sym_map(mana_syms, mana_sym_to_encoding)
-mana_symalt_decode = _build_reverse_sym_map(mana_symalt, mana_sym_to_encoding)
-mana_symall_decode = _build_reverse_sym_map(mana_symall, mana_sym_to_encoding)
-mana_syms_jdecode = _build_reverse_sym_map(mana_syms, mana_sym_to_json)
-mana_symalt_jdecode = _build_reverse_sym_map(mana_symalt, mana_sym_to_json)
-mana_symall_jdecode = _build_reverse_sym_map(mana_symall, mana_sym_to_json)
+mana_syms_decode = {mana_sym_to_encoding(sym): sym for sym in mana_syms}
+mana_symalt_decode = {mana_sym_to_encoding(sym): sym for sym in mana_symalt}
+mana_symall_decode = {mana_sym_to_encoding(sym): sym for sym in mana_symall}
+mana_syms_jdecode = {mana_sym_to_json(sym): sym for sym in mana_syms}
+mana_symalt_jdecode = {mana_sym_to_json(sym): sym for sym in mana_symalt}
+mana_symall_jdecode = {mana_sym_to_json(sym): sym for sym in mana_symall}
 
 # going straight from json to encoding and vice versa
 def mana_encode_direct(jsym):


### PR DESCRIPTION
### Refactor: Inline premature abstractions in lib/utils.py

**What:**
Inlined the `_build_sym_map` and `_build_reverse_sym_map` functions in `lib/utils.py` by replacing their 12 call sites with equivalent dictionary comprehensions and removing the function definitions.

**Why:**
These helper functions were "Premature Abstractions" that simply wrapped standard Python dictionary comprehension syntax. Inlining them reduces the cognitive load for developers and makes the symbol mapping logic more explicit and idiomatic. 

**Verification:**
Successfully ran the full test suite (`python3 -m pytest`), with all 696 tests passing. Specifically, `tests/test_utils.py` (39 tests) confirmed that mana symbol encoding and decoding logic remains intact.

---
*PR created automatically by Jules for task [6881632639451589746](https://jules.google.com/task/6881632639451589746) started by @RainRat*