### PR TITLE
[FEAT] Add Fair Mana Value (Recommended CMC) heuristic

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -729,6 +729,34 @@ class Card:
         return score
 
     @property
+    def recommended_cmc(self):
+        """Calculates a heuristic 'Fair Mana Value' for creatures based on stats and keywords."""
+        recommendation = 0.0
+        if self.is_creature:
+            p = utils.from_unary_single(self.pt_p)
+            t = utils.from_unary_single(self.pt_t)
+
+            # Default to 0 if non-numeric (X, *, etc.)
+            p_val = float(p) if isinstance(p, (int, float)) else 0.0
+            t_val = float(t) if isinstance(t, (int, float)) else 0.0
+
+            score = p_val + t_val
+
+            # Add keyword bonuses
+            face_mechanics = self.get_face_mechanics()
+            for m in face_mechanics:
+                score += KEYWORD_WEIGHTS.get(m, 0.0)
+
+            # Formula: (P + T + Keywords) / 2.0
+            # A basic 2/2 creature without abilities is recommended at 2.0 mana.
+            recommendation = score / 2.0
+
+        if self.bside:
+            recommendation = max(recommendation, self.bside.recommended_cmc)
+
+        return round(recommendation, 1)
+
+    @property
     def power_rating(self):
         """Calculates a heuristic power rating for creatures relative to their CMC."""
         rating = 0.0
@@ -1332,12 +1360,25 @@ class Card:
         if ansi_color and mechanics_str:
             mechanics_str = utils.colorize(mechanics_str, utils.Ansi.CYAN)
 
+        # Recommended CMC (Fair MV) for creatures
+        fair_mv = ''
+        if self.is_creature:
+            val = self.recommended_cmc
+            fair_mv = f'Fair MV: {val}'
+            if ansi_color:
+                # Use Green if the card is "fair" or better (cost >= fair_mv)
+                # Use Red if the card is pushed (cost < fair_mv)
+                color = utils.Ansi.GREEN if self.cost.cmc >= val else utils.Ansi.RED
+                fair_mv = utils.colorize(fair_mv, utils.Ansi.BOLD + color)
+
         # Construct final summary string with consistent bullet separators
         res = f'{status}{rarity_indicator}{cardname}{coststr} \u2022 {typeline}'
         if stats:
             res += f' \u2022 {stats}'
         if mechanics_str:
             res += f' \u2022 {mechanics_str}'
+        if fair_mv:
+            res += f' \u2022 {fair_mv}'
 
         if self.bside:
             res += ' // ' + self.bside.summary(ansi_color=ansi_color)

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1106,13 +1106,20 @@ def handle_power(args):
     if args.json: print(json.dumps({'total': len(creatures), 'top': [{'name': c.display_name, 'rating': c.power_rating} for c in sc[:limit]]}, indent=2))
     else:
         utils.print_header("POWER BALANCE ANALYSIS", count=len(creatures), use_color=use_color)
-        rows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ["Name", "Rating", "Cost", "P/T", "Rarity"]]]
+        rows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ["Name", "Rating", "Cost", "Fair MV", "P/T", "Rarity"]]]
         for c in sc[:limit]:
             rt = str(c.power_rating)
             if use_color: rt = utils.colorize(rt, utils.Ansi.BOLD+utils.Ansi.GREEN if c.power_rating>1.2 else (utils.Ansi.RED if c.power_rating<0.8 else ""))
+
+            val = c.recommended_cmc
+            fair_mv = str(val)
+            if use_color:
+                color = utils.Ansi.GREEN if c.cost.cmc >= val else utils.Ansi.RED
+                fair_mv = utils.colorize(fair_mv, utils.Ansi.BOLD + color)
+
             rar = c.rarity_name
