### PR TITLE
[UI/UX] Refine card display aesthetics and metadata hierarchy

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1380,7 +1380,7 @@ class Card:
         if self.bside:
             outstr += linebreak
             if not for_html and not for_forum and not for_md:
-                divider = "~~~~ (B-Side) " + "~" * 21
+                divider = "\u2014\u2014\u2014\u2014 (B-Side) " + "\u2014" * 21
                 if ansi_color:
                     divider = utils.colorize(divider, utils.Ansi.BOLD + utils.Ansi.CYAN)
                 outstr += divider + linebreak

--- a/scripts/mtg_oracle.py
+++ b/scripts/mtg_oracle.py
@@ -259,7 +259,7 @@ Example Usage:
     # Display the cards
     for i, card in enumerate(display_cards):
         if i > 0:
-            print("\n  " + "=" * 40 + "\n")
+            print("\n  " + "-" * 40 + "\n")
 
         formatted_card = card.format(gatherer=args.gatherer, ansi_color=use_color)
         indented_card = "\n".join(["  " + line for line in formatted_card.split("\n")])
@@ -290,7 +290,7 @@ Example Usage:
             score_val = utils.colorize(score_val, utils.Ansi.BOLD + utils.Ansi.MAGENTA)
         metadata_parts.append(f"{score_label} {score_val}")
 
-        footer = "  [ " + " | ".join(metadata_parts) + " ]"
+        footer = "  " + " \u2022 ".join(metadata_parts)
         print("\n" + footer)
 
         # Scryfall URL


### PR DESCRIPTION
Refined the visual output of card details in the CLI to improve readability and aesthetic polish. 

Key improvements:
1. Standardized B-Side dividers for multi-faced cards using em-dashes instead of tildes.
2. Reduced visual noise between search results by using a subtler single-line separator.
3. Modernized the metadata footer by removing heavy brackets/pipes and utilizing bullet separators, providing a cleaner look that emphasizes the data over the decoration.

---
*PR created automatically by Jules for task [7117196044450521835](https://jules.google.com/task/7117196044450521835) started by @RainRat*