### PR TITLE
Remove duplicate entry in Manatext.vectorize special_chars list

### DIFF
--- a/lib/manalib.py
+++ b/lib/manalib.py
@@ -196,7 +196,6 @@ class Manatext:
                          #utils.x_marker,
                          utils.tap_marker,
                          utils.untap_marker,
-                         utils.newline,
                          ';', ':', '"', ',', '.']
         for char in special_chars:
             text = text.replace(char, ' ' + char + ' ')


### PR DESCRIPTION
* **What:** Removed a redundant occurrence of `utils.newline` from the `special_chars` list in the `Manatext.vectorize` method within `lib/manalib.py`.
* **Why:** This eliminates a redundant string replacement operation during card vectorization. The change is strictly non-breaking as the behavior of the method remains identical while reducing logical duplication.

---
*PR created automatically by Jules for task [5644805969582356485](https://jules.google.com/task/5644805969582356485) started by @RainRat*