### PR TITLE
[DOCS] Replace MTG jargon 'Vanilla' with plain English

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ python3 scripts/mtg_power.py data/AllPrintings.json --rarity common --rarity rar
 # Export balance analysis to JSON
 python3 scripts/mtg_power.py generated_cards.txt --json
 ```
-*   **Metric:** A rating of 1.0 represents a standard "Vanilla" 2/2 for 2 mana. Keywords like Flying or Indestructible increase the rating.
+*   **Metric:** A rating of 1.0 represents a basic 2/2 creature with no abilities for 2 mana. Keywords like Flying or Indestructible increase the rating.
 *   **Options:** Supports `--json`, `--csv`, and all standard **Advanced Filtering** flags.
 
 ### `mtg_asfan.py`

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -749,7 +749,7 @@ class Card:
 
             # Adjust for CMC
             # Formula: (P + T + Keywords) / (2 * max(1, CMC))
-            # A "Vanilla" 2/2 for 2 has a rating of (2+2)/(2*2) = 1.0
+            # A basic 2/2 creature for 2 mana has a rating of (2+2)/(2*2) = 1.0
             cmc = self.cost.cmc
             rating = score / (2 * max(1, cmc))
 

--- a/scripts/mtg_power.py
+++ b/scripts/mtg_power.py
@@ -22,7 +22,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 The Power Rating is a heuristic that evaluates a creature's combat efficiency.
-A "Vanilla" 2/2 for 2 mana has a rating of 1.0.
+A basic 2/2 creature (no abilities) for 2 mana has a rating of 1.0.
 
 How the rating is calculated:
   - Base Score: Power + Toughness


### PR DESCRIPTION
This PR improves the codebase's documentation by removing the obscure MTG idiom "Vanilla" and replacing it with plain English descriptions.

- **README.md**: Updated the power rating metric description.
- **scripts/mtg_power.py**: Updated the CLI help text (epilog).
- **lib/cardlib.py**: Updated the code comment for the `power_rating` property.

These changes make the tool's heuristics and documentation more accessible to a global audience.

---
*PR created automatically by Jules for task [17952496506739694731](https://jules.google.com/task/17952496506739694731) started by @RainRat*