### PR TITLE
[UI/UX] Standardize oracle output indentation and fix metadata footer

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -452,12 +452,12 @@ def handle_oracle(args):
 
     for c in display_cards:
         if getattr(args, 'gatherer', False):
-            print(c.format(gatherer=True, ansi_color=use_color))
+            print("  " + c.format(gatherer=True, ansi_color=use_color).replace('\n', '\n  '))
         elif show_summary:
-            print(c.summary(ansi_color=use_color).replace('\u2014', '-'))
+            print("  " + c.summary(ansi_color=use_color).replace('\u2014', '-'))
         else:
             # Detailed View
-            print(c.summary(ansi_color=use_color).replace('\u2014', '-'))
+            print("  " + c.summary(ansi_color=use_color).replace('\u2014', '-'))
 
             def print_face(face, is_bside=False):
                 if is_bside:
@@ -474,7 +474,7 @@ def handle_oracle(args):
                 else:
                     print("  " + "-" * 40)
 
-                print(face.get_text(ansi_color=use_color).replace('\u2014', '-'))
+                print("  " + face.get_text(ansi_color=use_color).replace('\u2014', '-').replace('\n', '\n  '))
                 if face.bside:
                     print_face(face.bside, is_bside=True)
 
@@ -512,7 +512,8 @@ def handle_oracle(args):
             if url:
                 footer_lines.append(url)
 
-                    print("  " + line)
+            for line in footer_lines:
+                print("  " + line)
 
             # Rulings
             if not getattr(args, 'no_rulings', False) and c.rulings:


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** The `oracle` command output in `scripts/mtg_query.py` had inconsistent indentation. Card summaries and rules text were flush with the left margin, while headers and metadata footers were indented or used dividers. This created poor visual hierarchy. Additionally, the metadata footer had a logic error that caused an `IndentationError` and failed to display all lines.
* **Solution:** Standardized all output components (summaries, Gatherer view, and rules text lines) with a consistent 2-space indentation gutter. This aligns the content with the section dividers and headers, significantly improving readability and visual hierarchy. Fixed the `IndentationError` in the footer by properly wrapping the print statement in a loop.

---
*PR created automatically by Jules for task [166561646044044787](https://jules.google.com/task/166561646044044787) started by @RainRat*