### PR TITLE
Correct Power/Toughness unary conversion in JSON parsing

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -331,6 +331,8 @@ def fields_from_json(src_json, linetrans = True):
             src_types = [t.lower() for t in src_json.get('types', [])]
             if 'creature' not in src_types and 'vehicle' not in src_types:
                 p_t = ''
+        if p_t:
+            p_t = utils.to_ascii(utils.to_unary(str(p_t)))
     elif 'power' in src_json:
         p_t = utils.to_ascii(utils.to_unary(src_json['power'])) + '/' # hardcoded
         parsed_pt = False

--- a/tests/test_card_json_fields.py
+++ b/tests/test_card_json_fields.py
@@ -47,7 +47,7 @@ def test_fields_from_json_pt_logic():
     src["pt"] = "1/1"
     parsed, valid, fields = fields_from_json(src)
     assert parsed
-    assert fields[field_pt][0][1] == "1/1"
+    assert fields[field_pt][0][1] == utils.to_unary("1") + "/" + utils.to_unary("1")
 
     src = base_json.copy()
     src["power"] = "2"

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -69,10 +69,10 @@ def test_planeswalker_negative_loyalty_to_mse():
     assert "\tloyalty cost 2: -2\n" in mse_output
 
 @pytest.mark.parametrize("pt_string, expected_p, expected_t", [
-    ("1/2", "1", "2"),
-    (" 1 / 2 ", "1", "2"),
+    ("1/2", utils.to_unary("1"), utils.to_unary("2")),
+    (" 1 / 2 ", utils.to_unary("1"), utils.to_unary("2")),
     ("*/*", "*", "*"),
-    ("*/ *+1", "*", "*+1"),
+    ("*/ *+1", "*", "*+" + utils.to_unary("1")),
 ])
 def test_pt_parsing(pt_string, expected_p, expected_t):
     card = Card({"name": "Test Creature", "types": ["Creature"], "pt": pt_string})

--- a/tests/test_qa_coverage_boost.py
+++ b/tests/test_qa_coverage_boost.py
@@ -57,7 +57,7 @@ def test_card_pt_fallback_and_suppression():
         "rarity": "common"
     }
     card = cardlib.Card(src_creature)
-    assert card.pt == "2/2"
+    assert card.pt == utils.to_unary("2") + "/" + utils.to_unary("2")
     assert card.loyalty == ""
 
 def test_datalib_plimit_short_string():


### PR DESCRIPTION
Ensures consistent internal representation of Power/Toughness values as unary strings when parsing from JSON datasets.

---
*PR created automatically by Jules for task [14241216251002854507](https://jules.google.com/task/14241216251002854507) started by @RainRat*