### PR TITLE
Remove redundant wrapper functions in mtg_analyze.py

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -133,9 +133,6 @@ DIMENSIONS = {
     }
 }
 
-def get_produced_colors(card):
-    return card.produced_colors
-
 def get_mana_category(card):
     if card.is_creature: return "Creature"
     if card.is_artifact: return "Artifact"
@@ -171,9 +168,6 @@ def get_cost_metrics(card):
     intensity = colored_pips / max(1, cmc)
     max_commitment = max(color_pips.values()) if color_pips else 0
     return cmc, colored_pips, intensity, max_commitment
-
-def get_card_actions(card):
-    return card.actions
 
 def get_numeric_stats(card):
     return utils.from_unary_single(card.pt_p), utils.from_unary_single(card.pt_t), utils.from_unary_single(card.loyalty)
@@ -304,7 +298,7 @@ def calculate_synergy(cards, min_freq=2):
 def analyze_dataset(cards):
     s = {'total': len(cards), 'total_cards': len(cards), 'producers': 0, 'producer_count': 0, 'cats': Counter(), 'categories': Counter(), 'cols': Counter(), 'colors': Counter(), 'fixing': 0}
     for c in cards:
-        p = get_produced_colors(c)
+        p = c.produced_colors
         if p:
             s['producers'] += 1
             s['producer_count'] += 1
@@ -813,7 +807,7 @@ def handle_actions(args):
     if not check_cards(cards, args): return
     act_c, col_act = Counter(), defaultdict(Counter)
     for c in cards:
-        acts = get_card_actions(c)
+        acts = c.actions
         for a in acts:
             act_c[a] += 1
             for col in (c.cost.colors or ['C']): col_act[col][a] += 1

--- a/tests/test_mtg_actions.py
+++ b/tests/test_mtg_actions.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 import io
-from scripts.mtg_analyze import get_card_actions, main
+from scripts.mtg_analyze import main
 from lib.cardlib import Card
 
 class TestMtgActionsSimplified(unittest.TestCase):
@@ -9,12 +9,12 @@ class TestMtgActionsSimplified(unittest.TestCase):
     def test_get_card_actions_basic(self):
         # Removal
         card = Card({"name": "Murder", "manaCost": "{1}{B}{B}", "text": "destroy target creature.", "types": ["instant"], "rarity": "common"})
-        actions = get_card_actions(card)
+        actions = card.actions
         self.assertIn("Removal", actions)
 
         # Protection
         card = Card({"name": "Swiftfoot Boots", "manaCost": "{2}", "text": "hexproof", "types": ["artifact"], "rarity": "common"})
-        actions = get_card_actions(card)
+        actions = card.actions
         self.assertIn("Protection", actions)
 
     @patch('scripts.mtg_analyze.jdecode.mtg_open_file')

--- a/tests/test_mtg_mana.py
+++ b/tests/test_mtg_mana.py
@@ -21,7 +21,7 @@ class TestMtgMana(unittest.TestCase):
             'types': ['Land'],
             'subtypes': ['Forest']
         })
-        self.assertEqual(mtg_analyze.get_produced_colors(card_forest), {'G'})
+        self.assertEqual(card_forest.produced_colors, {'G'})
 
         # Dual Land
         card_volcanic = cardlib.Card({
@@ -29,7 +29,7 @@ class TestMtgMana(unittest.TestCase):
             'types': ['Land'],
             'subtypes': ['Island', 'Mountain']
         })
-        self.assertEqual(mtg_analyze.get_produced_colors(card_volcanic), {'U', 'R'})
+        self.assertEqual(card_volcanic.produced_colors, {'U', 'R'})
 
     def test_get_produced_colors_text(self):
         # Mana Creature
@@ -38,7 +38,7 @@ class TestMtgMana(unittest.TestCase):
             'types': ['Creature'],
             'text': '{T}: Add {G}.'
         })
-        self.assertEqual(mtg_analyze.get_produced_colors(card_elf), {'G'})
+        self.assertEqual(card_elf.produced_colors, {'G'})
 
         # Mana Artifact
         card_sol_ring = cardlib.Card({
@@ -46,7 +46,7 @@ class TestMtgMana(unittest.TestCase):
             'types': ['Artifact'],
             'text': '{T}: Add {C}{C}.'
         })
