### PR TITLE
Fix IndentationError in mtg_query.py oracle view

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -512,7 +512,8 @@ def handle_oracle(args):
             if url:
                 footer_lines.append(url)
 
-                    print("  " + line)
+            for line in footer_lines:
+                print("  " + line)
 
             # Rulings
             if not getattr(args, 'no_rulings', False) and c.rulings:


### PR DESCRIPTION
* **What**: Restored the missing `for line in footer_lines:` loop header in the `oracle` subcommand of `scripts/mtg_query.py` and corrected the indentation of the subsequent print statement.
* **Why**: The script was previously failing with a syntax error (`IndentationError: unexpected indent`) at runtime. This fix ensures the metadata footer is correctly printed and the script is functional. No breaking changes were introduced, and existing behavior is restored.

---
*PR created automatically by Jules for task [7004691595118350665](https://jules.google.com/task/7004691595118350665) started by @RainRat*