### PR TITLE
[TEST] Improve test coverage for sortlib and fix query/analyze bugs

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -338,7 +338,7 @@ def analyze_lexicon(cards, top=10, min_len=4, top_n=None):
         stats[col] = {'top': sorted([w for w in dist if f[w]>=2 or tot_c<50], key=lambda w: dist[w], reverse=True)[:top], 'freq': f, 'scores': dist, 'total': tot_c}
     res = {
         'total_cards': len(cards),
-        'total': len(cards),
+        'total': tot_g,
         'global_freq': gf,
         'color_stats': stats,
     }

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -512,7 +512,8 @@ def handle_oracle(args):
             if url:
                 footer_lines.append(url)
 
-                    print("  " + line)
+            for line in footer_lines:
+                print("  " + line)
 
             # Rulings
             if not getattr(args, 'no_rulings', False) and c.rulings:

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -129,7 +129,7 @@ def test_card_summary(sample_card_json):
 
     # Test plain summary
     output = card.summary()
-    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2) • Flying"
+    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2) • Flying • Fair MV: 1.8"
 
     # Test colored summary
     colored_output = card.summary(ansi_color=True)
@@ -139,8 +139,9 @@ def test_card_summary(sample_card_json):
     expected_pt = utils.colorize("(0/2)", utils.Ansi.RED)
     expected_rarity_indicator = utils.colorize("[U]", utils.Ansi.BOLD + utils.Ansi.CYAN)
     expected_mechanics = utils.colorize("Flying", utils.Ansi.CYAN)
+    expected_fair_mv = utils.colorize("Fair MV: 1.8", utils.Ansi.BOLD + utils.Ansi.RED)
 
-    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt} • {expected_mechanics}"
+    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt} • {expected_mechanics} • {expected_fair_mv}"
     assert colored_output == expected_colored_summary
 
 def test_card_summary_status_indicators():

--- a/tests/test_sortlib_criterion_gap.py
+++ b/tests/test_sortlib_criterion_gap.py
@@ -1,0 +1,17 @@
+import unittest
+import os
+import sys
+
+# Ensure lib is in path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib')))
+from sortlib import sort_cards
+
+class TestSortlibCriterionGap(unittest.TestCase):
+    def test_sort_cards_unknown_criterion(self):
+        # Line 118: covers the 'else: return cards' branch when an unknown criterion is passed.
+        cards = ["card1", "card2"]
+        sorted_cards = sort_cards(cards, "unknown_criterion")
+        self.assertEqual(cards, sorted_cards)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**PR Title:** [TEST] Improve test coverage for sortlib and fix query/analyze bugs

**Description:**
* **Type:** New Coverage / Bug Fix
* **What:** Added a new test `tests/test_sortlib_criterion_gap.py` to cover the fallback branch for unknown criteria in `lib/sortlib.py`. Fixed an `IndentationError` in `scripts/mtg_query.py` that caused test collection to fail. Fixed a bug in `scripts/mtg_analyze.py` where Lexicon analysis reported card count instead of word count in its summary. Updated `tests/test_cardlib.py` to reflect the current `Card.summary()` format.
* **Why:** The `IndentationError` was a critical bug blocking all tests using `mtg_query.py`. The `lexicon` bug caused functional test failures in `tests/test_mtg_lexicon.py`. The new test for `sortlib` improves core library coverage.

---
*PR created automatically by Jules for task [13479106080512878495](https://jules.google.com/task/13479106080512878495) started by @RainRat*