### PR TITLE
Consolidate creature power score calculation in cardlib.py

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -793,24 +793,29 @@ class Card:
 
         return score
 
+    def _get_face_power_score(self):
+        """Calculates the base power score for this card face (P + T + Keywords)."""
+        p = utils.from_unary_single(self.pt_p)
+        t = utils.from_unary_single(self.pt_t)
+
+        # Default to 0 if non-numeric (X, *, etc.)
+        p_val = float(p) if isinstance(p, (int, float)) else 0.0
+        t_val = float(t) if isinstance(t, (int, float)) else 0.0
+
+        score = p_val + t_val
+
+        # Add keyword bonuses
+        face_mechanics = self.get_face_mechanics()
+        for m in face_mechanics:
+            score += KEYWORD_WEIGHTS.get(m, 0.0)
+        return score
+
     @property
     def recommended_cmc(self):
         """Calculates a heuristic 'Fair Mana Value' for creatures based on stats and keywords."""
         recommendation = 0.0
         if self.is_creature:
-            p = utils.from_unary_single(self.pt_p)
-            t = utils.from_unary_single(self.pt_t)
-
-            # Default to 0 if non-numeric (X, *, etc.)
-            p_val = float(p) if isinstance(p, (int, float)) else 0.0
-            t_val = float(t) if isinstance(t, (int, float)) else 0.0
-
-            score = p_val + t_val
-
-            # Add keyword bonuses
-            face_mechanics = self.get_face_mechanics()
-            for m in face_mechanics:
-                score += KEYWORD_WEIGHTS.get(m, 0.0)
+            score = self._get_face_power_score()
 
             # Formula: (P + T + Keywords) / 2.0
             # A basic 2/2 creature without abilities is recommended at 2.0 mana.
@@ -826,19 +831,7 @@ class Card:
         """Calculates a heuristic power rating for creatures relative to their CMC."""
         rating = 0.0
         if self.is_creature:
-            p = utils.from_unary_single(self.pt_p)
-            t = utils.from_unary_single(self.pt_t)
-
-            # Default to 0 if non-numeric (X, *, etc.)
-            p_val = float(p) if isinstance(p, (int, float)) else 0.0
-            t_val = float(t) if isinstance(t, (int, float)) else 0.0
-
-            score = p_val + t_val
-
-            # Add keyword bonuses
-            face_mechanics = self.get_face_mechanics()
-            for m in face_mechanics:
-                score += KEYWORD_WEIGHTS.get(m, 0.0)
+            score = self._get_face_power_score()
 
             # Adjust for CMC
             # Formula: (P + T + Keywords) / (2 * max(1, CMC))

--- a/tests/test_advanced_filtering.py
+++ b/tests/test_advanced_filtering.py
@@ -4,8 +4,10 @@ import tempfile
 import json
 
 # Ensure lib is in path
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from lib import jdecode
+libdir = os.path.join(os.path.dirname(__file__), '../lib')
+if libdir not in sys.path:
+    sys.path.append(libdir)
+import jdecode
 
 def test_advanced_filtering():
     # Setup sample data with set codes and rarities


### PR DESCRIPTION
Identified and resolved a case of logic duplication in `lib/cardlib.py`. The `recommended_cmc` and `power_rating` properties of the `Card` class previously contained identical code for calculating a creature's heuristic base power score (sum of power, toughness, and keyword weights). 

This refactor extracts that logic into a private helper method `_get_face_power_score()`, improving maintainability and ensuring consistent calculations across the toolkit. 

Additionally, a minor fix was applied to `tests/test_advanced_filtering.py` to ensure the `lib` directory is correctly added to `sys.path`, allowing the full test suite to run successfully in the current environment. 

All 425 tests passed.

---
*PR created automatically by Jules for task [17914793652955622012](https://jules.google.com/task/17914793652955622012) started by @RainRat*