### PR TITLE
Consolidate card type processing and fix Vehicle logic bug in `lib/cardlib.py`

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -282,21 +282,22 @@ def fields_from_json(src_json, linetrans = True):
         parsed = parsed and cost.parsed
         fields[field_cost] = [(-1, cost)]
 
+    # Consolidate type processing
+    src_supertypes = [utils.to_ascii(s.lower()) for s in src_json.get('supertypes', [])]
+    src_types = [utils.to_ascii(s.lower()) for s in src_json.get('types', [])]
+    src_subtypes = [utils.to_ascii(s.lower()).replace('"', "'").replace('-', utils.dash_marker)
+                    for s in src_json.get('subtypes', [])]
+
     if 'supertypes' in src_json:
-        fields[field_supertypes] = [
-            (-1, list(map(lambda s: utils.to_ascii(s.lower()), src_json['supertypes'])))]
+        fields[field_supertypes] = [(-1, src_supertypes)]
 
     if 'types' in src_json:
-        fields[field_types] = [(-1, [utils.to_ascii(s.lower())
-                                     for s in src_json['types']])]
+        fields[field_types] = [(-1, src_types)]
     else:
         parsed = False
 
     if 'subtypes' in src_json:
-        fields[field_subtypes] = [(-1, [utils.to_ascii(s.lower())
-                                        # urza's lands...
-                                        .replace('"', "'").replace('-', utils.dash_marker) for s in src_json['subtypes']])]
-        
+        fields[field_subtypes] = [(-1, src_subtypes)]
 
     if 'rarity' in src_json:
         # Use lowercase for robust rarity lookup
@@ -314,7 +315,6 @@ def fields_from_json(src_json, linetrans = True):
         loyalty_val = src_json.get('defense')
     # Fallback to pt for datasets that use it for loyalty/defense (like Battles)
     if loyalty_val is None:
-        src_types = [t.lower() for t in src_json.get('types', [])]
         if 'planeswalker' in src_types or 'battle' in src_types:
             loyalty_val = src_json.get('pt')
 
@@ -328,8 +328,7 @@ def fields_from_json(src_json, linetrans = True):
         # If we already used 'pt' for loyalty/defense (fallback), don't also use it as P/T
         # as that would make the card invalid in fields_check_valid() if it's not a creature.
         if p_t == loyalty_val:
-            src_types = [t.lower() for t in src_json.get('types', [])]
-            if 'creature' not in src_types and 'vehicle' not in src_types:
+            if 'creature' not in src_types and 'vehicle' not in src_subtypes:
                 p_t = ''
         if p_t:
             p_t = utils.to_ascii(utils.to_unary(str(p_t)))


### PR DESCRIPTION
This PR improves the code quality and robustness of the `lib/cardlib.py` module by addressing redundant logic and a specific logic bug in card data parsing.

### Changes:
- **Consolidated Type Processing**: In `fields_from_json`, the extraction and normalization (lowercase + ASCII) of supertypes, types, and subtypes are now performed once at the beginning of the function and stored in local variables (`src_supertypes`, `src_types`, `src_subtypes`).
- **Eliminated Redundancy**: Removed four redundant list comprehensions/map calls that were re-processing the same type data for loyalty fallback and P/T clearing logic.
- **Fixed Vehicle Logic Bug**: Corrected the check for 'vehicle' in the P/T clearing block. Previously, it looked in the `types` field, but "Vehicle" is defined as a subtype in MTGJSON. It now correctly checks the `src_subtypes` variable.

### Benefits:
- **Performance**: Minor reduction in CPU cycles by avoiding repetitive string processing for every card during large dataset imports.
- **Correctness**: Ensures that non-creature Vehicles correctly retain their Power and Toughness values during parsing, preventing potential validation errors.
- **Maintainability**: Centralizes the source of truth for normalized type data within the function, making the logic easier to follow and less error-prone.

Verified with `tests/test_cardlib.py`, `tests/test_card_validation.py`, and `tests/test_card_stats_comprehensive.py`. All tests passed.

---
*PR created automatically by Jules for task [412180476881489659](https://jules.google.com/task/412180476881489659) started by @RainRat*