### PR TITLE
[UI/UX] Enhance Oracle detailed view with multi-face support and cleaner footer

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -448,9 +448,19 @@ def handle_oracle(args):
         elif show_summary:
             print(c.summary(ansi_color=use_color).replace('\u2014', '-'))
         else:
+            # Detailed View
             print(c.summary(ansi_color=use_color).replace('\u2014', '-'))
             print("  " + "-" * 40)
             print(c.get_text(ansi_color=use_color).replace('\u2014', '-'))
+
+            # Handle B-Sides in detailed view
+            curr = c.bside
+            while curr:
+                print("  " + "." * 40)
+                print(curr.summary(ansi_color=use_color).replace('\u2014', '-'))
+                print("  " + "-" * 40)
+                print(curr.get_text(ansi_color=use_color).replace('\u2014', '-'))
+                curr = curr.bside
 
             # Metadata Footer
             footer_lines = []
@@ -485,7 +495,7 @@ def handle_oracle(args):
             if footer_lines:
                 print("  " + "-" * 40)
                 for line in footer_lines:
-                    print(line)
+                    print("  " + line)
             print()
 
 # --- Extract Logic (from extract_one.py) ---


### PR DESCRIPTION
The `oracle` subcommand in `scripts/mtg_query.py` previously only displayed the front face of cards, which was insufficient for double-faced or split cards. This PR enhances the detailed view to recursively display all card faces. It also improves the visual hierarchy of the output by properly indenting the metadata footer (Set, ID, Score, Rating, URL) to match the rules text dividers.

### Changes:
- Modified `scripts/mtg_query.py`'s `handle_oracle` function to handle multi-faced cards via the `bside` link.
- Implemented a recursive display for all faces, including their summary lines and rules text.
- Standardized the footer indentation to improve scannability and aesthetics in the terminal.

Verified with `testdata/manual.json` (multi-faced test card) and `testdata/invasion_of_tarkir.json`. Full test suite passed (1022 tests).

---
*PR created automatically by Jules for task [11780263717483004204](https://jules.google.com/task/11780263717483004204) started by @RainRat*