### PR TITLE
Fix logic bug in from_unary transformation

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -146,6 +146,8 @@ def to_unary(s, warn = False):
 def from_unary(s):
     def replace_unary(match):
         n = match.group(0)
+        if n in _unary_exceptions_inv:
+            return str(_unary_exceptions_inv[n])
         i = (len(n) - len(unary_marker)) // len(unary_counter)
         return str(i)
 
@@ -416,7 +418,9 @@ mana_json_regex = (re.escape(mana_json_open_delimiter) + '['
                + ']+' + re.escape(mana_json_close_delimiter))
 
 number_decimal_regex = r'[0123456789]+'
-number_unary_regex = re.escape(unary_marker) + re.escape(unary_counter) + '*'
+# Sort keys by length descending to match longest first
+_exception_patterns = [re.escape(v) for v in sorted(_unary_exceptions_inv.keys(), key=len, reverse=True)]
+number_unary_regex = '(?:' + '|'.join(_exception_patterns + [re.escape(unary_marker) + re.escape(unary_counter) + '*']) + ')'
 # Pre-compile for performance
 _number_decimal_re = re.compile(number_decimal_regex)
 _number_unary_re = re.compile(number_unary_regex)

--- a/tests/test_datalib.py
+++ b/tests/test_datalib.py
@@ -237,9 +237,9 @@ def test_pt_ranking_outliers(capsys):
     dm.outliers()
     captured = capsys.readouterr()
     output = captured.out
-    # Note: outliers use utils.from_unary for display, which returns the exception label (e.g. "twenty~five")
-    assert "Largest creature power: twenty~five" in output
-    assert "Largest creature toughness: twenty~five" in output
+    # Note: outliers use utils.from_unary for display, which now correctly returns "25"
+    assert "Largest creature power: 25" in output
+    assert "Largest creature toughness: 25" in output
 
 def test_datamine_to_dict(datamine_instance):
     result = datamine_instance.to_dict()


### PR DESCRIPTION
* **What:** Updated `lib/utils.py` to ensure `from_unary()` correctly converts word-based unary exceptions (e.g., "thirty", "twenty~five") back into their decimal numeric strings. The associated `number_unary_regex` was also updated to include these exception patterns using a non-capturing group.
* **Why:** This ensures symmetry between `to_unary()` and `from_unary()`. Previously, `from_unary()` would leave these exception labels untouched, leading to inconsistencies in data analysis and display. This fix was verified by a full test suite run, and `tests/test_datalib.py` was updated to expect the correct numeric output.

---
*PR created automatically by Jules for task [16223683511073485179](https://jules.google.com/task/16223683511073485179) started by @RainRat*