### PR TITLE
[UI/UX] Modernize mtg_compare.py with smart baseline and enhanced metrics

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -532,6 +532,7 @@ class Datamine:
 
         self.avg_cmc = sum(c.cost.cmc for c in self.cards) / len(self.cards) if self.cards else 0
         self.avg_complexity = sum(c.complexity_score for c in self.cards) / len(self.cards) if self.cards else 0
+        self.avg_rating = sum(c.power_rating for c in self.cards) / len(self.cards) if self.cards else 0
 
         # Lexical metrics
         self.total_words = sum(self.global_word_counts.values())
@@ -864,6 +865,7 @@ class Datamine:
                 'textlines_max': max(self.by_textlines),
                 'avg_cmc': self.avg_cmc,
                 'avg_complexity': self.avg_complexity,
+                'avg_power_rating': self.avg_rating,
                 'avg_power': self.avg_power,
                 'avg_toughness': self.avg_toughness,
                 'total_words': self.total_words,

--- a/scripts/mtg_compare.py
+++ b/scripts/mtg_compare.py
@@ -86,7 +86,10 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Usage Examples:
-  # Compare official data vs generated cards
+  # Compare official data vs generated cards (automatically uses AllPrintings.json as baseline)
+  python3 scripts/mtg_compare.py generated.txt
+
+  # Compare two datasets explicitly
   python3 scripts/mtg_compare.py data/AllPrintings.json generated.txt
 
   # Compare multiple sets side-by-side
@@ -191,6 +194,17 @@ Usage Examples:
 
     args = parser.parse_args()
 
+    # UX Improvement: Smart Baseline Detection
+    # If only one input file is provided and it's not the default dataset,
+    # automatically prepend AllPrintings.json as a baseline if it exists.
+    if len(args.infiles) == 1 and args.infiles[0] != '-' and not args.infiles[0].endswith('AllPrintings.json'):
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        default_data = os.path.join(script_dir, '../data/AllPrintings.json')
+        if os.path.exists(default_data):
+            args.infiles.insert(0, default_data)
+        elif os.path.exists('data/AllPrintings.json'):
+            args.infiles.insert(0, 'data/AllPrintings.json')
+
     if args.sample > 0:
         args.shuffle = True
         args.limit = args.sample
@@ -216,7 +230,15 @@ Usage Examples:
     base_data = base_mine.to_dict()
 
     # Header row
-    filenames = [os.path.basename(f)[:15] for f in args.infiles]
+    filenames = []
+    for f in args.infiles:
+        name = os.path.basename(f)
+        for ext in ['.json', '.csv', '.txt', '.jsonl', '.xml', '.mse-set']:
+            if name.endswith(ext):
+                name = name[:-len(ext)]
+                break
+        filenames.append(name[:15])
+
     header = ["Metric", filenames[0]]
     for i in range(1, len(filenames)):
         header.append(filenames[i])
@@ -328,6 +350,8 @@ Usage Examples:
     add_metric_row("Avg CMC", ["stats", "avg_cmc"], reverse_color=True)
     add_metric_row("Avg Power", ["stats", "avg_power"])
     add_metric_row("Avg Toughness", ["stats", "avg_toughness"])
+    add_metric_row("Avg Complexity", ["stats", "avg_complexity"], reverse_color=True)
+    add_metric_row("Avg Rating", ["stats", "avg_power_rating"])
 
     # Color Distribution
     add_separator("Colors")

--- a/tests/test_mtg_compare.py
+++ b/tests/test_mtg_compare.py
@@ -89,6 +89,8 @@ class TestMtgCompare(unittest.TestCase):
                     self.assertIn("DATASET COMPARISON", output)
                     self.assertIn("Total Cards", output)
                     self.assertIn("Avg CMC", output)
+                    self.assertIn("Avg Complexity", output)
+                    self.assertIn("Avg Rating", output)
                     self.assertIn("1.0", output)
 
     def test_compare_main_two_files(self):
@@ -151,8 +153,9 @@ class TestMtgCompare(unittest.TestCase):
                     compare_main()
                     output = fake_out.getvalue()
                     self.assertIn("DATASET COMPARISON", output)
-                    self.assertIn("base.json", output)
-                    self.assertIn("target.json", output)
+                    # File extensions are now stripped in headers
+                    self.assertIn("base", output)
+                    self.assertIn("target", output)
                     self.assertIn("Avg CMC", output)
                     # Base CMC 2.0, Target CMC 4.0, Delta +2.0
                     self.assertIn("2.0", output)


### PR DESCRIPTION
This PR modernizes the `mtg_compare.py` utility to reduce friction for the common task of comparing new card data against the official Magic dataset.

### Key Improvements:

1.  **Friction Reduction (Smart Baseline):** The tool now detects if only one positional argument is provided. If `data/AllPrintings.json` exists, it is automatically prepended as the baseline dataset. This allows users to simply run `python3 scripts/mtg_compare.py generated.txt` instead of explicitly providing both paths.
2.  **Visual Clarity (Cleaner Headers):** Table headers now strip common extensions like `.json`, `.csv`, and `.txt` before applying the 15-character truncation. This results in much cleaner column labels (e.g., `AllPrintings` instead of `AllPrintings.jso`).
3.  **Information Density (New Metrics):** Added `Avg Complexity` and `Avg Rating` to the "Averages" section. These metrics are crucial for evaluating the "feel" and power level of generated sets compared to official data.
4.  **Core Library Support:** Updated the `Datamine` class in `lib/datalib.py` to calculate the average power rating across the dataset and export it via `to_dict()`.

### Verification:
- Updated the `tests/test_mtg_compare.py` suite to verify header stripping and new metric rows.
- Manually verified the "Smart Baseline" logic with sample datasets.
- Ran the full test suite (`python3 -m pytest`) to ensure no regressions in other tools using `datalib.py`.

---
*PR created automatically by Jules for task [10633013201570077964](https://jules.google.com/task/10633013201570077964) started by @RainRat*