### PR TITLE
Fix logic bug in card type normalization during text parsing

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -496,7 +496,10 @@ def fields_from_format(src_text, fmt_ordered, fmt_labeled, fieldsep, linetrans =
             valid = valid and fval.valid
             addf(fields, fname, (idx, fval))
         elif fname in [field_supertypes, field_types, field_subtypes]:
-            addf(fields, fname, (idx, textfield.split()))
+            vals = [utils.to_ascii(s.lower()) for s in textfield.split()]
+            if fname == field_subtypes:
+                vals = [v.replace('"', "'").replace('-', utils.dash_marker) for v in vals]
+            addf(fields, fname, (idx, vals))
         else:
             addf(fields, fname, (idx, textfield))
 


### PR DESCRIPTION
**PR Title:** Fix logic bug in card type normalization during text parsing
**Description:**
* **What:** Updated `fields_from_format` in `lib/cardlib.py` to lowercase and ASCII-normalize supertypes, types, and subtypes. Added character sanitization for subtypes (quotes and dashes) to match `fields_from_json` behavior.
* **Why:** This ensures that cards parsed from encoded text strings are consistent with those parsed from JSON. Without this normalization, case-sensitive validation checks (e.g., for 'creature') would fail if the input text was capitalized, incorrectly marking valid cards as invalid.


---
*PR created automatically by Jules for task [6964176584637693567](https://jules.google.com/task/6964176584637693567) started by @RainRat*