### PR TITLE
Simplify rarity handling logic in lib/cardlib.py

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -302,12 +302,9 @@ def fields_from_json(src_json, linetrans = True):
         # Use lowercase for robust rarity lookup
         rarity_val = src_json['rarity']
         rarity_key = rarity_val.lower() if hasattr(rarity_val, 'lower') else rarity_val
-        if rarity_key in utils.json_rarity_map:
-            fields[field_rarity] = [(-1, utils.json_rarity_map[rarity_key])]
-        elif rarity_val in utils.json_rarity_unmap:
-            fields[field_rarity] = [(-1, rarity_val)]
-        else:
-            fields[field_rarity] = [(-1, rarity_val)]
+
+        fields[field_rarity] = [(-1, utils.json_rarity_map.get(rarity_key, rarity_val))]
+        if rarity_key not in utils.json_rarity_map and rarity_val not in utils.json_rarity_unmap:
             parsed = False
     else:
         parsed = False


### PR DESCRIPTION
This PR simplifies the rarity handling logic within the `fields_from_json` function in `lib/cardlib.py`. 

The original implementation had redundant logic where the same assignment `fields[field_rarity] = [(-1, rarity_val)]` was repeated across different conditional branches. I merged these into a single assignment using `utils.json_rarity_map.get(rarity_key, rarity_val)`. 

Additionally, the `parsed = False` flag is now set only if the rarity is not found in either the forward mapping or the reverse mapping, which is a cleaner representation of the original intent.

Verified with `tests/test_cardlib.py`, `tests/test_mtg_oracle.py`, and `tests/test_manalib.py` (34/34 tests passed).

---
*PR created automatically by Jules for task [14872185180625121739](https://jules.google.com/task/14872185180625121739) started by @RainRat*