### PR TITLE
[DOCS] Replace 'synergy' business jargon with 'interaction'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,4 +43,4 @@ This will create a file containing the raw data for any cards that could not be 
 Key utility scripts for dataset analysis:
 *   `scripts/mtg_query.py search`: Comprehensive card searching and field extraction.
 *   `scripts/mtg_subset.py`: Creates filtered subsets of MTGJSON files.
-*   `scripts/mtg_analyze.py`: Unified metric and profiling tool (summary, curve, colorpie, grid, types, skeleton, mana, pips, costs, mechanics, synergy, actions, lexicon, stats, power, archetypes, balance, asfan, tokens, subtypes, compare).
+*   `scripts/mtg_analyze.py`: Unified metric and profiling tool (summary, curve, colorpie, grid, types, skeleton, mana, pips, costs, mechanics, interaction, actions, lexicon, stats, power, archetypes, balance, asfan, tokens, subtypes, compare).

--- a/README.md
+++ b/README.md
@@ -644,14 +644,14 @@ python3 scripts/mtg_analyze.py asfan data/AllPrintings.json --compare generated.
     *   `--csv`: Output results in CSV format.
     *   Supports standard **Advanced Filtering** flags and 'Smart Positional Argument Handling'.
 
-### `mtg_analyze.py synergy`
+### `mtg_analyze.py interaction`
 Analyzes how different mechanics (like Flying, Kicker, or Flashback) appear together on the same cards. It identifies frequent pairings and calculates a 'Lift Score' to measure if these mechanics appear together more often than expected by chance.
 ```bash
 # Analyze co-occurrence for a specific set
-python3 scripts/mtg_analyze.py synergy data/AllPrintings.json --set MOM
+python3 scripts/mtg_analyze.py interaction data/AllPrintings.json --set MOM
 
 # Find frequent pairings in AI designs with at least 5 occurrences
-python3 scripts/mtg_analyze.py synergy generated.txt --min-freq 5
+python3 scripts/mtg_analyze.py interaction generated.txt --min-freq 5
 ```
 *   **Options:**
     *   `--min-freq N`: Minimum co-occurrences required to report a pair (Default: 2).

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -286,7 +286,7 @@ def calculate_asfan(cards):
         return res
     return {'colors': calc_c(lambda c: c.cost.colors or ['C']), 'types': calc_c(lambda c: [t for t in TRACKED_TYPES if c._has_type(t)]), 'mechs': calc_c(lambda c: list(c.mechanics)), 'multi': 0.0}
 
-def calculate_synergy(cards, min_freq=2):
+def calculate_interaction(cards, min_freq=2):
     ind_c, pair_c, dens_d = Counter(), Counter(), Counter()
     for c in cards:
         ms = sorted(list(c.mechanics))
@@ -766,7 +766,7 @@ def handle_mechanics(args):
         for r in res: rows.append([utils.colorize(r['name'], utils.Ansi.CYAN) if use_color else r['name'], str(r['c1']), f"{r['p1']:5.1f}%", datalib.get_bar_chart(r['p1'], use_color, color=utils.Ansi.CYAN)])
     datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','r','r','c'] if c2 else ['l','r','r','l']), indent=2)
 
-def handle_synergy(args):
+def handle_interaction(args):
     cards = cli_utils.load_and_filter_cards(args)
     if not check_cards(cards, args): return
     ind_c, pair_c, dens_d = Counter(), Counter(), Counter()
@@ -782,7 +782,7 @@ def handle_synergy(args):
         syn.append({'pair': (m1, m2), 'cnt': cnt, 'lift': lift})
     syn.sort(key=lambda x: x['lift'], reverse=True)
     use_color = args.color if args.color is not None else (not (args.json or args.csv) and sys.stdout.isatty())
-    if args.json: print(json.dumps({'total': len(cards), 'total_cards': len(cards), 'density': dict(dens_d), 'density_distribution': dict(dens_d), 'synergy': syn, 'synergy_pairs': syn}, indent=2))
+    if args.json: print(json.dumps({'total': len(cards), 'total_cards': len(cards), 'density': dict(dens_d), 'density_distribution': dict(dens_d), 'interaction': syn, 'interaction_pairs': syn}, indent=2))
     elif args.csv:
         writer = csv.writer(sys.stdout)
         writer.writerow(['Mechanic 1', 'Mechanic 2', 'Count', 'Lift', 'P(A&B)'])
@@ -791,20 +791,20 @@ def handle_synergy(args):
             pa_b = r['cnt'] / len(cards) if cards else 0
             writer.writerow([m1, m2, r['cnt'], f"{r['lift']:.2f}", f"{pa_b:.4f}"])
     else:
