### PR TITLE
[DOCS] Clarify action categorization and fix misleading example in mtg_actions.py

### DIFF
--- a/scripts/mtg_actions.py
+++ b/scripts/mtg_actions.py
@@ -18,6 +18,9 @@ import cardlib
 
 # Categorization patterns
 # These look for functional "actions" in rules text.
+# Patterns include variants for both plain text and the project's internal
+# encoded unary format (e.g. using & and ^ for numbers) to ensure the
+# tool works on both raw and processed datasets.
 ACTION_CATEGORIES = {
     'Removal': [
         r'\bdestroy\b',
@@ -98,7 +101,8 @@ Usage Examples:
   python3 scripts/mtg_actions.py data/AllPrintings.json --colors U
 
   # Find removal spells in Green with CMC 3 or less
-  python3 scripts/mtg_actions.py data/AllPrintings.json --colors G --cmc "<=3" --grep "Removal"
+  # (Note: --grep filters by card text/name, not action category)
+  python3 scripts/mtg_actions.py data/AllPrintings.json --colors G --cmc "<=3" --grep "destroy"
 """
     )
 


### PR DESCRIPTION
* **Type:** Internal Help / Code Comments
* **What:** `scripts/mtg_actions.py`
* **Why:** The script's help text contained an example suggesting `--grep` could be used to filter by the tool's identified categories (e.g., "Removal"), which is incorrect as `--grep` filters on raw card data. Fixed the example and added comments to the regex patterns to explain why they match both plain text and encoded unary numbers.

---
*PR created automatically by Jules for task [3087092729590020412](https://jules.google.com/task/3087092729590020412) started by @RainRat*