### PR TITLE
[UI/UX] Add metadata footer to detailed card oracle view

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -418,6 +418,41 @@ def handle_oracle(args):
             print(c.summary(ansi_color=use_color).replace('\u2014', '-'))
             print("-" * 40)
             print(c.get_text(ansi_color=use_color).replace('\u2014', '-'))
+
+            # Metadata Footer
+            footer_lines = []
+
+            # 1. Set and Number
+            set_info = ""
+            if c.set_code:
+                set_info = f"SET: {c.set_code.upper()}"
+                if c.number:
+                    set_info += f" #{c.number}"
+            if set_info:
+                footer_lines.append(set_info)
+
+            # 2. Color Identity
+            identity = c.color_identity
+            if not identity: identity = "C"
+            id_str = f"ID: {identity}"
+            if use_color:
+                colored_id = "".join([utils.colorize(char, utils.Ansi.get_color_color(char)) for char in identity])
+                id_str = f"ID: {colored_id}"
+            footer_lines.append(id_str)
+
+            # 3. Scores
+            score_line = f"SCORE: {c.complexity_score} \u2022 RATING: {c.power_rating:.3f}"
+            footer_lines.append(score_line)
+
+            # 4. Scryfall URL
+            url = utils.get_scryfall_url(c.set_code, c.number)
+            if url:
+                footer_lines.append(url)
+
+            if footer_lines:
+                print("-" * 40)
+                for line in footer_lines:
+                    print(line)
             print()
 
 # --- Extract Logic (from extract_one.py) ---


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** The detailed oracle view for cards provides rules text but lacks secondary metadata like set information, color identity, and heuristic scores, requiring users to run additional commands or look up data elsewhere.
* **Solution:** Added a structured metadata footer to the `oracle` command output that displays the Set Code, Collector Number, Color Identity, Complexity Score, Power Rating, and a Scryfall URL. This footer is visually separated from the rules text with an indented divider, improving information density and providing helpful context in a single view.

---
*PR created automatically by Jules for task [8158805296452280991](https://jules.google.com/task/8158805296452280991) started by @RainRat*