### PR TITLE
[UI/UX] Implement Smart Positional Argument Handling in mtg_sets.py

### DIFF
--- a/scripts/mtg_sets.py
+++ b/scripts/mtg_sets.py
@@ -102,7 +102,10 @@ Usage Examples:
   # List all sets in a dataset
   python3 scripts/mtg_sets.py data/AllPrintings.json
 
-  # Find sets with "Masters" in their name or code
+  # Find sets with "Masters" in their name or code (shorthand query)
+  python3 scripts/mtg_sets.py "Masters"
+
+  # Find sets with "Masters" in their name or code (explicit flag)
   python3 scripts/mtg_sets.py data/AllPrintings.json --grep "Masters"
 """
     )
@@ -145,6 +148,27 @@ Usage Examples:
     color_group.add_argument('--no-color', action='store_false', dest='color', help='Disable ANSI color output.')
 
     args = parser.parse_args()
+
+    # UX Improvement: Smart positional argument handling
+    # If the user provides an infile that doesn't exist, but it might be a search query,
+    # we treat it as such and default the input to stdin/AllPrintings.json.
+    if args.infile and args.infile != '-' and not os.path.exists(args.infile):
+        # If there are 2 positional arguments and the first isn't a file but the second is, swap them.
+        if args.outfile and os.path.exists(args.outfile):
+            query = args.infile
+            args.infile = args.outfile
+            args.outfile = None
+            if not args.grep:
+                args.grep = [query]
+            else:
+                args.grep.append(query)
+        # If only one argument was provided (or both don't exist), treat it as a query.
+        else:
+            if not args.grep:
+                args.grep = [args.infile]
+            else:
+                args.grep.append(args.infile)
+            args.infile = '-'
 
     # UX Improvement: Default Dataset
     # If we are reading from stdin but it's an interactive terminal, use AllPrintings.json if it exists.


### PR DESCRIPTION
**PR Title:** [UI/UX] Implement Smart Positional Argument Handling in mtg_sets.py

**Description:**
* **Context:** CLI
* **Problem:** Users are often required to type the full path to a dataset (e.g., `data/AllPrintings.json`) and the explicit `--grep` flag even for quick set searches, which creates unnecessary friction for common tasks.
* **Solution:** This change implements "Smart Positional Argument Handling" in `scripts/mtg_sets.py`. If the first positional argument provided is not a valid file or directory, the script intelligently interprets it as a search query (shorthand for `--grep`). Additionally, if a second positional argument is provided that *is* a valid file, the script swaps them, treating the first as the query and the second as the input dataset. This creates a more intuitive and efficient user experience, consistent with other major utilities in the toolkit like `mtg_search.py` and `mtg_oracle.py`.

**Changes:**
```python
<<<<<<< SEARCH
    args = parser.parse_args()

    # UX Improvement: Default Dataset
    # If we are reading from stdin but it's an interactive terminal, use AllPrintings.json if it exists.
    if args.infile == '-' and sys.stdin.isatty():
=======
    args = parser.parse_args()

    # UX Improvement: Smart positional argument handling
    # If the user provides an infile that doesn't exist, but it might be a search query,
    # we treat it as such and default the input to stdin/AllPrintings.json.
    if args.infile and args.infile != '-' and not os.path.exists(args.infile):
        # If there are 2 positional arguments and the first isn't a file but the second is, swap them.
        if args.outfile and os.path.exists(args.outfile):
            query = args.infile
            args.infile = args.outfile
            args.outfile = None
            if not args.grep:
                args.grep = [query]
            else:
                args.grep.append(query)
        # If only one argument was provided (or both don't exist), treat it as a query.
        else:
            if not args.grep:
                args.grep = [args.infile]
            else:
                args.grep.append(args.infile)
            args.infile = '-'

    # UX Improvement: Default Dataset
    # If we are reading from stdin but it's an interactive terminal, use AllPrintings.json if it exists.
    if args.infile == '-' and sys.stdin.isatty():
>>>>>>> REPLACE
```
(and help text updates)

---
*PR created automatically by Jules for task [13207963520116025204](https://jules.google.com/task/13207963520116025204) started by @RainRat*