### PR TITLE
Replace broad except block in mtg_deckgen.py with specific exceptions

### DIFF
--- a/scripts/mtg_deckgen.py
+++ b/scripts/mtg_deckgen.py
@@ -34,7 +34,7 @@ def pick_cards_with_curve(pool, target_count, curve=None):
     for c in pool:
         try:
             cmc = int(float(c.cost.cmc))
-        except:
+        except (ValueError, TypeError):
             cmc = 0
         by_cmc[cmc].append(c)
         


### PR DESCRIPTION
This PR improves code quality in `scripts/mtg_deckgen.py` by replacing a broad `except:` block with specific exception handling.

### Changes:
- Modified `pick_cards_with_curve` in `scripts/mtg_deckgen.py` to use `except (ValueError, TypeError):` instead of a bare `except:`.

### Why:
- Prevents suppression of system signals (like `KeyboardInterrupt`) and unrelated logic errors.
- Follows Python best practices for robust error handling.
- Atomic, non-breaking change that maintains existing functionality.

### Verification:
- Verified the fix by running `python3 scripts/mtg_deckgen.py testdata/token_test.json --format standard`.
- Ran the full test suite (`python3 -m pytest`), all 923 tests passed.

---
*PR created automatically by Jules for task [11567582907456117833](https://jules.google.com/task/11567582907456117833) started by @RainRat*