### PR TITLE
Simplify redundant rarity color logic in Ansi.get_rarity_color

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -652,8 +652,6 @@ class Ansi:
             return Ansi.BOLD + Ansi.RED
         if r_lower == 'special' or rarity == rarity_special_marker:
             return Ansi.BOLD + Ansi.MAGENTA
-        if r_lower == 'basic land' or rarity == rarity_basic_land_marker:
-            return Ansi.BOLD
         return Ansi.BOLD
 
     @staticmethod


### PR DESCRIPTION
* **What:** Removed a redundant check for 'basic land' in the `Ansi.get_rarity_color` method that returned the same value as the default fallback.
* **Why:** This improves readability and simplifies the logic. The external behavior remains identical as 'basic land' and unknown rarities still correctly default to `Ansi.BOLD`.

---
*PR created automatically by Jules for task [5658602703346267351](https://jules.google.com/task/5658602703346267351) started by @RainRat*