### PR TITLE
Fix partial name matching for hyphenated queries in mtg_oracle.py

### DIFF
--- a/scripts/mtg_oracle.py
+++ b/scripts/mtg_oracle.py
@@ -228,7 +228,7 @@ Example Usage:
             display_cards = exact_matches
         else:
             # Fallback to partial matches
-            partial_matches = [c for c in cards if query_lower in c.name.lower()]
+            partial_matches = [c for c in cards if query_sanitized in c.name.lower()]
             if partial_matches:
                 display_cards = partial_matches
             else:


### PR DESCRIPTION
* **What:** Updated the fallback partial name matching logic in `scripts/mtg_oracle.py` to use `query_sanitized` instead of `query_lower`.
* **Why:** The project represents hyphens as a tilde `~` (`dash_marker`) internally for card names. The `query_sanitized` variable correctly transforms hyphens to tildes, whereas `query_lower` does not. Using `query_sanitized` ensures that partial searches for hyphenated card names (e.g., "fire-l") successfully match their internal representation (e.g., "fire~lit"). No breaking changes were introduced, and existing exact matching already used this transformation.

---
*PR created automatically by Jules for task [2043801636984831184](https://jules.google.com/task/2043801636984831184) started by @RainRat*