### PR TITLE
[FEAT] Add 'profile' subcommand for mechanical identity analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,18 @@ python3 sortcards.py encoded_output.txt sorted_sample.txt --sample 50 --grep "El
 *   `--md`, `--markdown`: Output in Markdown format with collapsible sections.
 *   `--color` / `--no-color`: Enable or disable ANSI color output.
 
+### `mtg_analyze.py profile`
+Identifies the "Mechanical Identity" (signature features) of a filtered subset of cards. It compares a specific context (like a color or rarity) against the global dataset to find over-represented keywords, actions, and subtypes.
+```bash
+# Identify what makes Red Rare cards unique in a set
+python3 scripts/mtg_analyze.py profile data/AllPrintings.json --colors R --rarity rare
+
+# Profile the mechanical identity of a specific set
+python3 scripts/mtg_analyze.py profile data/AllPrintings.json --set MOM
+```
+*   **Metrics:** Calculates "Lift" (subset frequency / global frequency) to identify defining features.
+*   **Options:** Supports `--top N` and all standard **Advanced Filtering** flags.
+
 ### `mtg_analyze.py summary`
 Shows statistics and reports on mechanics and word variety for your card data. It works with any card data (JSON, CSV, XML, encoded text, etc.).
 ```bash

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1370,6 +1370,151 @@ def handle_compare(args):
     utils.print_header("DATASET COMPARISON", use_color=use_color)
     datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l'] + ['r']*(len(header)-1)), indent=2)
 
+def handle_profile(args):
+    # Load targets using standard logic (applies filters)
+    subset_cards = cli_utils.load_and_filter_cards(args)
+    if not check_cards(subset_cards, args): return
+
+    # Load global baseline from same file (ignores filters)
+    import copy
+    global_args = copy.copy(args)
+    # Clear all filter and sampling attributes to get the full baseline pool
+    filter_attrs = ['grep', 'vgrep', 'grep_name', 'exclude_name', 'grep_type', 'exclude_type',
+                    'grep_text', 'exclude_text', 'grep_cost', 'exclude_cost', 'grep_pt', 'exclude_pt',
+                    'grep_loyalty', 'exclude_loyalty', 'set', 'rarity', 'colors', 'cmcs', 'pow', 'tou', 'loy',
+                    'mechanic', 'action', 'identities', 'id_counts', 'deck']
+    for attr in filter_attrs:
+        if hasattr(global_args, attr): setattr(global_args, attr, None)
+
+    # Numeric attributes should be reset to 0 to avoid TypeError in cli_utils
+    for attr in ['limit', 'sample', 'booster', 'box']:
+        if hasattr(global_args, attr): setattr(global_args, attr, 0)
+
+    # Use standard loading utility for baseline to ensure consistent format support
+    global_cards = cli_utils.load_and_filter_cards(global_args)
+
+    use_color = args.color if args.color is not None else sys.stdout.isatty()
+
+    # 1. Basic Stats
+    subset_mine = Datamine(subset_cards)
+    global_mine = Datamine(global_cards)
+
+    utils.print_header("MECHANICAL IDENTITY PROFILE", count=len(subset_cards), use_color=use_color)
+    print(f"  {datalib.color_line('Context:', use_color)} {args.infile}")
+
+    # Calculate Averages
+    p1_cmc = subset_mine.avg_cmc
+    p0_cmc = global_mine.avg_cmc
+
+    p1_pow = subset_mine.avg_power
+    p0_pow = global_mine.avg_power
+
+    p1_tou = subset_mine.avg_toughness
+    p0_tou = global_mine.avg_toughness
+
+    p1_comp = subset_mine.avg_complexity
+    p0_comp = global_mine.avg_complexity
+
+    avg_rows = [
+        ["Metric", "Subset", "Global", "Delta"],
+        ["Avg CMC", f"{p1_cmc:.2f}", f"{p0_cmc:.2f}", format_delta(p1_cmc, p0_cmc, use_color=use_color, reverse_color=True)],
+        ["Avg Power", f"{p1_pow:.2f}", f"{p0_pow:.2f}", format_delta(p1_pow, p0_pow, use_color=use_color)],
+        ["Avg Toughness", f"{p1_tou:.2f}", f"{p0_tou:.2f}", format_delta(p1_tou, p0_tou, use_color=use_color)],
+        ["Avg Complexity", f"{p1_comp:.1f}", f"{p0_comp:.1f}", format_delta(p1_comp, p0_comp, use_color=use_color, reverse_color=True)]
+    ]
+    if use_color:
+        avg_rows[0] = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in avg_rows[0]]
+
+    datalib.add_separator_row(avg_rows)
+    datalib.printrows(datalib.padrows(avg_rows, aligns=['l', 'r', 'r', 'r']), indent=4)
+    print()
+
+    def get_lift_report(title, subset_counts, global_counts, subset_total, global_total, top_n=10, formatter=None):
+        if not subset_counts: return
+        print(f"  {datalib.color_line(title, use_color)}")
+
+        lift_data = []
+        for key, count in subset_counts.items():
+            if count < 1: continue
+
+            p_subset = count / subset_total
+            # Handle cases where key might not be in global (e.g. custom keyword in subset)
+            count_global = global_counts.get(key, 0)
+            p_global = count_global / global_total if global_total > 0 else 0
+
+            # Lift = Representation in subset / Representation in global
+            if p_global > 0:
+                lift = p_subset / p_global
+            else:
+                lift = 99.0 # Infinite lift
+
+            lift_data.append({
+                'key': key,
+                'lift': lift,
+                'count': count,
+                'percent': p_subset * 100
+            })
+
+        # Sort by lift descending
+        lift_data.sort(key=lambda x: (x['lift'], x['count']), reverse=True)
+
+        header = ["Signature Feature", "Count", "Subset %", "Lift"]
+        if use_color:
+            header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+        rows = [header]
+
+        for item in lift_data[:top_n]:
+            display_key = formatter(item['key']) if formatter else str(item['key'])
+            if use_color:
+                # Highlight if lift is high
+                if item['lift'] > 2.0: display_key = utils.colorize(display_key, utils.Ansi.BOLD + utils.Ansi.GREEN)
+                elif item['lift'] > 1.2: display_key = utils.colorize(display_key, utils.Ansi.GREEN)
+
+            rows.append([
+                display_key,
+                str(item['count']),
+                f"{item['percent']:5.1f}%",
+                f"{item['lift']:.2f}x"
+            ])
+
+        datalib.add_separator_row(rows)
+        datalib.printrows(datalib.padrows(rows, aligns=['l', 'r', 'r', 'r']), indent=4)
+        print()
+
+    # 2. Signature Mechanics
+    sub_mechs = Counter()
+    for c in subset_cards:
+        for m in c.mechanics: sub_mechs[m] += 1
+
+    ref_mechs = Counter()
+    for c in global_cards:
+        for m in c.mechanics: ref_mechs[m] += 1
+
+    get_lift_report("Top Signature Mechanics:", sub_mechs, ref_mechs, len(subset_cards), len(global_cards), top_n=args.top)
+
+    # 3. Signature Actions
+    sub_acts = Counter()
+    for c in subset_cards:
+        for a in c.actions: sub_acts[a] += 1
+
+    ref_acts = Counter()
+    for c in global_cards:
+        for a in c.actions: ref_acts[a] += 1
+
+    get_lift_report("Top Signature Actions:", sub_acts, ref_acts, len(subset_cards), len(global_cards), top_n=args.top)
+
+    # 4. Signature Subtypes
+    sub_types = Counter()
+    for c in subset_cards:
+        for s in c.subtypes: sub_types[s] += 1
+
+    ref_types = Counter()
+    for c in global_cards:
+        for s in c.subtypes: ref_types[s] += 1
+
+    get_lift_report("Top Signature Subtypes:", sub_types, ref_types, len(subset_cards), len(global_cards), top_n=args.top,
+                    formatter=lambda s: titlecase(s.replace(utils.dash_marker, '-')))
+
 def main():
     parser = argparse.ArgumentParser(
         description="Unified MTG analysis tool.",
@@ -1381,6 +1526,9 @@ Examples:
 
   # Analyze the mana curve of a specific set
   python3 scripts/mtg_analyze.py curve data/AllPrintings.json --set MOM
+
+  # Identify what makes Red Rare cards unique (signature features)
+  python3 scripts/mtg_analyze.py profile data/AllPrintings.json --colors R --rarity rare
 
   # Calculate As-Fan statistics for a generated set
   python3 scripts/mtg_analyze.py asfan generated.txt
@@ -1549,6 +1697,12 @@ Examples:
     p_comp.add_argument('infiles', nargs='+', help='Two or more card data files to compare.')
     add_std(p_comp)
     p_comp.set_defaults(func=handle_compare)
+
+    # profile
+    p_prof = subparsers.add_parser('profile', help='Identify the "Mechanical Identity" (signature features) of a filtered subset of cards.')
+    add_std(p_prof)
+    p_prof.add_argument('--top', type=int, default=10, help='Number of signature features to show per category (Default: 10).')
+    p_prof.set_defaults(func=handle_profile)
 
     args = parser.parse_args()
     if not args.command: parser.print_help(); return

--- a/tests/test_mtg_profile.py
+++ b/tests/test_mtg_profile.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import io
+from contextlib import redirect_stdout, redirect_stderr
+
+# Add lib to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+import scripts.mtg_analyze as mtg_analyze
+
+class TestMtgProfile(unittest.TestCase):
+    def test_profile_basic(self):
+        # We use a real file from testdata for robustness
+        test_file = 'testdata/uthros.json'
+        if not os.path.exists(test_file):
+            self.skipTest("testdata/uthros.json not found")
+
+        # Mock sys.argv to call profile
+        test_args = ['mtg_analyze.py', 'profile', test_file, '--colors', 'U', '--no-color']
+
+        with patch('sys.argv', test_args):
+            f = io.StringIO()
+            with redirect_stdout(f):
+                mtg_analyze.main()
+
+            output = f.getvalue()
+            self.assertIn("MECHANICAL IDENTITY PROFILE", output)
+            self.assertIn("Avg CMC", output)
+            self.assertIn("Top Signature Mechanics", output)
+            self.assertIn("Top Signature Actions", output)
+            self.assertIn("Top Signature Subtypes", output)
+            self.assertIn("Spacecraft", output) # Unique subtype of Uthros
+
+    def test_profile_empty(self):
+        # Test with filters that match nothing
+        test_file = 'testdata/uthros.json'
+        if not os.path.exists(test_file):
+            self.skipTest("testdata/uthros.json not found")
+
+        test_args = ['mtg_analyze.py', 'profile', test_file, '--colors', 'R', '--no-color', '--quiet']
+
+        with patch('sys.argv', test_args):
+            f = io.StringIO()
+            with redirect_stdout(f):
+                mtg_analyze.main()
+
+            output = f.getvalue()
+            # Should not crash, but might print nothing or a warning if not quiet
+            # In this case, mtg_analyze.check_cards handles it
+            self.assertEqual(output.strip(), "")
+
+    def test_profile_lift_logic(self):
+        # Test lift calculation with a small controlled dataset
+        # We'll use a directory search to include multiple cards
+        test_dir = 'testdata/'
+        if not os.path.exists(test_dir):
+            self.skipTest("testdata/ directory not found")
+
+        # Profile Elf cards
+        test_args = ['mtg_analyze.py', 'profile', test_dir, '--grep', 'Elf', '--no-color', '--top', '5']
+
+        with patch('sys.argv', test_args):
+            f = io.StringIO()
+            with redirect_stdout(f):
+                mtg_analyze.main()
+
+            output = f.getvalue()
+            self.assertIn("MECHANICAL IDENTITY PROFILE", output)
+            self.assertIn("Elf", output)
+            self.assertIn("x", output) # Lift multiplier should be present
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Contextual Mechanical Profiler

This PR introduces the `profile` subcommand to `scripts/mtg_analyze.py`, filling a significant gap in the toolkit's analytical capabilities. 

#### **What:**
The `profile` tool allows users to identify the "Mechanical Identity" of any card subset. By applying standard filters (e.g., `--colors R --rarity uncommon`), the tool calculates:
1. **Statistical Comparison:** Delta analysis for Avg CMC, Power, Toughness, and Complexity.
2. **Signature Features:** Tables of Keywords, Actions, and Subtypes sorted by **Lift** (the ratio of frequency in the subset vs. the global baseline).

#### **Why:**
Previously, the toolkit offered global frequencies (`mechanics`) or fixed 2-color archetypes (`archetypes`). However, designers frequently need to know what defines a specific slice of a set or a custom dataset. For example, "What keywords are unique to Rare Green cards in MOM?". 

This tool provides immediate value for:
- **Design Verification:** Ensuring mechanics are assigned to the correct colors/rarities.
- **AI Evaluation:** Confirming that generated cards inherit the intended mechanical identity of their training context.
- **Set Exploration:** Understanding the unique mechanical hooks of different sets or decklists.

#### **Technical Improvements:**
- Leverages `cli_utils.load_and_filter_cards` for consistent directory and multi-format support.
- Includes a fix for a `TypeError` in `cli_utils` encountered when programmatically resetting numeric arguments (limit/sample/booster/box).
- Fully tested and documented.

**Usage Example:**
```bash
python3 scripts/mtg_analyze.py profile data/AllPrintings.json --colors G --rarity rare
```


---
*PR created automatically by Jules for task [1060551654963278991](https://jules.google.com/task/1060551654963278991) started by @RainRat*