-        utils.print_header("MECHANICAL SYNERGY ANALYSIS", count=len(cards), use_color=use_color)
+        utils.print_header("MECHANICAL INTERACTION ANALYSIS", count=len(cards), use_color=use_color)
         print(f"  {datalib.color_line('Mechanical Density:', use_color)}")
         rows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ["Mechanics", "Cards", "Percent", "Distribution"]]]
         for i in range(max(dens_d.keys())+1 if dens_d else 1):
             cnt = dens_d.get(i, 0); p = cnt/len(cards)*100
             rows.append([str(i), str(cnt), f"{p:5.1f}%", datalib.get_bar_chart(p, use_color, color=utils.Ansi.CYAN)])
         datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['r','r','r','l']), indent=4)
-        print(f"\n  {datalib.color_line('Top Synergistic Pairs (by Lift):', use_color)}")
+        print(f"\n  {datalib.color_line('Top Interaction Pairs (by Lift):', use_color)}")
         sh = ["Pair", "Count", "Lift", "Desc"]
         srows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in sh]]
         for r in syn[:args.top]:
             m1, m2 = r['pair']; lift = r['lift']
             pair = f"{utils.colorize(m1, utils.Ansi.CYAN)} + {utils.colorize(m2, utils.Ansi.CYAN)}" if use_color else f"{m1} + {m2}"
-            desc = "Strong Synergy" if lift>2.0 else ("Synergistic" if lift>1.2 else "Expected")
+            desc = "Strong Interaction" if lift>2.0 else ("Positive Interaction" if lift>1.2 else "Expected")
             srows.append([pair, str(r['cnt']), utils.colorize(f"{lift:6.2f}", utils.Ansi.BOLD+utils.Ansi.GREEN if lift>2.0 else "") if use_color else f"{lift:6.2f}", desc])
         datalib.add_separator_row(srows); datalib.printrows(datalib.padrows(srows, aligns=['l','r','r','l']), indent=4)
 
@@ -1449,8 +1449,8 @@ Examples:
   # Calculate As-Fan statistics for a generated set
   python3 scripts/mtg_analyze.py asfan generated.txt
 
-  # Analyze mechanical synergy in a card pool
-  python3 scripts/mtg_analyze.py synergy my_cards.json --min-freq 5
+  # Analyze mechanical interaction in a card pool
+  python3 scripts/mtg_analyze.py interaction my_cards.json --min-freq 5
 
   # Compare the color lexicon of two datasets
   python3 scripts/mtg_analyze.py lexicon data/AllPrintings.json --compare generated.txt
@@ -1535,9 +1535,10 @@ Examples:
     p_me.add_argument('--top', type=int, default=0, help='Limit the number of mechanics shown.')
     p_me.set_defaults(func=handle_mechanics)
 
