### PR TITLE
[Fix] Correct power_rating calculation for multi-faced cards

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -725,28 +725,27 @@ class Card:
     @property
     def power_rating(self):
         """Calculates a heuristic power rating for creatures relative to their CMC."""
-        if not self.is_creature:
-            return 0.0
+        rating = 0.0
+        if self.is_creature:
+            p = utils.from_unary_single(self.pt_p)
+            t = utils.from_unary_single(self.pt_t)
 
-        p = utils.from_unary_single(self.pt_p)
-        t = utils.from_unary_single(self.pt_t)
+            # Default to 0 if non-numeric (X, *, etc.)
+            p_val = float(p) if isinstance(p, (int, float)) else 0.0
+            t_val = float(t) if isinstance(t, (int, float)) else 0.0
 
-        # Default to 0 if non-numeric (X, *, etc.)
-        p_val = float(p) if isinstance(p, (int, float)) else 0.0
-        t_val = float(t) if isinstance(t, (int, float)) else 0.0
+            score = p_val + t_val
 
-        score = p_val + t_val
+            # Add keyword bonuses
+            face_mechanics = self.get_face_mechanics()
+            for m in face_mechanics:
+                score += KEYWORD_WEIGHTS.get(m, 0.0)
 
-        # Add keyword bonuses
-        face_mechanics = self.get_face_mechanics()
-        for m in face_mechanics:
-            score += KEYWORD_WEIGHTS.get(m, 0.0)
-
-        # Adjust for CMC
-        # Formula: (P + T + Keywords) / (2 * max(1, CMC))
-        # A "Vanilla" 2/2 for 2 has a rating of (2+2)/(2*2) = 1.0
-        cmc = self.cost.cmc
-        rating = score / (2 * max(1, cmc))
+            # Adjust for CMC
+            # Formula: (P + T + Keywords) / (2 * max(1, CMC))
+            # A "Vanilla" 2/2 for 2 has a rating of (2+2)/(2*2) = 1.0
+            cmc = self.cost.cmc
+            rating = score / (2 * max(1, cmc))
 
         if self.bside:
             rating = max(rating, self.bside.power_rating)

--- a/tests/test_card_power_tdfc.py
+++ b/tests/test_card_power_tdfc.py
@@ -1,0 +1,64 @@
+import sys
+import os
+import pytest
+
+# Add lib directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+from cardlib import Card
+
+def test_power_rating_tdfc_back_only():
+    """
+    Verifies that power_rating correctly identifies creature power on the back face
+    of a card whose front face is NOT a creature (e.g., a Saga transforming into a creature).
+    """
+    # Saga that transforms into a creature
+    # Front: Not a creature (Enchantment)
+    # Back: Creature 2/2 with Flying
+    tdfc_json = {
+        "name": "The Saga",
+        "manaCost": "{1}{G}",
+        "types": ["Enchantment", "Saga"],
+        "text": "III - Exile this, then return it transformed.",
+        "rarity": "rare",
+        "bside": {
+            "name": "The Spirit",
+            "types": ["Creature"],
+            "subtypes": ["Spirit"],
+            "pt": "&^^/&^^", # 2/2 in unary
+            "text": "Flying"
+        }
+    }
+
+    card = Card(tdfc_json)
+
+    # Assertions
+    assert not card.is_creature, "Front face should not be identified as a creature"
+    assert card.bside.is_creature, "Back face should be identified as a creature"
+
+    # Back face rating: (2 + 2 + 1.5) / (2 * max(1, 2)) = 5.5 / 4 = 1.375
+    # Since Card(tdfc_json) will parse bside as a Card, it shares the front face CMC (2)
+    # in some formats, but here it's parsed from JSON.
+    # Actually, cardlib.Card constructor for bside uses the provided dictionary.
+    # Manacost for bside will be empty if not provided, CMC 0.
+
+    back_rating = card.bside.power_rating
+    assert back_rating > 0.0, f"Back face power rating should be positive, got {back_rating}"
+
+    # The overall rating should match the maximum across faces
+    assert card.power_rating == back_rating, f"Overall power rating {card.power_rating} should match back face rating {back_rating}"
+
+def test_power_rating_creature_front_only():
+    """Verifies that power_rating still works for normal creatures."""
+    creature_json = {
+        "name": "Grizzly Bears",
+        "manaCost": "{1}{G}",
+        "types": ["Creature"],
+        "subtypes": ["Bear"],
+        "pt": "&^^/&^^", # 2/2
+        "rarity": "common"
+    }
+    card = Card(creature_json)
+    # (2+2)/(2*2) = 1.0
+    assert card.power_rating == 1.0


### PR DESCRIPTION
* **What:** Updated the `Card.power_rating` property in `lib/cardlib.py` to evaluate the back face (`bside`) of a card regardless of whether the front face is a creature. Added a new test suite `tests/test_card_power_tdfc.py` with specific test cases for this scenario.
* **Why:** Previously, transforming double-faced cards (TDFCs) whose front face was a non-creature (like Sagas or certain Artifacts) incorrectly reported a power rating of 0.0, even if their back face was a powerful creature. This fix ensures that the combat efficiency heuristic accurately reflects the strongest face of the card. The change is non-breaking as it preserves existing logic for single-faced cards and creature-front cards.

---
*PR created automatically by Jules for task [11846518315877072233](https://jules.google.com/task/11846518315877072233) started by @RainRat*