### PR TITLE
[TEST] Fix token type extraction bug and increase coverage for mtg_tokens.py

### DIFF
--- a/scripts/mtg_tokens.py
+++ b/scripts/mtg_tokens.py
@@ -52,8 +52,8 @@ def extract_tokens_from_text(text):
         # Remaining parts are likely types
         # This is very simplified but works for standard tokens
         types = color_and_types
-        for c in ['white', 'blue', 'black', 'red', 'green', 'colorless', 'multi']:
-             types = re.sub(c, '', types, flags=re.IGNORECASE)
+        for c in ['white', 'blue', 'black', 'red', 'green', 'colorless', 'multi', 'and', ',']:
+             types = re.sub(r'\b' + c + r'\b' if c.isalpha() else re.escape(c), '', types, flags=re.IGNORECASE)
         types = " ".join([t.capitalize() for t in types.split()])
 
         # Final name construction

--- a/tests/test_mtg_tokens_gaps.py
+++ b/tests/test_mtg_tokens_gaps.py
@@ -1,0 +1,174 @@
+import sys
+import os
+import json
+from unittest.mock import patch, MagicMock
+from io import StringIO
+import pytest
+
+# Add lib directory to path
+libdir = os.path.join(os.getcwd(), 'lib')
+if libdir not in sys.path:
+    sys.path.append(libdir)
+
+import scripts.mtg_tokens as mtg_tokens
+import cardlib
+
+def test_extract_tokens_creature_basic():
+    text = "Create a 1/1 white Soldier creature token."
+    tokens = mtg_tokens.extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "1/1 White Soldier Token"
+    assert tokens[0]['pt'] == "1/1"
+    assert tokens[0]['color'] == "White"
+    assert tokens[0]['type'] == "Soldier Creature"
+
+def test_extract_tokens_creature_multi_color():
+    # Tests the fix for "white and blue"
+    text = "Create a 1/1 white and blue Spirit creature token."
+    tokens = mtg_tokens.extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "1/1 White, Blue Spirit Token"
+    assert tokens[0]['color'] == "White, Blue"
+    assert tokens[0]['type'] == "Spirit Creature"
+
+def test_extract_tokens_creature_with_abilities():
+    text = "Create a 3/3 green Beast creature token with trample."
+    tokens = mtg_tokens.extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "3/3 Green Beast Token"
+    assert tokens[0]['abilities'] == "trample"
+
+def test_extract_tokens_multiple_subtypes():
+    text = "Create a 3/3 colorless Phyrexian Golem creature token."
+    tokens = mtg_tokens.extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "3/3 Colorless Phyrexian Golem Token"
+    assert tokens[0]['type'] == "Phyrexian Golem Creature"
+
+def test_extract_tokens_named_treasure():
+    text = "Create a Treasure token."
+    tokens = mtg_tokens.extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "Treasure Token"
+    assert "Sacrifice this artifact" in tokens[0]['abilities']
+
+def test_extract_tokens_named_food():
+    text = "Create two Food tokens."
+    tokens = mtg_tokens.extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "Food Token"
+    assert "gain 3 life" in tokens[0]['abilities']
+
+def test_extract_tokens_named_clue():
+    text = "Create a Clue token."
+    tokens = mtg_tokens.extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "Clue Token"
+    assert "Draw a card" in tokens[0]['abilities']
+
+@patch('scripts.mtg_tokens.jdecode.mtg_open_file')
+@patch('sys.stdout', new_callable=StringIO)
+def test_mtg_tokens_main_json(mock_stdout, mock_open_file):
+    # Mock card data
+    mock_card = MagicMock(spec=cardlib.Card)
+    mock_card.name = "Test Card"
+    mock_card.get_text.return_value = "Create a 1/1 white Soldier creature token."
+    mock_open_file.return_value = [mock_card]
+
+    with patch('sys.argv', ['mtg_tokens.py', 'dummy.json', '--json']):
+        mtg_tokens.main()
+
+    output = mock_stdout.getvalue()
+    data = json.loads(output)
+    assert len(data) == 1
+    assert data[0]['name'] == "1/1 White Soldier Token"
+
+@patch('scripts.mtg_tokens.jdecode.mtg_open_file')
+@patch('sys.stdout', new_callable=StringIO)
+def test_mtg_tokens_main_table(mock_stdout, mock_open_file):
+    # Mock card data
+    mock_card = MagicMock(spec=cardlib.Card)
+    mock_card.name = "Test Card"
+    mock_card.get_text.return_value = "Create a 1/1 white Soldier creature token."
+    mock_open_file.return_value = [mock_card]
+
+    with patch('sys.argv', ['mtg_tokens.py', 'dummy.json']):
+        mtg_tokens.main()
+
+    output = mock_stdout.getvalue()
+    assert "EXTRACTED TOKENS" in output
+    assert "Soldier Token" in output
+
+@patch('scripts.mtg_tokens.jdecode.mtg_open_file')
+@patch('sys.stdout', new_callable=StringIO)
+def test_mtg_tokens_main_no_cards(mock_stdout, mock_open_file):
+    mock_open_file.return_value = []
+
+    with patch('sys.argv', ['mtg_tokens.py', 'dummy.json']):
+        mtg_tokens.main()
+
+    # Should print "No cards found" to stderr, let's just check it doesn't crash
+    # and stdout is empty or doesn't have the header
+    assert "EXTRACTED TOKENS" not in mock_stdout.getvalue()
+
+@patch('scripts.mtg_tokens.jdecode.mtg_open_file')
+@patch('sys.stdout', new_callable=StringIO)
+def test_mtg_tokens_main_no_tokens(mock_stdout, mock_open_file):
+    mock_card = MagicMock(spec=cardlib.Card)
+    mock_card.name = "Test Card"
+    mock_card.get_text.return_value = "No tokens here."
+    mock_open_file.return_value = [mock_card]
+
+    with patch('sys.argv', ['mtg_tokens.py', 'dummy.json']):
+        mtg_tokens.main()
+
+    assert "No token definitions found" in mock_stdout.getvalue()
+
+@patch('scripts.mtg_tokens.jdecode.mtg_open_file')
+@patch('sys.stdout', new_callable=StringIO)
+def test_mtg_tokens_main_duplicate_tokens(mock_stdout, mock_open_file):
+    mock_card1 = MagicMock(spec=cardlib.Card)
+    mock_card1.name = "Card 1"
+    mock_card1.get_text.return_value = "Create a 1/1 white Soldier creature token."
+
+    mock_card2 = MagicMock(spec=cardlib.Card)
+    mock_card2.name = "Card 2"
+    mock_card2.get_text.return_value = "Create a 1/1 white Soldier creature token."
+
+    mock_open_file.return_value = [mock_card1, mock_card2]
+
+    with patch('sys.argv', ['mtg_tokens.py', 'dummy.json']):
+        mtg_tokens.main()
+
+    output = mock_stdout.getvalue()
+    # Check that count is 2 in the table
+    assert "2" in output
+
+@patch('scripts.mtg_tokens.jdecode.mtg_open_file')
+@patch('sys.stdout', new_callable=StringIO)
+def test_mtg_tokens_main_verbose(mock_stdout, mock_open_file):
+    mock_card = MagicMock(spec=cardlib.Card)
+    mock_card.name = "Test Card"
+    mock_card.get_text.return_value = "Create a 1/1 white Soldier creature token."
+    mock_open_file.return_value = [mock_card]
+
+    with patch('sys.argv', ['mtg_tokens.py', 'dummy.json', '--verbose']):
+        mtg_tokens.main()
+
+    output = mock_stdout.getvalue()
+    assert "Processing card: Test Card" in output
+    assert "Found 1 tokens" in output
+
+@patch('scripts.mtg_tokens.jdecode.mtg_open_file')
+@patch('sys.stdout', new_callable=StringIO)
+def test_mtg_tokens_main_color_force(mock_stdout, mock_open_file):
+    mock_card = MagicMock(spec=cardlib.Card)
+    mock_card.name = "Test Card"
+    mock_card.get_text.return_value = "Create a 1/1 white Soldier creature token."
+    mock_open_file.return_value = [mock_card]
+
+    with patch('sys.argv', ['mtg_tokens.py', 'dummy.json', '--color']):
+        mtg_tokens.main()
+
+    output = mock_stdout.getvalue()
+    assert "\x1b[" in output


### PR DESCRIPTION
This PR addresses a logic error in `scripts/mtg_tokens.py` where multi-color token descriptions (e.g., "white and blue Spirit") resulted in incorrect type fields (e.g., "And Spirit Creature"). The fix uses regex with word boundaries to cleanly remove colors, conjunctions, and punctuation from the type string.

Additionally, a new test suite `tests/test_mtg_tokens_gaps.py` was implemented to perform Gap Analysis and ensure high coverage for the script. The new tests verify:
- Standard creature tokens (single and multi-color).
- Tokens with multiple subtypes (e.g., "Phyrexian Golem").
- Named predefined tokens (Treasure, Food, Clue).
- Tokens with abilities.
- CLI functionality (JSON output, Table output, Verbose mode, and Color output) via mocking.

Coverage for `scripts/mtg_tokens.py` increased from 0% (untracked) to 92%.

---
*PR created automatically by Jules for task [4423873861979377348](https://jules.google.com/task/4423873861979377348) started by @RainRat*