### PR TITLE
[TEST] Fix core utility bugs and increase query tool coverage

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -259,14 +259,26 @@ def format_delta(val, base_val, is_percent=False, use_color=False, reverse_color
             res = utils.colorize(res, color)
     return res
 
-def summarize_data(infile, verbose=False, grep=None, vgrep=None, 
-                   sets=None, rarities=None, colors=None, cmcs=None, 
+def summarize_data(infile, verbose=False, grep=None, vgrep=None,
+                   grep_name=None, vgrep_name=None,
+                   grep_types=None, vgrep_types=None,
+                   grep_text=None, vgrep_text=None,
+                   grep_cost=None, vgrep_cost=None,
+                   grep_pt=None, vgrep_pt=None,
+                   grep_loyalty=None, vgrep_loyalty=None,
+                   sets=None, rarities=None, colors=None, cmcs=None,
                    mechanics=None, identities=None, id_counts=None,
                    limit=0, shuffle=False, seed=None, quiet=False, oname=None, decklist_file=None,
                    top=10, booster=0, sort=None, reverse_sort=False, box=0,
                    json_out=False, outliers=False, dump_all=False, use_color=None):
-    cards = jdecode.mtg_open_file(infile, verbose=verbose, grep=grep, vgrep=vgrep, 
-                                  sets=sets, rarities=rarities, colors=colors, cmcs=cmcs, 
+    cards = jdecode.mtg_open_file(infile, verbose=verbose, grep=grep, vgrep=vgrep,
+                                  grep_name=grep_name, vgrep_name=vgrep_name,
+                                  grep_types=grep_types, vgrep_types=vgrep_types,
+                                  grep_text=grep_text, vgrep_text=vgrep_text,
+                                  grep_cost=grep_cost, vgrep_cost=vgrep_cost,
+                                  grep_pt=grep_pt, vgrep_pt=vgrep_pt,
+                                  grep_loyalty=grep_loyalty, vgrep_loyalty=vgrep_loyalty,
+                                  sets=sets, rarities=rarities, colors=colors, cmcs=cmcs,
                                   mechanics=mechanics, identities=identities, id_counts=id_counts,
                                   limit=limit, shuffle=shuffle, seed=seed, decklist_file=decklist_file,
                                   booster=booster, box=box)
@@ -338,7 +350,7 @@ def analyze_lexicon(cards, top=10, min_len=4, top_n=None):
         stats[col] = {'top': sorted([w for w in dist if f[w]>=2 or tot_c<50], key=lambda w: dist[w], reverse=True)[:top], 'freq': f, 'scores': dist, 'total': tot_c}
     res = {
         'total_cards': len(cards),
-        'total': len(cards),
+        'total': tot_g,
         'global_freq': gf,
         'color_stats': stats,
     }

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -512,7 +512,8 @@ def handle_oracle(args):
             if url:
                 footer_lines.append(url)
 
-                    print("  " + line)
+            for line in footer_lines:
+                print("  " + line)
 
             # Rulings
             if not getattr(args, 'no_rulings', False) and c.rulings:

--- a/tests/test_cardlib.py
+++ b/tests/test_cardlib.py
@@ -129,7 +129,7 @@ def test_card_summary(sample_card_json):
 
     # Test plain summary
     output = card.summary()
-    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2) • Flying"
+    assert output == "[U] Ornithopter {0} • Artifact Creature — Thopter • (0/2) • Flying • Fair MV: 1.8"
 
     # Test colored summary
     colored_output = card.summary(ansi_color=True)
@@ -139,8 +139,9 @@ def test_card_summary(sample_card_json):
     expected_pt = utils.colorize("(0/2)", utils.Ansi.RED)
     expected_rarity_indicator = utils.colorize("[U]", utils.Ansi.BOLD + utils.Ansi.CYAN)
     expected_mechanics = utils.colorize("Flying", utils.Ansi.CYAN)
+    expected_fair_mv = utils.colorize("Fair MV: 1.8", utils.Ansi.BOLD + utils.Ansi.RED)
 
-    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt} • {expected_mechanics}"
+    expected_colored_summary = f"{expected_rarity_indicator} {expected_name} {expected_cost} • {expected_type} • {expected_pt} • {expected_mechanics} • {expected_fair_mv}"
     assert colored_output == expected_colored_summary
 
 def test_card_summary_status_indicators():

--- a/tests/test_mtg_query_extract.py
+++ b/tests/test_mtg_query_extract.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import sys
+import io
+import json
+import os
+from scripts.mtg_query import handle_extract
+
+class TestMtgQueryExtract(unittest.TestCase):
+    def setUp(self):
+        self.args = MagicMock()
+        self.args.infile = 'test.json'
+        self.args.set_code = 'TEST'
+        self.args.card_name = 'Grizzly Bears'
+        self.args.outfile = None
+        self.args.verbose = False
+        self.args.color = False
+        self.args.quiet = False
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{"data": {"TEST": {"cards": [{"name": "Grizzly Bears"}]}}}')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_handle_extract_success(self, mock_stdout, mock_file):
+        handle_extract(self.args)
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output['name'], 'Grizzly Bears')
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{"not_data": {}}')
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_handle_extract_missing_data_key(self, mock_stderr, mock_file):
+        handle_extract(self.args)
+        self.assertIn("Error: 'data' key not found", mock_stderr.getvalue())
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{"data": {"OTHER": {}}}')
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_handle_extract_set_not_found(self, mock_stderr, mock_file):
+        handle_extract(self.args)
+        self.assertIn("Error: Set code 'TEST' not found.", mock_stderr.getvalue())
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{"data": {"TEST": {"cards": [{"name": "Pikachu"}]}}}')
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_handle_extract_card_not_found(self, mock_stderr, mock_file):
+        handle_extract(self.args)
+        self.assertIn("Error: Card 'Grizzly Bears' not found.", mock_stderr.getvalue())
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{"data": {"TEST": {"cards": [{"name": "Grizzly Bears"}]}}}')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_handle_extract_verbose(self, mock_stderr, mock_stdout, mock_file):
+        self.args.verbose = True
+        handle_extract(self.args)
+        self.assertIn("Loading test.json...", mock_stderr.getvalue())
+        self.assertIn("Grizzly Bears", mock_stdout.getvalue())
+
+    @patch('builtins.open', new_callable=mock_open, read_data='{"data": {"ABC": {"cards": [{"name": "Grizzly Bears"}]}}}')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_handle_extract_any_set(self, mock_stdout, mock_file):
+        self.args.set_code = 'ANY'
+        handle_extract(self.args)
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output['name'], 'Grizzly Bears')
+
+    @patch('builtins.open', side_effect=Exception("File not found"))
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_handle_extract_exception(self, mock_stderr, mock_file):
+        handle_extract(self.args)
+        self.assertIn("Error: File not found", mock_stderr.getvalue())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR addresses several critical issues discovered in the codebase:

1. **Bug Fix (scripts/mtg_query.py):** Corrected an `IndentationError` in the `oracle` subcommand metadata footer logic that prevented the script from running.
2. **Bug Fix (scripts/mtg_analyze.py):** Updated the `summarize_data` function signature to include all standard filter arguments passed by `handle_summary`, resolving a `TypeError`.
3. **Bug Fix (scripts/mtg_analyze.py):** Fixed `analyze_lexicon` to return the actual word count in its `total` field, ensuring "Insufficient card text" warnings are correctly triggered when applicable.
4. **Test Maintenance (tests/test_cardlib.py):** Updated summary assertions to include the "Fair MV" (Recommended CMC) field, aligning tests with the current library implementation.
5. **New Coverage (tests/test_mtg_query_extract.py):** Implemented a comprehensive test suite for the `extract` subcommand in `mtg_query.py`, covering success, missing data key, set not found, and card not found scenarios.

All 1051 tests passed.

---
*PR created automatically by Jules for task [16421208388949684878](https://jules.google.com/task/16421208388949684878) started by @RainRat*