### PR TITLE
[DOCS] Improve synergy subcommand help text and define Lift Score

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1472,7 +1472,22 @@ Examples:
     p_me.set_defaults(func=handle_mechanics)
 
     # synergy
-    p_sy = subparsers.add_parser('synergy', help='Analyze how mechanics appear together (co-occurrence).')
+    p_sy = subparsers.add_parser(
+        'synergy',
+        help='Analyze how mechanics appear together (co-occurrence).',
+        description="""
+Analyzes how different mechanics (like Flying, Kicker, or Flashback) appear
+together on the same cards. It identifies frequent pairings and calculates
+a 'Lift Score' to measure the interaction between them.
+
+The Lift Score measures if two mechanics appear together more often than
+expected by chance:
+- Score > 1.0: The mechanics appear together MORE often than expected (interaction).
+- Score = 1.0: The mechanics appear together exactly as often as expected by chance.
+- Score < 1.0: The mechanics appear together LESS often than expected.
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     add_std(p_sy)
     p_sy.add_argument('--min-freq', type=int, default=2, help='Minimum co-occurrences required to report a pair (Default: 2).')
     p_sy.add_argument('--top', type=int, default=20, help='Show the top N pairings (Default: 20).')


### PR DESCRIPTION
Improved the internal help text for the `synergy` subcommand in `scripts/mtg_analyze.py`.

**Changes:**
*   Added a `description` to the `synergy` subparser.
*   The description explains mechanical co-occurrence analysis and defines the "Lift Score" metric (Synergy > 1.0, No Correlation = 1.0, Anti-synergy < 1.0).
*   Set `formatter_class=argparse.RawDescriptionHelpFormatter` for the subparser to preserve the formatting of the description.

This change helps users understand the output of the synergy tool without needing to refer to external documentation. It follows the style guidelines by using simple, jargon-free English and active voice.

---
*PR created automatically by Jules for task [14384593301327933817](https://jules.google.com/task/14384593301327933817) started by @RainRat*