### PR TITLE
[DOCS] Replace Magic jargon with plain English in mana analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ python3 scripts/mtg_curve.py data/AllPrintings.json --grep-type "Creature"
     *   Supports all **Advanced Filtering** flags.
 
 ### `mtg_mana.py`
-Identifies mana-producing cards using rules text patterns (e.g., 'Add {G}', 'any color') and intrinsic basic land types. It categorizes producers into Dorks (creatures), Rocks (artifacts), Lands, and Rituals (spells), profiles produced colors, and identifies color-fixing density.
+Identifies mana-producing cards using rules text patterns (e.g., 'Add {G}', 'any color') and intrinsic basic land types. It categorizes producers into Creatures, Artifacts, Lands, and Spells, profiles produced colors, and identifies color-fixing density.
 ```bash
 # Analyze mana production for a specific set
 python3 scripts/mtg_mana.py data/AllPrintings.json --set MOM

--- a/scripts/mtg_mana.py
+++ b/scripts/mtg_mana.py
@@ -73,10 +73,10 @@ def get_produced_colors(card):
 
 def get_category(card):
     """Categorizes a mana producer."""
-    if card.is_creature: return "Dork"
-    if card.is_artifact: return "Rock"
+    if card.is_creature: return "Creature"
+    if card.is_artifact: return "Artifact"
     if card.is_land: return "Land"
-    if card.is_instant or card.is_sorcery: return "Ritual"
+    if card.is_instant or card.is_sorcery: return "Spell"
     return "Other"
 
 def analyze_dataset(cards):
@@ -115,7 +115,7 @@ def main():
         description="Identify and profile mana-producing cards in a dataset.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-This tool identifies mana producers using rules text patterns (e.g., 'Add {G}', 'any color') and intrinsic basic land types. It categorizes producers into Dorks (creatures), Rocks (artifacts), Lands, and Rituals (spells).
+This tool identifies mana producers using rules text patterns (e.g., 'Add {G}', 'any color') and intrinsic basic land types. It categorizes producers into Creatures, Artifacts, Lands, and Spells.
 
 Usage Examples:
   # Analyze mana production for a specific set
@@ -124,7 +124,7 @@ Usage Examples:
   # Compare mana fixing between official data and AI-generated cards
   python3 scripts/mtg_mana.py data/AllPrintings.json --compare generated.txt
 
-  # Find only green mana-producing creatures (Mana Dorks)
+  # Find only green mana-producing creatures
   python3 scripts/mtg_mana.py data/AllPrintings.json --colors G --grep-type "Creature"
 
   # Quickly find mana producers using the default dataset
@@ -409,7 +409,7 @@ Usage Examples:
                 c_header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in c_header]
 
             c_rows = [c_header]
-            for cat in ["Dork", "Rock", "Land", "Ritual", "Other"]:
+            for cat in ["Creature", "Artifact", "Land", "Spell", "Other"]:
                 p1 = stats1['categories'][cat] / stats1['total_cards'] * 100
                 row = [cat, f"{p1:5.1f}%"]
                 if stats2:

--- a/tests/test_mtg_mana.py
+++ b/tests/test_mtg_mana.py
@@ -32,7 +32,7 @@ class TestMtgMana(unittest.TestCase):
         self.assertEqual(mtg_mana.get_produced_colors(card_volcanic), {'U', 'R'})
 
     def test_get_produced_colors_text(self):
-        # Mana Dork
+        # Mana Creature
         card_elf = cardlib.Card({
             'name': 'Llanowar Elves',
             'types': ['Creature'],
@@ -40,7 +40,7 @@ class TestMtgMana(unittest.TestCase):
         })
         self.assertEqual(mtg_mana.get_produced_colors(card_elf), {'G'})
 
-        # Mana Rock
+        # Mana Artifact
         card_sol_ring = cardlib.Card({
             'name': 'Sol Ring',
             'types': ['Artifact'],
@@ -57,21 +57,21 @@ class TestMtgMana(unittest.TestCase):
         self.assertEqual(mtg_mana.get_produced_colors(card_lotus), {'Any'})
 
     def test_get_category(self):
-        # Dork
+        # Creature
         c = cardlib.Card({'name': 'Elf', 'types': ['Creature']})
-        self.assertEqual(mtg_mana.get_category(c), 'Dork')
+        self.assertEqual(mtg_mana.get_category(c), 'Creature')
 
-        # Rock
+        # Artifact
         c = cardlib.Card({'name': 'Ring', 'types': ['Artifact']})
-        self.assertEqual(mtg_mana.get_category(c), 'Rock')
+        self.assertEqual(mtg_mana.get_category(c), 'Artifact')
 
         # Land
         c = cardlib.Card({'name': 'Forest', 'types': ['Land']})
         self.assertEqual(mtg_mana.get_category(c), 'Land')
 
-        # Ritual
+        # Spell
         c = cardlib.Card({'name': 'Ritual', 'types': ['Instant']})
-        self.assertEqual(mtg_mana.get_category(c), 'Ritual')
+        self.assertEqual(mtg_mana.get_category(c), 'Spell')
 
     def test_analyze_dataset(self):
         cards = [
@@ -84,7 +84,7 @@ class TestMtgMana(unittest.TestCase):
         self.assertEqual(stats['total_cards'], 3)
         self.assertEqual(stats['producer_count'], 3)
         self.assertEqual(stats['categories']['Land'], 2)
-        self.assertEqual(stats['categories']['Dork'], 1)
+        self.assertEqual(stats['categories']['Creature'], 1)
         self.assertEqual(stats['colors']['G'], 2)
         self.assertEqual(stats['colors']['U'], 1)
 


### PR DESCRIPTION
This PR improves the project's documentation and tool output by removing niche Magic: The Gathering jargon and replacing it with plain English terms.

**Changes:**
- **`scripts/mtg_mana.py`**: Updated the `get_category` function, CLI help text, and output table formatting to use "Creature", "Artifact", and "Spell" instead of "Dork", "Rock", and "Ritual".
- **`README.md`**: Updated the utility tools section to reflect the improved terminology.
- **`tests/test_mtg_mana.py`**: Updated unit tests to assert on the new user-friendly category names.

**Impact:**
Users unfamiliar with MTG slang will now find the mana production reports easier to understand, as the categories now match standard card types.

---
*PR created automatically by Jules for task [11868439495240808197](https://jules.google.com/task/11868439495240808197) started by @RainRat*