### PR TITLE
[DOCS] Clarify default field sequence in Field Labels section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Rarity is encoded using a single-letter marker. These markers are often the seco
 | `L` | Basic Land | **L**and |
 
 ### Field Labels
-If you don't use the `--nolabel` flag, each field is prefixed with a number for easier identification:
+If you don't use the `--nolabel` flag, each field is prefixed with a number for easier identification. By default (in the `std` encoding), the fields appear in this sequence: Types (5), Supertypes (4), Subtypes (6), Loyalty/Defense (7), Power/Toughness (8), Rules Text (9), Mana Cost (3), Rarity (0), and finally Name (1).
 
 | Label | Card Part | Example |
 | :--- | :--- | :--- |


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the "Field Labels" section in `README.md`.
* **Why:** Clarified the visual sequence of card fields in the default encoding format. Users often need to know the order in which data (like Mana Cost or Rules Text) appears when interpreting encoded output. By listing the sequence in the introductory text while keeping the reference table numerically sorted, the documentation is now both informative and easy to use as a quick lookup tool. Verified against the actual output of `encode.py` and the `fmt_ordered_default` definition in `lib/cardlib.py`.

---
*PR created automatically by Jules for task [14998602761227471286](https://jules.google.com/task/14998602761227471286) started by @RainRat*