### PR TITLE
[UI/UX] Implement smart dataset detection and argument swapping in mtg_oracle.py

### DIFF
--- a/scripts/mtg_oracle.py
+++ b/scripts/mtg_oracle.py
@@ -145,6 +145,19 @@ Example Usage:
 
     args = parser.parse_args()
 
+    # Smart Dataset Detection & Positional Argument Swapping
+    # If the first argument is not a valid path and we have no second argument,
+    # assume the first argument is actually the query.
+    if args.infile != '-' and not os.path.exists(args.infile) and args.query is None:
+        args.query = args.infile
+        args.infile = '-'
+
+    # If reading from stdin in an interactive terminal, default to AllPrintings.json
+    if args.infile == '-' and sys.stdin.isatty():
+        default_data = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../data/AllPrintings.json')
+        if os.path.exists(default_data):
+            args.infile = default_data
+
     # Handle --sample
     if args.sample > 0:
         args.shuffle = True


### PR DESCRIPTION
**PR Title:** [UI/UX] Implement smart dataset detection and argument swapping in mtg_oracle.py 
 
**Description:** 
* **Context:** CLI 
* **Problem:** Users are currently forced to provide the path to the card dataset (e.g., `data/AllPrintings.json`) even for quick single-card lookups, which is the most common use case for `mtg_oracle.py`. This adds significant friction and unnecessary keystrokes. 
* **Solution:** Implemented "Smart Dataset Detection" and "Positional Argument Swapping". If the first argument provided is not a valid file or directory path and no second argument is present, the tool now intelligently treats that first argument as the search query. Furthermore, if the tool is run in an interactive terminal without an explicit input file, it automatically defaults to loading `data/AllPrintings.json`. This enables the extremely efficient workflow: `python3 scripts/mtg_oracle.py "Grizzly Bears"`.
 
**Changes:** 
```python
    args = parser.parse_args()

    # Smart Dataset Detection & Positional Argument Swapping
    # If the first argument is not a valid path and we have no second argument,
    # assume the first argument is actually the query.
    if args.infile != '-' and not os.path.exists(args.infile) and args.query is None:
        args.query = args.infile
        args.infile = '-'

    # If reading from stdin in an interactive terminal, default to AllPrintings.json
    if args.infile == '-' and sys.stdin.isatty():
        default_data = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../data/AllPrintings.json')
        if os.path.exists(default_data):
            args.infile = default_data
```

---
*PR created automatically by Jules for task [7249383561647322193](https://jules.google.com/task/7249383561647322193) started by @RainRat*