### PR TITLE
[UI/UX] Improve Oracle view hierarchy and result feedback

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1400,8 +1400,8 @@ class Card:
             return self.bside.search_loyalty(pattern)
         return False
 
-    def summary(self, ansi_color=False):
-        """Returns a compact, one-line summary of the card."""
+    def get_face_header(self, ansi_color=False):
+        """Returns a minimal identification line for the current card face."""
         # Status indicator
         status = ''
         if not self.parsed:
@@ -1447,27 +1447,28 @@ class Card:
         if not stats:
             stats = self._get_loyalty_display(ansi_color=ansi_color)
 
+        # Construct final header string
+        res = f'{status}{rarity_indicator}{cardname}{coststr} \u2022 {typeline}'
+        if stats:
+            res += f' \u2022 {stats}'
+        return res
+
+    def header(self, ansi_color=False):
+        """Returns a minimal identification line for the card (including b-sides)."""
+        res = self.get_face_header(ansi_color=ansi_color)
+        if self.bside:
+            res += ' // ' + self.bside.header(ansi_color=ansi_color)
+        return res
+
+    def summary(self, ansi_color=False):
+        """Returns a compact, one-line summary of the card."""
+        res = self.get_face_header(ansi_color=ansi_color)
+
         # Mechanics
         face_mechanics = sorted(list(self.get_face_mechanics()))
         mechanics_str = ", ".join(face_mechanics)
         if ansi_color and mechanics_str:
             mechanics_str = utils.colorize(mechanics_str, utils.Ansi.CYAN)
-
-        # Recommended CMC (Fair MV) for creatures
-        fair_mv = ''
-        if self.is_creature:
-            val = self.recommended_cmc
-            fair_mv = f'Fair MV: {val}'
-            if ansi_color:
-                # Use Green if the card is "fair" or better (cost >= fair_mv)
-                # Use Red if the card is pushed (cost < fair_mv)
-                color = utils.Ansi.GREEN if self.cost.cmc >= val else utils.Ansi.RED
-                fair_mv = utils.colorize(fair_mv, utils.Ansi.BOLD + color)
-
-        # Construct final summary string with consistent bullet separators
-        res = f'{status}{rarity_indicator}{cardname}{coststr} \u2022 {typeline}'
-        if stats:
-            res += f' \u2022 {stats}'
         if mechanics_str:
             res += f' \u2022 {mechanics_str}'
 
@@ -1479,7 +1480,13 @@ class Card:
                 act_str = utils.colorize(act_str, utils.Ansi.CYAN)
             res += f' \u2022 {act_str}'
 
-        if fair_mv:
+        # Recommended CMC (Fair MV) for creatures
+        if self.is_creature:
+            val = self.recommended_cmc
+            fair_mv = f'Fair MV: {val}'
+            if ansi_color:
+                color = utils.Ansi.GREEN if self.cost.cmc >= val else utils.Ansi.RED
+                fair_mv = utils.colorize(fair_mv, utils.Ansi.BOLD + color)
             res += f' \u2022 {fair_mv}'
 
         if self.bside:

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -447,7 +447,7 @@ def handle_oracle(args):
 
     if not args.quiet:
         if getattr(args, 'limit', 0) > 0 or getattr(args, 'sample', 0) > 0:
-            count_str = f"Showing {len(display_cards)} of"
+            count_str = f"Showing {len(display_cards)} of {prelimit_count}"
         else:
             count_str = f"Showing {len(display_cards)} of {prelimit_count}" if prelimit_count != len(display_cards) else str(len(display_cards))
         header_title = "SIMILAR CARDS" if getattr(args, 'similar', False) else "SEARCH RESULTS"
@@ -460,7 +460,7 @@ def handle_oracle(args):
             print("  " + c.summary(ansi_color=use_color).replace('\u2014', '-'))
         else:
             # Detailed View
-            print("  " + c.summary(ansi_color=use_color).replace('\u2014', '-'))
+            print("  " + c.header(ansi_color=use_color).replace('\u2014', '-'))
 
             def print_face(face, is_bside=False):
                 if is_bside:
@@ -531,14 +531,23 @@ def handle_oracle(args):
                 score_line += f" \u2022 FAIR MV: {fair_val}"
             footer_lines.append(score_line)
 
-            # 3. Actions Line
+            # 3. Mechanics & Actions Line
+            face_mechanics = sorted(list(c.get_face_mechanics()))
             face_actions = sorted(list(c.get_face_actions()))
+
+            if face_mechanics:
+                mech_str = f"MECHANICS: {', '.join(face_mechanics)}"
+                if use_color:
+                    mech_str = f"MECHANICS: {utils.colorize(', '.join(face_mechanics), utils.Ansi.CYAN)}"
+                footer_lines.append(mech_str)
+
             if face_actions:
                 act_str = f"ACTIONS: {', '.join(face_actions)}"
                 if use_color:
                     act_str = f"ACTIONS: {utils.colorize(', '.join(face_actions), utils.Ansi.CYAN)}"
                 footer_lines.append(act_str)
 
+            print() # Visual separation from rules text
             for line in footer_lines:
                 print("  " + line)
 


### PR DESCRIPTION
This PR implements several UI/UX improvements to the `mtg_query oracle` command and the underlying `Card` library:

1. **Friction Reduction & Visual Hierarchy**: The `Card` class now has a dedicated `header()` method for minimal identification. In the detailed `oracle` view, we now use this header instead of the full `summary()`. This prevents information like mechanics and "Fair MV" from appearing twice on the screen, as they are already summarized in the dedicated metadata footer.

2. **Feedback & Clarity**: Fixed a logic bug in the CLI result counter. Previously, using `--limit` or `--sample` would cause the total match count to be lost in the status message (e.g., "Showing 5 of"). It now correctly displays "Showing 5 of 10".

3. **Information Density**: Added a "MECHANICS" line to the detailed view footer. This ensures that keyword abilities are summarized in a predictable location even when the rules text is very long.

4. **Visual Hierarchy**: Added a blank line before the metadata footer in the detailed view to clearly separate the card's rules text from its analytical metadata (Complexity, Rating, etc.).

All changes have been visually verified and pass the existing test suite.

---
*PR created automatically by Jules for task [17463948953817292648](https://jules.google.com/task/17463948953817292648) started by @RainRat*