### PR TITLE
[FIX] Preserve Planeswalker loyalty costs in MSE roundtrip

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -589,23 +589,24 @@ def mtg_open_mse_content(content, verbose=False):
         if subtypes:
             d['subtypes'] = subtypes.split()
 
-        # Planeswalker loyalty costs
-        if d.get('loyalty'):
-            for j in range(1, 10):
-                cost_key = f'loyalty cost {j}'
-                if cost_key in c:
-                    c[cost_key]
-                    # We assume abilities are separated by newlines in 'rule text'
-                    # if they were exported by our to_mse
-                    # But for general MSE, they might be in separate fields.
-                    # Our to_mse puts them all in 'rule text'.
-                    pass
-            # Reconstructing PW text from loyalty costs and rule text is hard in general
-            # but if it was exported by us, the costs are missing from 'rule text'.
-            # However, Card.fields_from_json handles 'text' which should contain the costs.
-            # So if we want it to work with our encoder, we should probably
-            # try to put the costs back into the text if they are separate.
-            # But wait, MSE's 'rule text' for PWs in our to_mse HAS the costs stripped.
+        # Reconstruct Planeswalker loyalty costs in text if present
+        if 'loyalty cost 1' in c:
+            text_lines = d['text'].split('\n')
+            reconstructed_lines = []
+            l_idx = 1
+            for line in text_lines:
+                # Skip empty lines that might have been preserved
+                if not line.strip():
+                    reconstructed_lines.append(line)
+                    continue
+
+                l_key = f'loyalty cost {l_idx}'
+                if l_key in c:
+                    reconstructed_lines.append(f"{c[l_key]}: {line}")
+                    l_idx += 1
+                else:
+                    reconstructed_lines.append(line)
+            d['text'] = '\n'.join(reconstructed_lines)
 
         # Handle split card (B-side)
         if 'name 2' in c:

--- a/tests/test_mse_roundtrip.py
+++ b/tests/test_mse_roundtrip.py
@@ -1,0 +1,70 @@
+import sys
+import os
+import unittest
+import json
+
+# Add project root to sys.path
+sys.path.append(os.getcwd())
+
+from lib.cardlib import Card
+from lib import jdecode, utils
+
+class TestMSERoundtrip(unittest.TestCase):
+
+    def test_planeswalker_roundtrip_loyalty_costs(self):
+        """
+        Tests that Planeswalker loyalty costs are preserved when exporting to MSE
+        and then reopening the MSE content.
+        """
+        pw_json = {
+            "name": "Jace, the Mind Sculptor",
+            "manaCost": "{2}{U}{U}",
+            "types": ["Planeswalker"],
+            "subtypes": ["Jace"],
+            "text": "+2: Look at the top card of target player's library.\n0: Draw three cards.\n-1: Return target creature to its owner's hand.\n-12: Exile all cards from target player's library.",
+            "loyalty": "3",
+            "rarity": "Mythic"
+        }
+        card = Card(pw_json)
+        mse_out = card.to_mse()
+
+        # Verify MSE output has loyalty cost fields
+        self.assertIn("loyalty cost 1: +2", mse_out)
+        self.assertIn("loyalty cost 2: 0", mse_out)
+        self.assertIn("loyalty cost 3: -1", mse_out)
+        self.assertIn("loyalty cost 4: -12", mse_out)
+
+        # Reopen
+        srcs, _ = jdecode.mtg_open_mse_content(mse_out)
+        self.assertIn("jace, the mind sculptor", srcs)
+        reopened_json = srcs["jace, the mind sculptor"][0]
+
+        # The bug is that reopened_json["text"] will lack the loyalty costs
+        expected_text = "+2: Look at the top card of target player's library.\n0: Draw three cards.\n-1: Return target creature to its owner's hand.\n-12: Exile all cards from target player's library."
+
+        # Normalized comparison (ignoring minor whitespace/case if needed, but let's be strict first)
+        self.assertEqual(reopened_json["text"].strip(), expected_text)
+
+    def test_planeswalker_roundtrip_with_x_costs(self):
+        pw_json = {
+            "name": "Nissa, Steward of Elements",
+            "manaCost": "{X}{G}{U}",
+            "types": ["Planeswalker"],
+            "text": "+X: Scry X.\n-10: You win.",
+            "loyalty": "X",
+            "rarity": "Mythic"
+        }
+        card = Card(pw_json)
+        mse_out = card.to_mse()
+
+        self.assertIn("loyalty cost 1: +X", mse_out)
+        self.assertIn("loyalty cost 2: -10", mse_out)
+
+        srcs, _ = jdecode.mtg_open_mse_content(mse_out)
+        reopened_json = srcs["nissa, steward of elements"][0]
+
+        expected_text = "+X: Scry X.\n-10: You win."
+        self.assertEqual(reopened_json["text"].strip(), expected_text)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Type: Bug Fix / New Coverage

### What:
This PR fixes a bug in the Magic Set Editor (MSE) import logic where Planeswalker loyalty costs were lost during round-tripping (exporting to MSE and then reopening). It also adds a new test suite `tests/test_mse_roundtrip.py` to ensure reliable handling of this scenario.

### Why:
When a Planeswalker card is exported to MSE format, its loyalty costs are stripped from the rules text and stored in separate `loyalty cost N` fields. Previously, the toolkit's MSE parser (`mtg_open_mse_content`) did not reconstruct the rules text using these fields, resulting in cards that lacked their essential mechanical costs. This fix restores the canonical MTG representation of these abilities upon import.

---
*PR created automatically by Jules for task [7888815535262100194](https://jules.google.com/task/7888815535262100194) started by @RainRat*