### PR TITLE
Eliminate redundant string splitting in `Card._set_text`

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -904,13 +904,13 @@ class Card:
                 self.__dict__[field_text] = mtext
                 fulltext = mtext.encode()
                 if fulltext:
-                    self.__dict__[field_text + '_lines'] = list(map(Manatext,
-                                                                    fulltext.split(utils.newline)))
+                    lines = fulltext.split(utils.newline)
+                    self.__dict__[field_text + '_lines'] = list(map(Manatext, lines))
                     self.__dict__[field_text + '_words'] = re.sub(utils.unletters_regex,
                                                                   ' ',
                                                                   fulltext.lower()).split()
                     self.__dict__[field_text + '_lines_words'] = [re.sub(
-                        utils.unletters_regex, ' ', line.lower()).split() for line in fulltext.split(utils.newline)]
+                        utils.unletters_regex, ' ', line.lower()).split() for line in lines]
             else:
                 self.valid = False
                 self.__dict__[field_other] += [(idx, '<text> ' + str(value))]


### PR DESCRIPTION
**What:** Extracted the result of `fulltext.split(utils.newline)` into a local variable `lines` within the `_set_text` method of the `Card` class in `lib/cardlib.py`.

**Why:** This avoids performing the same string split operation twice when populating `text_lines` and `text_lines_words` attributes. This change improves code readability and avoids redundant computation without altering any external behavior, as verified by the project's extensive test suite.

---
*PR created automatically by Jules for task [939889565061031585](https://jules.google.com/task/939889565061031585) started by @RainRat*