-            rows.append([utils.colorize(c.display_name, c._get_ansi_color()) if use_color else c.display_name, rt, c.cost.format(ansi_color=use_color), c._get_pt_display(ansi_color=use_color, include_parens=False), utils.colorize(rar, utils.Ansi.get_rarity_color(rar)) if use_color else rar])
-        datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','l','r','l']), indent=4)
+            rows.append([utils.colorize(c.display_name, c._get_ansi_color()) if use_color else c.display_name, rt, c.cost.format(ansi_color=use_color), fair_mv, c._get_pt_display(ansi_color=use_color, include_parens=False), utils.colorize(rar, utils.Ansi.get_rarity_color(rar)) if use_color else rar])
+        datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','l','r','r','l']), indent=4)
 
 def handle_archetypes(args):
     cards = cli_utils.load_and_filter_cards(args)

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -52,6 +52,7 @@ FIELD_MAP = {
     'box': {'header': 'Box', 'align': 'r', 'aliases': ['box_id']},
     'complexity': {'header': 'Score', 'align': 'r', 'aliases': ['score']},
     'rating': {'header': 'Rating', 'align': 'r', 'aliases': ['power_rating']},
+    'fair_cmc': {'header': 'Fair MV', 'align': 'r', 'aliases': ['fcmc', 'fair_cost', 'fair_mv', 'recommended_cmc']},
     'summary': {'header': 'Summary', 'align': 'l', 'aliases': ['view']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
@@ -149,6 +150,13 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         res = str(card.power_rating)
         if ansi_color:
             res = utils.colorize(res, utils.Ansi.BOLD + utils.Ansi.RED)
+        return res
+    elif canon == 'fair_cmc':
+        val = card.recommended_cmc
+        res = str(val) if val > 0 else ""
+        if res and ansi_color:
+            color = utils.Ansi.GREEN if card.cost.cmc >= val else utils.Ansi.RED
+            res = utils.colorize(res, utils.Ansi.BOLD + color)
         return res
     elif canon == 'summary':
         return card.summary(ansi_color=ansi_color).replace('\u2014', '-')
@@ -475,6 +483,8 @@ def handle_oracle(args):
 
             # 3. Scores
             score_line = f"SCORE: {c.complexity_score} \u2022 RATING: {c.power_rating:.3f}"
+            if c.is_creature:
+                score_line += f" \u2022 FAIR MV: {c.recommended_cmc}"
             footer_lines.append(score_line)
 
             # 4. Scryfall URL

--- a/tests/test_recommended_cmc.py
+++ b/tests/test_recommended_cmc.py
@@ -1,0 +1,53 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+# Ensure lib and scripts are in path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+if libdir not in sys.path:
+    sys.path.append(libdir)
+
+import cardlib
+import utils
+
+class TestRecommendedCMC(unittest.TestCase):
+    def test_basic_creature(self):
+        # 2/2 for 2 mana
+        d = {'name': 'Bears', 'types': ['Creature'], 'power': '2', 'toughness': '2', 'manaCost': '{1}{G}'}
+        c = cardlib.Card(d)
+        self.assertEqual(c.recommended_cmc, 2.0)
+        self.assertEqual(c.power_rating, 1.0)
+
+    def test_keywords(self):
+        # 2/1 for 1 mana with Flying (1.5)
+        # Score = 2 + 1 + 1.5 = 4.5
+        # Fair MV = 4.5 / 2 = 2.25 -> 2.3
+        d = {'name': 'Bird', 'types': ['Creature'], 'power': '2', 'toughness': '1', 'manaCost': '{U}', 'text': 'Flying'}
+        c = cardlib.Card(d)
+        self.assertEqual(c.recommended_cmc, 2.2)
+
+    def test_negative_keywords(self):
+        # 4/4 for 4 mana with Defender (-1.0)
+        # Score = 4 + 4 - 1.0 = 7.0
+        # Fair MV = 7.0 / 2 = 3.5
+        d = {'name': 'Wall', 'types': ['Creature'], 'power': '4', 'toughness': '4', 'manaCost': '{4}', 'text': 'Defender'}
+        c = cardlib.Card(d)
+        self.assertEqual(c.recommended_cmc, 3.5)
+
+    def test_non_creature(self):
+        d = {'name': 'Growth', 'types': ['Instant'], 'manaCost': '{G}', 'text': 'Target creature gets +3/+3.'}
+        c = cardlib.Card(d)
+        self.assertEqual(c.recommended_cmc, 0.0)
+
+    def test_bside(self):
+        # Front: 2/2 (2.0), Back: 4/4 (4.0)
+        d = {
+            'name': 'Small', 'types': ['Creature'], 'power': '2', 'toughness': '2', 'manaCost': '{1}{G}',
+            'bside': {'name': 'Big', 'types': ['Creature'], 'power': '4', 'toughness': '4', 'manaCost': '{4}{G}'}
+        }
+        c = cardlib.Card(d)
+        self.assertEqual(c.recommended_cmc, 4.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a "Fair Mana Value" (Fair MV) heuristic to the toolkit, providing automated mana cost recommendations for creature cards based on their combat statistics and mechanical abilities.

### Key Changes:
1.  **Core Logic (`lib/cardlib.py`):**
    *   Added a `recommended_cmc` property to the `Card` class. It uses the existing `KEYWORD_WEIGHTS` and a standard `(Power + Toughness + Keywords) / 2.0` formula to estimate a balanced mana cost.
    *   Updated `Card.summary()` to include the Fair MV, providing immediate feedback in tools like `mtg_forge`.

2.  **Query Integration (`scripts/mtg_query.py`):**
    *   Added `fair_cmc` (and aliases `fair_mv`, `fcmc`, `recommended_cmc`) to the searchable fields.
    *   Updated the `oracle` view to display the Fair MV in the metadata footer alongside existing complexity and power ratings.

3.  **Analysis Enhancement (`scripts/mtg_analyze.py`):**
    *   Added a "Fair MV" column to the `power` analysis table, allowing for side-by-side comparison of actual vs. recommended costs.

4.  **Testing:**
    *   Created `tests/test_recommended_cmc.py` with comprehensive test cases for various creature configurations, non-creatures, and multi-faced cards.

This feature provides significant value for card designers and analysts by automating the first pass of balance evaluation.

---
*PR created automatically by Jules for task [16091427970385402895](https://jules.google.com/task/16091427970385402895) started by @RainRat*