### PR TITLE
[Maintenance] Eliminate redundant string splitting in Card._set_text

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -904,13 +904,13 @@ class Card:
                 self.__dict__[field_text] = mtext
                 fulltext = mtext.encode()
                 if fulltext:
-                    self.__dict__[field_text + '_lines'] = list(map(Manatext,
-                                                                    fulltext.split(utils.newline)))
+                    lines = fulltext.split(utils.newline)
+                    self.__dict__[field_text + '_lines'] = list(map(Manatext, lines))
                     self.__dict__[field_text + '_words'] = re.sub(utils.unletters_regex,
                                                                   ' ',
                                                                   fulltext.lower()).split()
                     self.__dict__[field_text + '_lines_words'] = [re.sub(
-                        utils.unletters_regex, ' ', line.lower()).split() for line in fulltext.split(utils.newline)]
+                        utils.unletters_regex, ' ', line.lower()).split() for line in lines]
             else:
                 self.valid = False
                 self.__dict__[field_other] += [(idx, '<text> ' + str(value))]


### PR DESCRIPTION
* **What:** Refactored the `Card._set_text` method in `lib/cardlib.py` to extract the result of `fulltext.split(utils.newline)` into a local variable `lines`. This variable is then reused to populate the `_lines` and `_lines_words` attributes.
* **Why:** This change eliminates redundant computation by avoiding multiple split operations on the same string. It improves code readability and slightly enhances performance during card processing without altering any external behavior.

---
*PR created automatically by Jules for task [13351091728636733316](https://jules.google.com/task/13351091728636733316) started by @RainRat*