-    # synergy
+    # interaction
     p_sy = subparsers.add_parser(
-        'synergy',
+        'interaction',
+        aliases=['synergy'],
         help='Analyze how mechanics appear together (co-occurrence).',
         description="""
 Analyzes how different mechanics (like Flying, Kicker, or Flashback) appear
@@ -1555,7 +1556,7 @@ expected by chance:
     add_std(p_sy)
     p_sy.add_argument('--min-freq', type=int, default=2, help='Minimum co-occurrences required to report a pair (Default: 2).')
     p_sy.add_argument('--top', type=int, default=20, help='Show the top N pairings (Default: 20).')
-    p_sy.set_defaults(func=handle_synergy)
+    p_sy.set_defaults(func=handle_interaction)
 
     # actions
     p_ac = subparsers.add_parser('actions', help='Analyze and categorize functional card effects (Removal, Buffs, etc).')

--- a/tests/test_mtg_interaction.py
+++ b/tests/test_mtg_interaction.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../scripts'))
 import scripts.mtg_analyze as mtg_analyze
 import cardlib
 
-class TestMtgSynergy(unittest.TestCase):
+class TestMtgInteraction(unittest.TestCase):
 
     def setUp(self):
         # Create sample cards with mechanics
@@ -23,8 +23,8 @@ class TestMtgSynergy(unittest.TestCase):
         self.card4 = cardlib.Card({'name': 'Vanilla', 'rarity': 'common', 'text': ''})
         self.cards = [self.card1, self.card2, self.card3, self.card4]
 
-    def test_calculate_synergy_basic(self):
-        density_dist, ind_counts, pair_counts, synergy_results = mtg_analyze.calculate_synergy(self.cards, min_freq=1)
+    def test_calculate_interaction_basic(self):
+        density_dist, ind_counts, pair_counts, interaction_results = mtg_analyze.calculate_interaction(self.cards, min_freq=1)
 
         # Density distribution:
         # card1: 2 (Flying, Haste)
@@ -55,33 +55,33 @@ class TestMtgSynergy(unittest.TestCase):
         # P(A) = 2/4 = 0.5
         # P(B) = 2/4 = 0.5
         # Lift = 0.25 / (0.5 * 0.5) = 1.0
-        flying_haste = next(r for r in synergy_results if r['pair'] == ('Flying', 'Haste'))
+        flying_haste = next(r for r in interaction_results if r['pair'] == ('Flying', 'Haste'))
         self.assertAlmostEqual(flying_haste['lift'], 1.0)
 
-    def test_calculate_synergy_min_freq(self):
+    def test_calculate_interaction_min_freq(self):
         # min_freq=2 should return no results for this dataset
-        _, _, _, synergy_results = mtg_analyze.calculate_synergy(self.cards, min_freq=2)
-        self.assertEqual(len(synergy_results), 0)
+        _, _, _, interaction_results = mtg_analyze.calculate_interaction(self.cards, min_freq=2)
+        self.assertEqual(len(interaction_results), 0)
 
-    def test_calculate_synergy_empty(self):
-        density_dist, ind_counts, pair_counts, synergy_results = mtg_analyze.calculate_synergy([], min_freq=1)
+    def test_calculate_interaction_empty(self):
+        density_dist, ind_counts, pair_counts, interaction_results = mtg_analyze.calculate_interaction([], min_freq=1)
         self.assertEqual(density_dist, {})
         self.assertEqual(len(ind_counts), 0)
         self.assertEqual(len(pair_counts), 0)
-        self.assertEqual(len(synergy_results), 0)
+        self.assertEqual(len(interaction_results), 0)
 
     @patch('jdecode.mtg_open_file')
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_main_table(self, mock_stdout, mock_open):
         mock_open.return_value = self.cards
 
-        with patch('sys.argv', ['mtg_analyze.py', 'synergy', 'dummy.json', '--no-color', '--min-freq', '1']):
+        with patch('sys.argv', ['mtg_analyze.py', 'interaction', 'dummy.json', '--no-color', '--min-freq', '1']):
             mtg_analyze.main()
 
         output = mock_stdout.getvalue()
-        self.assertIn("MECHANICAL SYNERGY ANALYSIS", output)
+        self.assertIn("MECHANICAL INTERACTION ANALYSIS", output)
         self.assertIn("Mechanical Density", output)
-        self.assertIn("Top Synergistic Pairs", output)
+        self.assertIn("Top Interaction Pairs", output)
         self.assertIn("Flying + Haste", output)
 
     @patch('jdecode.mtg_open_file')
@@ -89,21 +89,21 @@ class TestMtgSynergy(unittest.TestCase):
     def test_main_json(self, mock_stdout, mock_open):
         mock_open.return_value = self.cards
 
-        with patch('sys.argv', ['mtg_analyze.py', 'synergy', 'dummy.json', '--json', '--min-freq', '1']):
+        with patch('sys.argv', ['mtg_analyze.py', 'interaction', 'dummy.json', '--json', '--min-freq', '1']):
             mtg_analyze.main()
 
         output = json.loads(mock_stdout.getvalue())
         self.assertEqual(output['total_cards'], 4)
         self.assertIn('density_distribution', output)
-        self.assertIn('synergy_pairs', output)
-        self.assertTrue(any(p['pair'] == ['Flying', 'Haste'] for p in output['synergy_pairs']))
+        self.assertIn('interaction_pairs', output)
+        self.assertTrue(any(p['pair'] == ['Flying', 'Haste'] for p in output['interaction_pairs']))
 
     @patch('jdecode.mtg_open_file')
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_main_csv(self, mock_stdout, mock_open):
         mock_open.return_value = self.cards
 
-        with patch('sys.argv', ['mtg_analyze.py', 'synergy', 'dummy.json', '--csv', '--min-freq', '1']):
+        with patch('sys.argv', ['mtg_analyze.py', 'interaction', 'dummy.json', '--csv', '--min-freq', '1']):
             mtg_analyze.main()
 
         output = mock_stdout.getvalue()
@@ -124,7 +124,7 @@ class TestMtgSynergy(unittest.TestCase):
         mock_isatty.return_value = True
         mock_open.return_value = self.cards
 
-        with patch('sys.argv', ['mtg_analyze.py', 'synergy', 'Flying']):
+        with patch('sys.argv', ['mtg_analyze.py', 'interaction', 'Flying']):
             mtg_analyze.main()
 
         self.assertTrue(mock_open.called)
@@ -137,7 +137,7 @@ class TestMtgSynergy(unittest.TestCase):
     def test_main_no_cards(self, mock_stderr, mock_open):
         mock_open.return_value = []
 
-        with patch('sys.argv', ['mtg_analyze.py', 'synergy', 'dummy.json']):
+        with patch('sys.argv', ['mtg_analyze.py', 'interaction', 'dummy.json']):
             mtg_analyze.main()
 
         self.assertIn("No cards found matching the criteria.", mock_stderr.getvalue())


### PR DESCRIPTION
This PR refactors the mechanical co-occurrence analysis tool in `mtg_analyze.py` to remove the business buzzword "synergy" and replace it with the plain English term "interaction," as required by the project's technical writing style guide.

The refactor includes renaming the CLI subcommand (while maintaining a backward-compatible alias), updating internal function names, and refreshing all user-facing documentation and help text. The test suite has been updated and verified to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [1697698427524550005](https://jules.google.com/task/1697698427524550005) started by @RainRat*