### PR TITLE
[DOCS] Enhance shared CLI filtering help strings

### DIFF
--- a/lib/cli_utils.py
+++ b/lib/cli_utils.py
@@ -40,31 +40,42 @@ def add_standard_filters(parser):
     filter_group.add_argument('--exclude-loyalty', action='append',
                         help='Exclude cards whose loyalty/defense matches a search pattern.')
     filter_group.add_argument('--set', action='append',
-                        help='Only include cards from specific sets.')
+                        help='Only include cards from specific sets (e.g., MOM, MRD). Supports multiple values (OR logic).')
     filter_group.add_argument('--rarity', action='append',
-                        help="Only include cards of specific rarities. Supports full names or shorthands (O, N, A, Y, I, L).")
+                        help="Only include cards of specific rarities. Supports full names (e.g., 'common', 'mythic') or shorthands: "
+                             "O (Common), N (Uncommon), A (Rare), Y (Mythic), I (Special), or L (Basic Land). "
+                             "Supports multiple values (OR logic).")
     filter_group.add_argument('--colors', action='append',
-                        help="Only include cards of specific colors (W, U, B, R, G, C, A).")
+                        help="Only include cards of specific colors (W, U, B, R, G). Use 'C' or 'A' for colorless. "
+                             "Supports multiple values (OR logic).")
     filter_group.add_argument('--identity', action='append',
-                        help="Only include cards with specific color identities.")
+                        help="Only include cards with specific colors in their color identity (W, U, B, R, G). "
+                             "Use 'C' or 'A' for colorless. Supports multiple values (OR logic).")
     filter_group.add_argument('--id-count', action='append',
-                        help='Only include cards with specific color identity counts.')
+                        help='Only include cards with specific color identity counts. Supports exact values ("2"), '
+                             'inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
     filter_group.add_argument('--cmc', action='append',
-                        help='Only include cards with specific CMC values.')
+                        help='Only include cards with specific CMC (Converted Mana Cost) values. Supports exact values, '
+                             'inequalities (e.g., ">3", "<=2"), ranges (e.g., "1-4"), and multiple values (OR logic).')
     filter_group.add_argument('--pow', '--power', action='append', dest='pow',
-                        help='Only include cards with specific Power values.')
+                        help='Only include cards with specific Power values. Supports exact values, '
+                             'inequalities, ranges, and multiple values (OR logic).')
     filter_group.add_argument('--tou', '--toughness', action='append', dest='tou',
-                        help='Only include cards with specific Toughness values.')
+                        help='Only include cards with specific Toughness values. Supports exact values, '
+                             'inequalities, ranges, and multiple values (OR logic).')
     filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
-                        help='Only include cards with specific Loyalty or Defense values.')
+                        help='Only include cards with specific Loyalty or Defense values. Supports exact values, '
+                             'inequalities, ranges, and multiple values (OR logic).')
     filter_group.add_argument('--mechanic', action='append',
-                        help='Only include cards with specific mechanical features.')
+                        help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). '
+                             'Supports multiple values (OR logic).')
     filter_group.add_argument('--action', action='append',
-                        help='Only include cards with specific functional actions (Removal, Protection, Buffs, Card Advantage, Disruption, Mana).')
+                        help='Only include cards with specific functional actions (Removal, Protection, Buffs, Card Advantage, Disruption, or Mana). '
+                             'Supports multiple values (OR logic).')
     filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
-                        help='Filter cards using a standard MTG decklist file.')
+                        help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     filter_group.add_argument('--booster', type=int, default=0,
-                        help='Simulate opening N booster packs.')
+                        help='Simulate opening N booster packs. Distribution: 10 Common, 3 Uncommon, 1 Rare/Mythic, 1 Basic Land.')
     filter_group.add_argument('--box', type=int, default=0,
                         help='Simulate opening N booster boxes (36 packs each).')
     filter_group.add_argument('-n', '--limit', type=int, default=0,


### PR DESCRIPTION
Enhanced the internal help strings in `lib/cli_utils.py`, which provides the shared filtering logic for unified toolkit utilities like `mtg_query.py` and `mtg_analyze.py`. 

The updates clarify supported formats for numerical filters (inequalities and ranges), provide a key for rarity shorthands, and detail the booster pack distribution. This ensures that users of the modern unified tools have access to the same level of detailed documentation previously only available in standalone scripts.

Verified via `--help` output of multiple subcommands and confirmed no regressions via the full 1068-test suite.

---
*PR created automatically by Jules for task [99563375227327913](https://jules.google.com/task/99563375227327913) started by @RainRat*