### PR TITLE
Fix 'Station' mechanic false positives using word boundaries

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -278,7 +278,7 @@ def fields_check_valid(fields):
             return False
     # Station cards can become creatures, so they are allowed to NOT have P/T.
     # We also allow them to HAVE P/T if they want.
-    elif isartifact and 'station' in text:
+    elif isartifact and re.search(r'\bstation\b', text):
         pass
     else:
         if field_pt in fields:
@@ -966,7 +966,7 @@ class Card:
         if 'level up' in text_raw or 'level &' in text_enc:
             m.add('Leveler')
 
-        if 'station' in text_raw:
+        if re.search(r'\bstation\b', text_raw):
             m.add('Station')
 
         if '%' in text_enc or '#' in text_enc or 'counter' in text_raw:

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -81,7 +81,7 @@ def check_pt(card):
     if 'battle' in card.types:
         return None
     # "Station" cards are artifacts that can become creatures, so they are exempt from P/T checks.
-    if "station" in card.text.text.lower():
+    if re.search(r'\bstation\b', card.text.text.lower()):
         return None
     if ('creature' in card.types or 'vehicle' in card.subtypes) or card.pt:
         return ((('creature' in card.types or 'vehicle' in card.subtypes) and len(re.findall(re.escape('/'), card.pt)) == 1)


### PR DESCRIPTION
**What:** Updated the detection of the 'Station' mechanic (a specific cycle of cards) to use regular expression word boundaries (`\bstation\b`) instead of simple substring matching.

**Why:** The original substring check incorrectly identified cards with words like "manifestation" or "infestation" as being part of the Station cycle, which bypassed certain validation rules (like Power/Toughness requirements for artifacts). This fix ensures only the standalone word "station" is recognized, improving metadata accuracy and validation integrity. No breaking changes were introduced.

---
*PR created automatically by Jules for task [11873025643845018162](https://jules.google.com/task/11873025643845018162) started by @RainRat*