### PR TITLE
[DOCS] Expand field options in mtg_query search help

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -927,7 +927,7 @@ Note: If no input file is provided, data/AllPrintings.json is used if available.
     p_search.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the search results. If not provided, results print to the console.')
     p_search.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                        help='Comma-separated list of fields to extract (e.g., name, cost, type, stats, text).')
+                        help='Comma-separated list of fields to extract (e.g., name, cost, type, stats, text, mechanics, actions, identity, complexity, rating, fair_mv).')
     p_search.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     cli_utils.add_standard_filters(p_search)


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Updated the `--fields` argument help string for the `search` subcommand in `scripts/mtg_query.py`.
* **Why:** Explicitly listing available fields like `actions`, `complexity`, `rating`, `fair_mv`, and `identity` improves feature discoverability. Users can now see a more comprehensive list of valid extraction targets directly in the CLI help output without needing to refer to the source code.

---
*PR created automatically by Jules for task [15053629464672097001](https://jules.google.com/task/15053629464672097001) started by @RainRat*