### PR TITLE
[DOCS] Improve search fields help text in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -927,7 +927,7 @@ Note: If no input file is provided, data/AllPrintings.json is used if available.
     p_search.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the search results. If not provided, results print to the console.')
     p_search.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                        help='Comma-separated list of fields to extract (e.g., name, cost, type, stats, text).')
+                        help='Comma-separated list of fields to extract (e.g., name, cost, type, stats, text, complexity, rating, fair_mv, identity, actions).')
     p_search.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     cli_utils.add_standard_filters(p_search)


### PR DESCRIPTION
Improved the internal help documentation for the `scripts/mtg_query.py` search tool.

### Changes:
- Updated the `help` string for the `-f` / `--fields` argument in the `search` subcommand.
- Added `complexity`, `rating`, `fair_mv`, `identity`, and `actions` to the list of example fields.

### Why:
These fields were already supported by the internal `FIELD_MAP` but were not mentioned in the `--help` output, making them difficult for users to discover. This change follows the "Plain English" and "Simplicity" guidelines while ensuring the documentation matches actual code behavior ("Truth First").

---
*PR created automatically by Jules for task [8680512552251608267](https://jules.google.com/task/8680512552251608267) started by @RainRat*