### PR TITLE
Consolidate duplicated power score calculation in Card class

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -793,24 +793,29 @@ class Card:
 
         return score
 
+    def _get_face_power_score(self):
+        """Calculates the base power score for this card face based on stats and keywords."""
+        p = utils.from_unary_single(self.pt_p)
+        t = utils.from_unary_single(self.pt_t)
+
+        # Default to 0 if non-numeric (X, *, etc.)
+        p_val = float(p) if isinstance(p, (int, float)) else 0.0
+        t_val = float(t) if isinstance(t, (int, float)) else 0.0
+
+        score = p_val + t_val
+
+        # Add keyword bonuses
+        face_mechanics = self.get_face_mechanics()
+        for m in face_mechanics:
+            score += KEYWORD_WEIGHTS.get(m, 0.0)
+        return score
+
     @property
     def recommended_cmc(self):
         """Calculates a heuristic 'Fair Mana Value' for creatures based on stats and keywords."""
         recommendation = 0.0
         if self.is_creature:
-            p = utils.from_unary_single(self.pt_p)
-            t = utils.from_unary_single(self.pt_t)
-
-            # Default to 0 if non-numeric (X, *, etc.)
-            p_val = float(p) if isinstance(p, (int, float)) else 0.0
-            t_val = float(t) if isinstance(t, (int, float)) else 0.0
-
-            score = p_val + t_val
-
-            # Add keyword bonuses
-            face_mechanics = self.get_face_mechanics()
-            for m in face_mechanics:
-                score += KEYWORD_WEIGHTS.get(m, 0.0)
+            score = self._get_face_power_score()
 
             # Formula: (P + T + Keywords) / 2.0
             # A basic 2/2 creature without abilities is recommended at 2.0 mana.
@@ -826,19 +831,7 @@ class Card:
         """Calculates a heuristic power rating for creatures relative to their CMC."""
         rating = 0.0
         if self.is_creature:
-            p = utils.from_unary_single(self.pt_p)
-            t = utils.from_unary_single(self.pt_t)
-
-            # Default to 0 if non-numeric (X, *, etc.)
-            p_val = float(p) if isinstance(p, (int, float)) else 0.0
-            t_val = float(t) if isinstance(t, (int, float)) else 0.0
-
-            score = p_val + t_val
-
-            # Add keyword bonuses
-            face_mechanics = self.get_face_mechanics()
-            for m in face_mechanics:
-                score += KEYWORD_WEIGHTS.get(m, 0.0)
+            score = self._get_face_power_score()
 
             # Adjust for CMC
             # Formula: (P + T + Keywords) / (2 * max(1, CMC))


### PR DESCRIPTION
This PR addresses a duplication issue in `lib/cardlib.py` where the logic for calculating a creature's heuristic power score was repeated across two properties.

### Changes:
- **What:** Extracted the logic for summing power, toughness, and keyword weights into a new private method `_get_face_power_score()`.
- **Why:** To follow DRY (Don't Repeat Yourself) principles, making the code easier to maintain and reducing the risk of logic drift between the two properties.
- **Safety:** The implementation is identical to the original logic. 34 relevant tests in `tests/test_cardlib.py`, `tests/test_recommended_cmc.py`, and other related suites passed successfully, confirming no functional changes or regressions.

---
*PR created automatically by Jules for task [3907383267111503592](https://jules.google.com/task/3907383267111503592) started by @RainRat*