### PR TITLE
[TEST] Add coverage for mtg_deckgen.py and fix IndexError in standard mode

### DIFF
--- a/scripts/mtg_deckgen.py
+++ b/scripts/mtg_deckgen.py
@@ -201,11 +201,19 @@ def main():
         
         decklist = []
         
-        for i in range(creatures_target):
-            decklist.append(random.choice(c_sample).name.title())
+        if creatures_target > 0:
+            if not c_sample:
+                print("Warning: No creatures found in pool for standard deck.", file=sys.stderr)
+            else:
+                for i in range(creatures_target):
+                    decklist.append(random.choice(c_sample).name.title())
             
-        for i in range(spells_target):
-            decklist.append(random.choice(s_sample).name.title())
+        if spells_target > 0:
+            if not s_sample:
+                print("Warning: No non-creature spells found in pool for standard deck.", file=sys.stderr)
+            else:
+                for i in range(spells_target):
+                    decklist.append(random.choice(s_sample).name.title())
             
         grouped = defaultdict(int)
         for name in decklist:

--- a/tests/test_mtg_deckgen.py
+++ b/tests/test_mtg_deckgen.py
@@ -1,0 +1,130 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import io
+
+# Add lib and scripts directory to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../scripts'))
+
+import mtg_deckgen
+
+class TestMtgDeckgen(unittest.TestCase):
+
+    def test_get_color_identity_set(self):
+        card = MagicMock()
+        card.color_identity = "WU"
+        self.assertEqual(mtg_deckgen.get_color_identity_set(card), {'W', 'U'})
+
+        card.color_identity = ""
+        self.assertEqual(mtg_deckgen.get_color_identity_set(card), set())
+
+        card = object() # No color_identity attribute
+        self.assertEqual(mtg_deckgen.get_color_identity_set(card), set())
+
+    def test_subset_identity(self):
+        self.assertTrue(mtg_deckgen.subset_identity({'W'}, {'W', 'U'}))
+        self.assertTrue(mtg_deckgen.subset_identity(set(), {'W', 'U'}))
+        self.assertFalse(mtg_deckgen.subset_identity({'R'}, {'W', 'U'}))
+
+    def test_pick_cards_with_curve_basic(self):
+        pool = [MagicMock() for _ in range(10)]
+        picked = mtg_deckgen.pick_cards_with_curve(pool, 5)
+        self.assertEqual(len(picked), 5)
+        for p in picked:
+            self.assertIn(p, pool)
+
+    def test_pick_cards_with_curve_empty_pool(self):
+        self.assertEqual(mtg_deckgen.pick_cards_with_curve([], 5), [])
+
+    def test_pick_cards_with_curve_with_curve(self):
+        c1 = MagicMock()
+        c1.cost.cmc = 1
+        c2 = MagicMock()
+        c2.cost.cmc = 2
+        c6 = MagicMock()
+        c6.cost.cmc = 6
+
+        pool = [c1, c2, c6]
+        curve = {1: 1, 2: 1, 6: 1}
+        picked = mtg_deckgen.pick_cards_with_curve(pool, 3, curve=curve)
+        self.assertEqual(len(picked), 3)
+        self.assertIn(c1, picked)
+        self.assertIn(c2, picked)
+        self.assertIn(c6, picked)
+
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_main_commander(self, mock_stderr, mock_stdout, mock_open):
+        # Create a pool with a legendary creature and some other cards
+        commander = MagicMock()
+        commander.name = "Galia"
+        commander.supertypes = ["Legendary"]
+        commander.types = ["Creature"]
+        commander.color_identity = "RG"
+
+        card1 = MagicMock()
+        card1.name = "Goblin"
+        card1.types = ["Creature"]
+        card1.color_identity = "R"
+        card1.cost.cmc = 2
+
+        mock_open.return_value = [commander, card1]
+
+        with patch('sys.argv', ['mtg_deckgen.py', 'dummy.json', '--format', 'commander', '--commander', 'Galia']):
+            mtg_deckgen.main()
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Galia", output)
+        self.assertIn("Goblin", output)
+        # Should also include some lands
+        self.assertIn("Mountain", output)
+        self.assertIn("Forest", output)
+
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_main_standard(self, mock_stderr, mock_stdout, mock_open):
+        c1 = MagicMock()
+        c1.name = "Soldier"
+        c1.types = ["Creature"]
+        c1.cost.cmc = 1
+
+        s1 = MagicMock()
+        s1.name = "Shock"
+        s1.types = ["Instant"]
+        s1.cost.cmc = 1
+
+        mock_open.return_value = [c1, s1]
+
+        with patch('sys.argv', ['mtg_deckgen.py', 'dummy.json', '--format', 'standard']):
+            mtg_deckgen.main()
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Soldier", output)
+        self.assertIn("Shock", output)
+
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_main_no_legendary(self, mock_stderr, mock_open):
+        mock_open.return_value = []
+        with patch('sys.argv', ['mtg_deckgen.py', 'dummy.json']), self.assertRaises(SystemExit):
+            mtg_deckgen.main()
+        self.assertIn("Error: No legendary creatures found", mock_stderr.getvalue())
+
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_main_standard_empty_pool(self, mock_stderr, mock_stdout, mock_open):
+        mock_open.return_value = []
+        with patch('sys.argv', ['mtg_deckgen.py', 'dummy.json', '--format', 'standard']):
+            # Should no longer raise IndexError
+            mtg_deckgen.main()
+        self.assertIn("Warning: No creatures found", mock_stderr.getvalue())
+        self.assertIn("Warning: No non-creature spells found", mock_stderr.getvalue())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a new test suite for the `mtg_deckgen.py` utility and addresses a runtime crash.

**Changes:**
1.  **New Coverage:** Created `tests/test_mtg_deckgen.py` which provides unit tests for internal logic and integration tests for the 'commander' and 'standard' deck generation modes.
2.  **Bug Fix:** Modified `scripts/mtg_deckgen.py` to gracefully handle cases where the card pool lacks creatures or non-creature spells when generating a 'standard' format deck. Previously, this would result in an `IndexError` when calling `random.choice()` on an empty sample.
3.  **Robustness:** Added warning messages to `stderr` when categories are skipped due to empty pools, allowing the script to finish and provide a partial decklist instead of crashing.

Verified with 946 passing tests.

---
*PR created automatically by Jules for task [2548531702245290943](https://jules.google.com/task/2548531702245290943) started by @RainRat*