### PR TITLE
[DOCS] Improve mtg_search CLI help text and field documentation

### DIFF
--- a/scripts/mtg_search.py
+++ b/scripts/mtg_search.py
@@ -161,19 +161,19 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Search card data and extract specific fields. It works with all supported formats (JSON, CSV, XML, or encoded text).",
+        description="Search card data and extract specific fields. It supports various input formats (JSON, JSONL, CSV, XML, MSE, ZIP, and Decklist) and can process entire directories.",
         epilog='''
 Available Fields (aliases in parentheses):
   Basic Metadata:
-    name, cost (mana, mana_cost), cmc (mv, mana_value), rarity, set (code), number (num)
+    name, cost (mana, mana_cost, manacost), cmc (mv, mana_value), rarity, set (code), number (num, collector_number)
   Types & Text:
     type (typeline), text (rules, oracle), mechanics (keywords), supertypes, types, subtypes
   Stats:
-    stats (Smart field: P/T, Loyalty, or Defense), pt (pow_tou), power (pow), toughness (tou), loyalty (def, defense)
+    stats (Smart field: P/T, Loyalty, or Defense), pt (pow_tou), power (pow), toughness (tou), loyalty (def, defense, loy)
   Color Info:
     colors, identity (ci, color_identity), id_count (identity_count)
-  Simulation & Encoding:
-    pack, box, encoded
+  Display & Simulation:
+    summary (view), complexity (score), pack, box, encoded
 
 Usage Examples:
   # List names and costs of all Goblins in a table


### PR DESCRIPTION
This PR improves the internal help text for the `mtg_search.py` CLI utility. 

**Changes:**
*   **Description:** Updated to list all supported input formats (JSON, JSONL, CSV, XML, MSE, ZIP, and Decklist) and explicitly mention directory processing support.
*   **Field Aliases:** Added verified aliases `manacost` (for `cost`), `collector_number` (for `number`), and `loy` (for `loyalty`) to the `epilog`.
*   **Missing Fields:** Documented the `summary` (alias `view`) and `complexity` (alias `score`) fields in the `epilog`.
*   **Organization:** Reorganized the field documentation into logical categories, adding a new 'Display & Simulation' section.

**Why:**
The previous help text did not accurately represent the tool's full capabilities, making it harder for users to discover advanced features like MSE support or design complexity analysis. These updates ensure the documentation matches the actual code behavior ("Truth First") and follows "Plain English" standards.

**Verification:**
*   Manually verified the output of `python3 scripts/mtg_search.py --help`.
*   Ran the full test suite (`pytest`) to ensure no regressions. All 696 tests passed.

---
*PR created automatically by Jules for task [2426256874598391990](https://jules.google.com/task/2426256874598391990) started by @RainRat*