### PR TITLE
[FEAT] Side-by-side card comparison in mtg_query.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,8 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `search`: Search card data and extract specific fields.
 *   `oracle`: Look up a card by name and display its full rules text.
 *   `sets`: List and filter sets in an MTGJSON file.
-*   `functional`: Identify and group functional reprints.
+*   `functional`: Identify and group cards with the same mechanics but different names.
+*   `compare`: Compare two cards side-by-side by name to identify differences.
 *   `extract`: Extract a single card object from a large JSON database.
 
 ---
@@ -502,6 +503,19 @@ python3 scripts/mtg_query.py functional
 
 # Create a deduplicated dataset
 python3 scripts/mtg_query.py functional --dedupe unique_cards.json
+```
+
+---
+
+#### **Subcommand: `compare`**
+Side-by-side card comparison for identifying design differences. Supports fuzzy matching and multi-faced cards.
+
+```bash
+# Compare two cards by name
+python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre"
+
+# Compare two cards in a specific file and highlight differences
+python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
 ```
 
 ---

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -763,6 +763,118 @@ def handle_functional(args):
             print(group[0].summary(ansi_color=use_color).replace('\u2014', '-'))
             print()
 
+# --- Compare Logic ---
+
+def handle_compare_cards(args):
+    # Smart positional argument handling for infile
+    if args.card2 and os.path.exists(args.card2) and (args.infile == '-' or not os.path.exists(args.infile)):
+        temp = args.card2
+        args.card2 = args.infile if args.infile != '-' else None
+        args.infile = temp
+
+    # Load all cards to perform fuzzy matching
+    all_cards = cli_utils.load_and_filter_cards(args)
+    if not all_cards:
+        if not args.quiet:
+            print("No cards found in the dataset.", file=sys.stderr)
+        return
+
+    def resolve_card(name, pool):
+        if not name: return None
+        name_sanitized = name.lower().replace('-', utils.dash_marker)
+
+        # Expand pool to include all faces
+        expanded_pool = []
+        for c in pool:
+            expanded_pool.append(c)
+            curr = c
+            while curr.bside:
+                expanded_pool.append(curr.bside)
+                curr = curr.bside
+
+        # 1. Exact match
+        matches = [c for c in expanded_pool if c.name.lower() == name_sanitized]
+        if matches: return matches[0]
+
+        # 2. Partial match
+        matches = [c for c in expanded_pool if name_sanitized in c.name.lower()]
+        if matches: return matches[0]
+
+        # 3. Fuzzy match
+        search_names = {c.name.lower(): c for c in expanded_pool}
+        # Use a more lenient cutoff or also check titlecased versions for fuzzy matching
+        close = difflib.get_close_matches(name.lower().replace('-', ' '), list(search_names.keys()), n=1, cutoff=0.5)
+        if close:
+            if not args.quiet:
+                print(f"Notice: Card '{name}' not found. Using best match: {cardlib.titlecase(close[0].replace(utils.dash_marker, '-'))}", file=sys.stderr)
+            return search_names[close[0]]
+
+        return None
+
+    card1 = resolve_card(args.card1, all_cards)
+    card2 = resolve_card(args.card2, all_cards)
+
+    if not card1 or not card2:
+        if not card1 and not args.quiet:
+            print(f"Error: Could not find card '{args.card1}'", file=sys.stderr)
+        if not card2 and not args.quiet:
+            print(f"Error: Could not find card '{args.card2}'", file=sys.stderr)
+        return
+
+    use_color = args.color if args.color is not None else sys.stdout.isatty()
+
+    if args.json:
+        diff_data = {
+            'card1': card1.to_dict(),
+            'card2': card2.to_dict(),
+        }
+        print(json.dumps(diff_data, indent=4))
+    else:
+        if not args.quiet:
+            utils.print_header("CARD COMPARISON", use_color=use_color)
+
+        fields = [
+            ('Name', 'name'),
+            ('Cost', 'cost'),
+            ('CMC', 'cmc'),
+            ('Type', 'type'),
+            ('Stats', 'stats'),
+            ('Rarity', 'rarity'),
+            ('Mechanics', 'mechanics'),
+            ('Actions', 'actions'),
+            ('Fair MV', 'fair_cmc'),
+            ('Rating', 'rating'),
+            ('Complexity', 'complexity'),
+            ('Text', 'text')
+        ]
+
+        rows = []
+        header = ["Field", cardlib.titlecase(card1.name.replace(utils.dash_marker, '-')), cardlib.titlecase(card2.name.replace(utils.dash_marker, '-'))]
+        if use_color:
+            header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+        rows.append(header)
+
+        for label, field in fields:
+            v1 = get_field_value(card1, field, ansi_color=False)
+            v2 = get_field_value(card2, field, ansi_color=False)
+
+            display_v1 = get_field_value(card1, field, ansi_color=use_color)
+            display_v2 = get_field_value(card2, field, ansi_color=use_color)
+
+            # Strip newlines for table view for better alignment
+            if field == 'text':
+                display_v1 = display_v1.replace('\n', ' ')
+                display_v2 = display_v2.replace('\n', ' ')
+
+            if v1 != v2:
+                if use_color:
+                    label = utils.colorize(label, utils.Ansi.BOLD + utils.Ansi.YELLOW)
+
+            rows.append([label, display_v1, display_v2])
+
+        datalib.add_separator_row(rows)
+        datalib.printrows(datalib.padrows(rows, aligns=['l', 'l', 'l']), indent=2)
+
 # --- Main Entry Point ---
 
 def main():
@@ -912,6 +1024,28 @@ Usage Examples:
     cli_utils.add_standard_filters(p_functional)
     cli_utils.add_standard_output_args(p_functional)
     p_functional.set_defaults(func=handle_functional)
+
+    # Compare Subparser
+    p_compare = subparsers.add_parser(
+        'compare',
+        help='Compare two cards side-by-side by name.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Usage Examples:
+  # Compare two cards by name
+  python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre"
+
+  # Compare two cards in a specific file
+  python3 scripts/mtg_query.py compare "Grizzly Bears" "Balduvian Bears" my_cards.json
+"""
+    )
+    p_compare.add_argument('card1', help='First card name to compare.')
+    p_compare.add_argument('card2', help='Second card name to compare.')
+    p_compare.add_argument('infile', nargs='?', default='-',
+                         help='Input card data. Defaults to data/AllPrintings.json if available.')
+    cli_utils.add_standard_filters(p_compare)
+    cli_utils.add_standard_output_args(p_compare)
+    p_compare.set_defaults(func=handle_compare_cards)
 
     args = parser.parse_args()
     if not args.command:

--- a/tests/test_mtg_query_compare.py
+++ b/tests/test_mtg_query_compare.py
@@ -1,0 +1,49 @@
+import subprocess
+import json
+import os
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "../scripts/mtg_query.py")
+
+def test_query_compare_basic():
+    """Test basic card comparison."""
+    cmd = ["python3", SCRIPT_PATH, "compare", "Uthros", "Invasion of Alara", "testdata/", "--no-color"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "CARD COMPARISON" in result.stdout
+    assert "Uthros Research Craft" in result.stdout
+    assert "Invasion of Alara" in result.stdout
+    assert "CMC" in result.stdout
+    assert "Fair MV" in result.stdout
+
+def test_query_compare_json():
+    """Test JSON output for comparison."""
+    cmd = ["python3", SCRIPT_PATH, "compare", "Uthros", "Invasion", "testdata/", "--json"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert "card1" in data
+    assert "card2" in data
+    assert data["card1"]["name"] == "Uthros Research Craft"
+    assert data["card2"]["name"] == "Invasion of Alara"
+
+def test_query_compare_fuzzy():
+    """Test fuzzy matching in comparison."""
+    # "Uthros Research" is a fuzzy match for "Uthros Research Craft"
+    cmd = ["python3", SCRIPT_PATH, "compare", "Uthros Research", "Alara", "testdata/", "--no-color"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Uthros Research Craft" in result.stdout
+    assert "Invasion of Alara" in result.stdout
+
+def test_query_compare_multi_face():
+    """Test comparison of multiple card faces."""
+    # Compare front and back of the same card
+    cmd = ["python3", SCRIPT_PATH, "compare", "Double Front", "Double Back", "testdata/manual.json", "--no-color"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Double Front // Double Back" in result.stdout
+    assert "Double Back" in result.stdout
+    # Check that they are identified as different in the table
+    # Since Double Front matches the whole card (both faces) and Double Back matches only one face
+    assert "1/1 // 2/2" in result.stdout
+    assert "2/2" in result.stdout


### PR DESCRIPTION
Added a new `compare` subcommand to `scripts/mtg_query.py` for side-by-side card evaluation. This tool bridges the gap between searching and individual lookup, providing a convenient way to analyze differences in stats, mechanics, and design metrics between two cards.

---
*PR created automatically by Jules for task [6160510288709543130](https://jules.google.com/task/6160510288709543130) started by @RainRat*