### PR TITLE
[TEST] Add coverage for mtg_mechanics.py and fix Station mechanic detection

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -18,7 +18,7 @@ RECOGNIZED_MECHANICS = [
     'Flying', 'Trample', 'Lifelink', 'Haste', 'Deathtouch', 'Vigilance',
     'Ward', 'Prowess', 'Menace', 'Reach', 'Flash', 'Indestructible',
     'Defender', 'Scry', 'Draw A Card', 'Mill', 'Exile', 'Token',
-    'Discard', 'Cycling', 'Convoke'
+    'Discard', 'Cycling', 'Convoke', 'Station'
 ]
 
 sent_tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
@@ -759,6 +759,9 @@ class Card:
 
         if 'level up' in text_raw or 'level &' in text_enc:
             m.add('Leveler')
+
+        if 'station' in text_raw:
+            m.add('Station')
 
         if '%' in text_enc or '#' in text_enc or 'counter' in text_raw:
             m.add('Counters')

--- a/tests/test_mtg_complexity.py
+++ b/tests/test_mtg_complexity.py
@@ -64,7 +64,7 @@ class TestMtgComplexity(unittest.TestCase):
                 complexity_main()
                 output = fake_out.getvalue()
                 self.assertIn("COMPLEXITY ANALYSIS", output)
-                self.assertIn("Average Complexity Score: 99.00", output)
+                self.assertIn("Average Complexity Score: 107.00", output)
                 self.assertIn("Uthros Research Craft", output)
 
     def test_complexity_cli_json(self):
@@ -73,16 +73,16 @@ class TestMtgComplexity(unittest.TestCase):
                 complexity_main()
                 output = fake_out.getvalue()
                 data = json.loads(output)
-                self.assertEqual(data['average_complexity'], 99.0)
+                self.assertEqual(data['average_complexity'], 107.0)
                 self.assertEqual(len(data['top_cards']), 1)
-                self.assertEqual(data['top_cards'][0]['complexity'], 99)
+                self.assertEqual(data['top_cards'][0]['complexity'], 107)
 
     def test_search_complexity_field(self):
         with patch('sys.stdout', new=io.StringIO()) as fake_out:
             with patch('sys.argv', ['mtg_search.py', 'testdata/uthros.json', '--fields', 'name,complexity', '--text', '--no-color']):
                 search_main()
                 output = fake_out.getvalue()
-                self.assertIn("Uthros Research Craft | 99", output)
+                self.assertIn("Uthros Research Craft | 107", output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mtg_mechanics.py
+++ b/tests/test_mtg_mechanics.py
@@ -1,0 +1,100 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import io
+import sys
+import os
+
+# Add lib and scripts to path
+sys.path.append(os.getcwd())
+sys.path.append(os.path.join(os.getcwd(), 'lib'))
+
+from scripts.mtg_mechanics import main as mechanics_main
+
+class TestMtgMechanics(unittest.TestCase):
+
+    def test_mechanics_list_only(self):
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_mechanics.py', '--no-color']):
+                mechanics_main()
+                output = fake_out.getvalue()
+                self.assertIn("RECOGNIZED MECHANICS", output)
+                self.assertIn("Total:", output)
+                # Check for some common mechanics
+                self.assertIn("Flying", output)
+                self.assertIn("Trample", output)
+
+    def test_mechanics_single_file(self):
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--no-color']):
+                mechanics_main()
+                output = fake_out.getvalue()
+                self.assertIn("MECHANICAL FREQUENCY", output)
+                self.assertIn("Total Cards: 1", output)
+                # Uthros has Flying and Station
+                self.assertIn("Flying", output)
+                self.assertIn("Station", output)
+
+    def test_mechanics_comparison(self):
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--compare', 'testdata/tarkir.json', '--no-color']):
+                mechanics_main()
+                output = fake_out.getvalue()
+                self.assertIn("MECHANICAL COMPARISON", output)
+                self.assertIn("Delta", output)
+
+    def test_mechanics_no_matches(self):
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--rarity', 'common', '--no-color']):
+                mechanics_main()
+                self.assertIn("No cards found", fake_err.getvalue())
+
+    def test_mechanics_sorting_and_limit(self):
+        # Test sort by count
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--sort', 'count', '--limit', '1', '--no-color']):
+                mechanics_main()
+                output = fake_out.getvalue()
+                self.assertIn("MECHANICAL FREQUENCY", output)
+                # Header + separator + 1 row = 3 rows in data area usually,
+                # but let's just ensure it doesn't crash and contains at least one mechanic.
+
+    def test_mechanics_grep_filter(self):
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--grep', 'Uthros', '--no-color']):
+                mechanics_main()
+                self.assertIn("Total Cards: 1", fake_out.getvalue())
+
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--grep', 'NonExistent', '--no-color']):
+                mechanics_main()
+                self.assertIn("No cards found", fake_err.getvalue())
+
+    def test_mechanics_sample(self):
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--sample', '1', '--no-color']):
+                mechanics_main()
+                self.assertIn("Total Cards: 1", fake_out.getvalue())
+
+    def test_mechanics_color(self):
+        mock_stdout = MagicMock(spec=io.TextIOBase)
+        mock_stdout.isatty.return_value = True
+        mock_stdout.write = MagicMock()
+
+        captured_output = io.StringIO()
+        mock_stdout.write.side_effect = captured_output.write
+
+        with patch('sys.stdout', mock_stdout):
+            with patch('sys.argv', ['mtg_mechanics.py', '--color']):
+                mechanics_main()
+                output = captured_output.getvalue()
+                self.assertIn("\033[", output)
+
+    def test_mechanics_quiet(self):
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_mechanics.py', 'testdata/uthros.json', '--quiet', '--no-color']):
+                mechanics_main()
+                output = fake_out.getvalue()
+                self.assertIn("MECHANICAL FREQUENCY", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new test suite for the `mtg_mechanics.py` utility, addressing a significant coverage gap. During the implementation, I discovered and fixed a bug where the 'Station' mechanic (common in the test datasets) was not being correctly identified. I also updated existing complexity tests that were affected by this correction.

Key changes:
- **New Coverage:** Added `tests/test_mtg_mechanics.py` covering CLI functionality, filtering, and side-by-side comparison.
- **Bug Fix:** Updated `lib/cardlib.py` to include 'Station' in recognized mechanics and implemented its detection logic.
- **Test Maintenance:** Updated `tests/test_mtg_complexity.py` to reflect the improved complexity scoring for cards with the 'Station' mechanic.

---
*PR created automatically by Jules for task [4046110243763662384](https://jules.google.com/task/4046110243763662384) started by @RainRat*