### PR TITLE
[TEST] [Fix false positive 'Station' mechanic detection]

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -278,7 +278,7 @@ def fields_check_valid(fields):
             return False
     # Station cards can become creatures, so they are allowed to NOT have P/T.
     # We also allow them to HAVE P/T if they want.
-    elif isartifact and 'station' in text:
+    elif isartifact and re.search(r'\bstation\b', text):
         pass
     else:
         if field_pt in fields:
@@ -966,7 +966,7 @@ class Card:
         if 'level up' in text_raw or 'level &' in text_enc:
             m.add('Leveler')
 
-        if 'station' in text_raw:
+        if re.search(r'\bstation\b', text_raw):
             m.add('Station')
 
         if '%' in text_enc or '#' in text_enc or 'counter' in text_raw:

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -81,7 +81,7 @@ def check_pt(card):
     if 'battle' in card.types:
         return None
     # "Station" cards are artifacts that can become creatures, so they are exempt from P/T checks.
-    if "station" in card.text.text.lower():
+    if re.search(r'\bstation\b', card.text.text.lower()):
         return None
     if ('creature' in card.types or 'vehicle' in card.subtypes) or card.pt:
         return ((('creature' in card.types or 'vehicle' in card.subtypes) and len(re.findall(re.escape('/'), card.pt)) == 1)

--- a/tests/test_station_fix.py
+++ b/tests/test_station_fix.py
@@ -1,0 +1,67 @@
+import pytest
+import sys
+import os
+import re
+
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+scriptsdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../scripts')
+if libdir not in sys.path:
+    sys.path.append(libdir)
+if scriptsdir not in sys.path:
+    sys.path.append(scriptsdir)
+
+from cardlib import Card
+import mtg_validate
+
+def test_station_mechanic_no_false_positive():
+    # 'manifestation' contains 'station' but should not trigger the Station mechanic
+    c = Card({
+        "name": "Soulbeam Manifestation",
+        "types": ["Enchantment"],
+        "text": "Manifestation is cool."
+    })
+    assert "Station" not in c.mechanics
+
+def test_station_mechanic_legitimate():
+    # Actual Station card should still trigger the mechanic
+    c = Card({
+        "name": "Summoning Station",
+        "types": ["Artifact"],
+        "text": "Station."
+    })
+    assert "Station" in c.mechanics
+
+def test_station_validation_no_false_positive():
+    # In mtg_validate, a 'manifestation' artifact without P/T should still be invalid (not exempt)
+    c = Card({
+        "name": "Manifestation Artifact",
+        "types": ["Artifact"],
+        "text": "This manifestation is weird."
+    })
+    # check_pt returns None if exempt or if it doesn't apply.
+    # If it is NOT a creature and NOT a station, it should return None at the end.
+    # Wait, check_pt(card) logic:
+    # if 'station' in text: return None
+    # if 'creature' in types or card.pt: ...
+    # return None
+
+    # Let's test an artifact with P/T that is NOT a station.
+    c_pt = Card({
+        "name": "Non-Station Artifact with PT",
+        "types": ["Artifact"],
+        "text": "Manifestation.",
+        "pt": "1/1"
+    })
+    # This should return False (Invalid) because it's not a creature but has PT, and is not a station.
+    assert mtg_validate.check_pt(c_pt) is False
+
+def test_station_validation_legitimate():
+    # Legitimate station artifact with PT should be exempt from normal PT checks in mtg_validate
+    c = Card({
+        "name": "Summoning Station",
+        "types": ["Artifact"],
+        "text": "Station 3+.",
+        "pt": "2/2"
+    })
+    # It returns None when exempt.
+    assert mtg_validate.check_pt(c) is None


### PR DESCRIPTION
* **Type:** Bug Fix / New Coverage
* **What:** Updated 'Station' mechanic detection to use word boundaries in `lib/cardlib.py` and `scripts/mtg_validate.py`. Added a regression test suite in `tests/test_station_fix.py`.
* **Why:** Prevented false positives where words like "manifestation" were incorrectly identified as part of the "Station" mechanic, which led to incorrect mechanical profiling and validation exemptions.

---
*PR created automatically by Jules for task [13617042477435282931](https://jules.google.com/task/13617042477435282931) started by @RainRat*