-        self.assertEqual(mtg_analyze.get_produced_colors(card_sol_ring), {'C'})
+        self.assertEqual(card_sol_ring.produced_colors, {'C'})
 
         # "Any Color"
         card_lotus = cardlib.Card({
@@ -54,7 +54,7 @@ class TestMtgMana(unittest.TestCase):
             'types': ['Artifact'],
             'text': '{T}, Sacrifice @: Add three mana of any color.'
         })
-        self.assertEqual(mtg_analyze.get_produced_colors(card_lotus), {'Any'})
+        self.assertEqual(card_lotus.produced_colors, {'Any'})
 
     def test_get_mana_category(self):
         # Creature

--- a/tests/test_mtg_mana_gaps.py
+++ b/tests/test_mtg_mana_gaps.py
@@ -19,20 +19,20 @@ class TestMtgManaGaps(unittest.TestCase):
     def test_get_produced_colors_wastes(self):
         # Wastes as subtype
         card = Card({'name': 'Wastes', 'types': ['Land'], 'subtypes': ['Wastes']})
-        self.assertEqual(mtg_analyze.get_produced_colors(card), {'C'})
+        self.assertEqual(card.produced_colors, {'C'})
 
         # Wastes as type
         card = Card({'name': 'Wastes', 'types': ['Wastes', 'Land']})
-        self.assertEqual(mtg_analyze.get_produced_colors(card), {'C'})
+        self.assertEqual(card.produced_colors, {'C'})
 
     def test_get_produced_colors_hybrid_and_complex(self):
         # Hybrid symbols
         card = Card({'name': 'Hybrid', 'types': ['Artifact'], 'text': '{T}: Add {W/U}.'})
-        self.assertEqual(mtg_analyze.get_produced_colors(card), {'W', 'U'})
+        self.assertEqual(card.produced_colors, {'W', 'U'})
 
         # Multiple symbols in one line
         card = Card({'name': 'Complex', 'types': ['Artifact'], 'text': '{T}: Add {R}{G} or {B}{B}.'})
-        self.assertEqual(mtg_analyze.get_produced_colors(card), {'R', 'G', 'B'})
+        self.assertEqual(card.produced_colors, {'R', 'G', 'B'})
 
     def test_get_produced_colors_older_text(self):
         patterns = [
@@ -45,18 +45,18 @@ class TestMtgManaGaps(unittest.TestCase):
         ]
         for text, color in patterns:
             card = Card({'name': 'Old Text', 'types': ['Artifact'], 'text': text})
-            self.assertEqual(mtg_analyze.get_produced_colors(card), {color}, f"Failed for pattern: {text}")
+            self.assertEqual(card.produced_colors, {color}, f"Failed for pattern: {text}")
 
     def test_get_produced_colors_bside_recursion(self):
         # B-side produces Any
         bside_json = {'name': 'Back', 'types': ['Artifact'], 'text': '{T}: Add one mana of any color.'}
         card = Card({'name': 'Front', 'types': ['Enchantment'], 'bside': bside_json})
-        self.assertEqual(mtg_analyze.get_produced_colors(card), {'Any'})
+        self.assertEqual(card.produced_colors, {'Any'})
 
         # B-side produces specific color
         bside_json = {'name': 'Back', 'types': ['Land'], 'subtypes': ['Forest']}
         card = Card({'name': 'Front', 'types': ['Artifact'], 'bside': bside_json})
-        self.assertEqual(mtg_analyze.get_produced_colors(card), {'G'})
+        self.assertEqual(card.produced_colors, {'G'})
 
     @patch('mtg_analyze.jdecode.mtg_open_file')
     @patch('sys.stdout', new_callable=io.StringIO)


### PR DESCRIPTION
This change removes two redundant wrapper functions in `scripts/mtg_analyze.py`: `get_produced_colors(card)` and `get_card_actions(card)`. Both functions were merely returning the value of properties already defined in the `Card` class (`produced_colors` and `actions`).

By removing these wrappers and updating the call sites to access the properties directly, we reduce unnecessary indirection and make the code more idiomatic.

Changes:
- Removed `get_produced_colors(card)` and `get_card_actions(card)` from `scripts/mtg_analyze.py`.
- Updated `analyze_dataset` and `handle_actions` in `scripts/mtg_analyze.py` to use `c.produced_colors` and `c.actions`.
- Updated `tests/test_mtg_mana.py`, `tests/test_mtg_mana_gaps.py`, and `tests/test_mtg_actions.py` to call the properties directly.
- Verified all 18 affected tests pass.

---
*PR created automatically by Jules for task [17706952246687552262](https://jules.google.com/task/17706952246687552262) started by @RainRat*