### PR TITLE
[DOCS] Standardize CLI help strings for mtg_pips.py

### DIFF
--- a/scripts/mtg_pips.py
+++ b/scripts/mtg_pips.py
@@ -73,26 +73,34 @@ Usage Examples:
     fmt_group_title = parser.add_argument_group('Output Format')
     fmt_group = fmt_group_title.add_mutually_exclusive_group()
     fmt_group.add_argument('--table', action='store_true', help='Generate a formatted table (Default for terminal).')
-    fmt_group.add_argument('--json', action='store_true', help='Generate a JSON file (Auto-detected for .json).')
+    fmt_group.add_argument('-j', '--json', action='store_true', help='Generate a JSON file (Auto-detected for .json).')
     fmt_group.add_argument('--csv', action='store_true', help='Generate a CSV file (Auto-detected for .csv).')
 
     # Group: Filtering Options (Standard)
     filter_group = parser.add_argument_group('Filtering Options')
-    filter_group.add_argument('--grep', action='append', help='Only include cards matching a search pattern.')
-    filter_group.add_argument('--vgrep', '--exclude', action='append', dest='vgrep', help='Exclude cards matching a search pattern.')
-    filter_group.add_argument('--set', action='append', help='Only include cards from specific sets.')
-    filter_group.add_argument('--rarity', action='append', help='Only include cards of specific rarities.')
-    filter_group.add_argument('--colors', action='append', help='Only include cards of specific colors.')
-    filter_group.add_argument('--identity', action='append', help='Only include cards with specific color identities.')
-    filter_group.add_argument('--cmc', action='append', help='Only include cards with specific CMC values.')
-    filter_group.add_argument('--pow', '--power', action='append', dest='pow', help='Only include cards with specific Power values.')
-    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou', help='Only include cards with specific Toughness values.')
-    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy', help='Only include cards with specific Loyalty or Defense values.')
-    filter_group.add_argument('--mechanic', action='append', help='Only include cards with specific mechanical features.')
+    filter_group.add_argument('-g', '--grep', action='append', help='Only include cards matching a search pattern (checks name, typeline, text, cost, and stats). Use multiple times for AND logic.')
+    filter_group.add_argument('--vgrep', '--exclude', action='append', dest='vgrep', help='Skip cards matching a search pattern (checks name, typeline, text, cost, and stats). Use multiple times for OR logic.')
+    filter_group.add_argument('--set', action='append', help='Only include cards from specific sets (e.g., MOM, MRD). Supports multiple sets (OR logic).')
+    filter_group.add_argument('--rarity', action='append',
+                        help="Only include cards of specific rarities. Supports full names (e.g., 'common', 'mythic') or shorthands: O (Common), N (Uncommon), A (Rare), Y (Mythic), I (Special), L (Basic Land). Supports multiple values (OR logic).")
+    filter_group.add_argument('--colors', action='append',
+                        help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple values (OR logic).")
+    filter_group.add_argument('--identity', action='append',
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). Use 'C' or 'A' for colorless. Supports multiple values (OR logic).")
+    filter_group.add_argument('--cmc', action='append',
+                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
+    filter_group.add_argument('--pow', '--power', action='append', dest='pow',
+                        help='Only include cards with specific Power values. Supports inequalities, ranges, and multiple values (OR logic).')
+    filter_group.add_argument('--tou', '--toughness', action='append', dest='tou',
+                        help='Only include cards with specific Toughness values. Supports inequalities, ranges, and multiple values (OR logic).')
+    filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
+                        help='Only include cards with specific Loyalty or Defense values. Supports inequalities, ranges, and multiple values (OR logic).')
+    filter_group.add_argument('--mechanic', action='append',
+                        help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). Supports multiple values (OR logic).')
     filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck', help='Filter cards using a standard MTG decklist file.')
-    filter_group.add_argument('--booster', type=int, default=0, help='Simulate opening N booster packs.')
-    filter_group.add_argument('--box', type=int, default=0, help='Simulate opening N booster boxes.')
-    filter_group.add_argument('--limit', type=int, default=0, help='Only process the first N cards.')
+    filter_group.add_argument('--booster', type=int, default=0, help='Simulate opening N booster packs. Shuffles by default.')
+    filter_group.add_argument('--box', type=int, default=0, help='Simulate opening N booster boxes (36 packs each). Shuffles by default.')
+    filter_group.add_argument('-n', '--limit', type=int, default=0, help='Only process the first N cards.')
     filter_group.add_argument('--shuffle', action='store_true', help='Randomize card order.')
     filter_group.add_argument('--sample', type=int, default=0, help='Pick N random cards.')
     filter_group.add_argument('--seed', type=int, help='Seed for random generator.')


### PR DESCRIPTION
Standardized the internal help strings in `scripts/mtg_pips.py` to improve consistency across the toolkit. Added standard shorthands (`-j`, `-g`, `-n`) and expanded filtering descriptions to provide more helpful context for users.

---
*PR created automatically by Jules for task [16163080313301054312](https://jules.google.com/task/16163080313301054312) started by @RainRat*