### PR TITLE
[DOCS] Clarify default field sequence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ Rarity is encoded using a single-letter marker. These markers are often the seco
 | `L` | Basic Land | **L**and |
 
 ### Field Labels
-If you don't use the `--nolabel` flag, each field is prefixed with a number for easier identification:
+If you don't use the `--nolabel` flag, each field is prefixed with a number for easier identification. The default (`std`) encoding format uses the following sequence: **Types (5), Supertypes (4), Subtypes (6), Loyalty/Defense (7), Power/Toughness (8), Rules Text (9), Mana Cost (3), Rarity (0), and Name (1).**
+
+The table below lists the labels in numerical order for reference:
 
 | Label | Card Part | Example |
 | :--- | :--- | :--- |


### PR DESCRIPTION
Updated the `README.md` 'Field Labels' section to explicitly clarify the sequence of fields in the default (`std`) encoding format. While the reference table is sorted numerically for easy lookup, it now includes an introductory note explaining the actual sequence seen in encoded output (starting with Types and ending with Name). This improves clarity for users interpreting AI-generated or encoded card data.

---
*PR created automatically by Jules for task [18075658262917201652](https://jules.google.com/task/18075658262917201652) started by @RainRat*