### PR TITLE
[Refactor] Remove redundant lowercasing on normalized card type fields

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -611,7 +611,7 @@ class Card:
 
     def _has_type(self, type_name):
         """Returns True if the card has the specified type (case-insensitive)."""
-        return any(t.lower() == type_name.lower() for t in self.types)
+        return type_name.lower() in self.types
 
     @property
     def is_artifact(self):
@@ -621,7 +621,7 @@ class Card:
     @property
     def is_creature(self):
         """Returns True if the card is a creature or a vehicle."""
-        return self._has_type('creature') or any(s.lower() == 'vehicle' for s in self.subtypes)
+        return self._has_type('creature') or 'vehicle' in self.subtypes
 
     @property
     def is_planeswalker(self):
@@ -861,7 +861,7 @@ class Card:
         if 'uncast' in text_raw:
             m.add('Uncast')
 
-        if 'equipment' in [t.lower() for t in self.subtypes] or 'equip' in text_raw:
+        if 'equipment' in self.subtypes or 'equip' in text_raw:
             m.add('Equipment')
 
         if 'level up' in text_raw or 'level &' in text_enc:

--- a/scripts/mtg_mana.py
+++ b/scripts/mtg_mana.py
@@ -24,7 +24,7 @@ def get_produced_colors(card):
 
     # 1. Intrinsic basic land production (even if text is empty)
     # Check both types and subtypes for basic land types
-    all_types = [t.lower() for t in card.types + card.subtypes]
+    all_types = card.types + card.subtypes
     if 'plains' in all_types: produced.add('W')
     if 'island' in all_types: produced.add('U')
     if 'swamp' in all_types: produced.add('B')


### PR DESCRIPTION
This PR improves code quality by removing redundant `.lower()` calls and list comprehensions on card type-related fields that are already normalized to lowercase during initialization.

Key changes:
- In `lib/cardlib.py`:
  - Refactored `Card._has_type` to use `type_name.lower() in self.types`.
  - Refactored `Card.is_creature` property to use direct membership check `'vehicle' in self.subtypes`.
  - Refactored `Card.get_face_mechanics` to remove a redundant list comprehension when checking for 'equipment'.
- In `scripts/mtg_mana.py`:
  - Refactored `get_produced_colors` to remove a redundant list comprehension and `.lower()` calls on card types and subtypes.

These changes are non-breaking as they rely on existing normalization logic in the `Card` initialization process. Verified with existing test suites.

---
*PR created automatically by Jules for task [5434670882692793537](https://jules.google.com/task/5434670882692793537) started by @RainRat*