### PR TITLE
Fix logic bug in check_triggered validation

### DIFF
--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -291,9 +291,9 @@ def check_triggered(card):
     for line in card.text_lines:
         if 'when ' + utils.this_marker + ' enters the battlefield' in line.text:
             triggered += 1
-        if 'when ' + utils.this_marker + ' leaves the battlefield' in line.text:
+        elif 'when ' + utils.this_marker + ' leaves the battlefield' in line.text:
             triggered += 1
-        if 'when ' + utils.this_marker + ' dies' in line.text:
+        elif 'when ' + utils.this_marker + ' dies' in line.text:
             triggered += 1
         elif 'at the beginning' == line.text[:16] or 'when' == line.text[:4]:
             if 'from your graveyard' in line.text:


### PR DESCRIPTION
This PR fixes a logic bug in the `check_triggered` function within `scripts/mtg_validate.py`. 

### What
Converted a sequence of independent `if` statements into an `if/elif` chain for standard Magic: The Gathering triggered abilities.

### Why
The previous implementation had a logic bug where common triggers (like "enters the battlefield" or "leaves the battlefield") were being double-counted because they matched both their specific `if` block and a general `elif` block that checked for the "when" keyword. By consolidating these into a single `if/elif` structure, each rules text line (representing a single ability) is now correctly counted exactly once. This improves the accuracy of the validation report's internal counts and prevents confusing results during debugging.

All 1022 existing tests passed after the fix.

---
*PR created automatically by Jules for task [9985013039920059116](https://jules.google.com/task/9985013039920059116) started by @RainRat*