### PR TITLE
Add card rulings support to Oracle lookup

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -552,6 +552,7 @@ class Card:
         # metadata for interoperability
         self.set_code = None
         self.number = None
+        self.rulings = []
 
         self.bside = None
         # format-independent view of processed input
@@ -562,6 +563,7 @@ class Card:
             self.json = src
             self.set_code = src.get('setCode')
             self.number = src.get('number')
+            self.rulings = src.get('rulings', [])
             if utils.json_field_bside in src:
                 self.bside = Card(src[utils.json_field_bside],
                                   fmt_ordered = fmt_ordered,
@@ -1618,6 +1620,9 @@ class Card:
             d['setCode'] = self.set_code
         if self.number:
             d['number'] = self.number
+
+        if self.rulings:
+            d['rulings'] = self.rulings
 
         if hasattr(self, 'box_id'):
             d['box_id'] = self.box_id

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -171,6 +171,12 @@ def _normalize_scryfall_card(card):
     _map_scryfall_face(card, card)
     if 'set' in card: card['setCode'] = card['set'].upper()
     if 'collector_number' in card: card['number'] = card['collector_number']
+    if 'rulings' in card:
+        # Map Scryfall rulings to MTGJSON style if needed
+        card['rulings'] = [{
+            'date': r.get('published_at', r.get('date', '')),
+            'text': r.get('comment', r.get('text', ''))
+        } for r in card['rulings']]
 
     # Handle multi-faced cards (Splits, Transforms, Adventures, etc.)
     if 'card_faces' in card:

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -486,6 +486,20 @@ def handle_oracle(args):
                 print("  " + "-" * 40)
                 for line in footer_lines:
                     print(line)
+
+            # Rulings
+            if not getattr(args, 'no_rulings', False) and c.rulings:
+                print()
+                rulings_header = "RULINGS"
+                if use_color:
+                    rulings_header = utils.colorize(rulings_header, utils.Ansi.BOLD + utils.Ansi.CYAN)
+                print(f"  {rulings_header}:")
+                for ruling in c.rulings:
+                    date = ruling.get('date', 'Unknown Date')
+                    text = ruling.get('text', '')
+                    if use_color:
+                        date = utils.colorize(date, utils.Ansi.BOLD)
+                    print(f"  - {date}: {text}")
             print()
 
 # --- Extract Logic (from extract_one.py) ---
@@ -746,6 +760,7 @@ def main():
     p_oracle.add_argument('-s', '--similar', action='store_true', help='Show mechanically similar cards instead of direct matches.')
     p_oracle.add_argument('-G', '--gatherer', action='store_true', help='Use Gatherer-style formatting.')
     p_oracle.add_argument('--full', action='store_true', help='Force full details even for multiple matches.')
+    p_oracle.add_argument('--no-rulings', action='store_true', help='Suppress display of card rulings.')
     p_oracle.set_defaults(func=handle_oracle)
 
     # Extract Subparser


### PR DESCRIPTION
This PR adds support for Magic: The Gathering card rulings to the toolkit.

**Key Changes:**
1.  **`lib/cardlib.py`**: Added `rulings` attribute to the `Card` class and ensured it is preserved during `to_dict()` serialization.
2.  **`lib/jdecode.py`**: Updated Scryfall normalization to map `published_at` and `comment` fields to the internal standard `date` and `text` keys.
3.  **`scripts/mtg_query.py`**: Updated the `oracle` subcommand to display a formatted "RULINGS" section when viewing card details. A new `--no-rulings` flag allows users to skip this section for a more compact output.

**Why:**
Rulings are a vital part of the Oracle database, providing necessary context for complex card interactions. Adding them significantly increases the utility of the toolkit for players and designers.

---
*PR created automatically by Jules for task [2984055694923119556](https://jules.google.com/task/2984055694923119556) started by @RainRat*