### PR TITLE
[UI/UX] [CLI] Implement Smart Positional Argument Handling in mtg_pips.py

### DIFF
--- a/scripts/mtg_pips.py
+++ b/scripts/mtg_pips.py
@@ -50,6 +50,9 @@ Usage Examples:
 
   # Include pips found in rules text (e.g. activation costs)
   python3 scripts/mtg_pips.py data/AllPrintings.json --set MOM --include-text
+
+  # Quickly find pip distribution for cards matching a name using the default dataset
+  python3 scripts/mtg_pips.py "Dragon"
 """
     )
 
@@ -115,6 +118,27 @@ Usage Examples:
     color_group.add_argument('--no-color', action='store_false', dest='color', help='Disable ANSI color output.')
 
     args = parser.parse_args()
+
+    # UX Improvement: Smart positional argument handling
+    # If the user provides an infile that doesn't exist, but it might be a search query,
+    # we treat it as such and default the input to stdin/AllPrintings.json.
+    if args.infile and args.infile != '-' and not os.path.exists(args.infile):
+        # If there are 2 positional arguments and the first isn't a file but the second is, swap them.
+        if args.outfile and os.path.exists(args.outfile):
+            query = args.infile
+            args.infile = args.outfile
+            args.outfile = None
+            if not args.grep:
+                args.grep = [query]
+            else:
+                args.grep.append(query)
+        # If only one argument was provided (or both don't exist), treat it as a query.
+        else:
+            if not args.grep:
+                args.grep = [args.infile]
+            else:
+                args.grep.append(args.infile)
+            args.infile = '-'
 
     # UX Improvement: Default Dataset
     # If we are reading from stdin but it's an interactive terminal, use AllPrintings.json if it exists.


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** The `mtg_pips.py` utility required explicit `--grep` flags for searching and a mandatory input file path even for common lookups. This created friction for users who wanted to quickly analyze the pip distribution of a specific card or set using the default dataset.
* **Solution:** Implemented "Smart Positional Argument Handling." If the first positional argument is not a valid file path, it is now automatically treated as a search query (`--grep`), and the script defaults the input to `data/AllPrintings.json`. Additionally, if a user provides a query followed by a valid file path (e.g., `python3 mtg_pips.py "Dragon" cards.json`), the script intelligently swaps them. This matches the UX pattern established in other core utilities in the project.
* **Changes:**
    - Modified `scripts/mtg_pips.py` to add smart positional argument logic.
    - Updated the `argparse` epilog with a new usage example demonstrating the shorthand.

---
*PR created automatically by Jules for task [6639644012757926412](https://jules.google.com/task/6639644012757926412) started by @RainRat*