### PR TITLE
[TEST] Refactor subtype analysis and add regression test

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -222,7 +222,7 @@ def analyze_subtypes(cards, top=10):
     cw, aw, cc = defaultdict(list), [], Counter()
     for c in cards:
         g = get_color_group(c); cc[g]+=1
-        for s in c.subtypes:
+        for s in getattr(c, 'subtypes', []):
             sc = titlecase(s.replace(utils.dash_marker, '-'))
             cw[g].append(sc); aw.append(sc)
     gf = Counter(aw); tot_gi = sum(gf.values())
@@ -1276,24 +1276,17 @@ def handle_profile(args):
 def handle_subtypes(args):
     cards = cli_utils.load_and_filter_cards(args)
     if not check_cards(cards, args): return
-    cw, aw, cc = defaultdict(list), [], Counter()
-    for c in cards:
-        g = get_color_group(c); cc[g]+=1
-        for s in c.subtypes:
-            sc = titlecase(s.replace(utils.dash_marker, '-'))
-            cw[g].append(sc); aw.append(sc)
-    gf = Counter(aw); tot_gi = sum(gf.values())
-    if not aw: return
-    c_stats = {}
-    for g in 'WUBRGMA':
-        inst = cw[g]
-        if not inst: continue
-        f = Counter(inst); tot_ci = sum(f.values()); dist = {s: (f[s]/tot_ci)/(gf[s]/tot_gi) for s in f}
-        top = sorted([s for s in dist if f[s]>=1], key=lambda s: dist[s], reverse=True)[:args.top]
-        c_stats[g] = {'top': top, 'freq': f, 'scores': dist, 'total': tot_ci, 'cnt': cc[g]}
+
+    stats = analyze_subtypes(cards, top=args.top)
+    gf = stats['global_freq']
+    if not gf: return
+
+    c_stats = stats['color_stats']
+    tot_gi = sum(gf.values())
+
     use_color = args.color if args.color is not None else (not (args.json or args.csv) and sys.stdout.isatty())
     if args.json:
-        res = {'total_cards': len(cards), 'total': len(cards), 'global_freq': dict(gf), 'color_stats': c_stats, 'stats': {g: {'top': v['top'], 'total': v['total'], 'cnt': v['cnt']} for g, v in c_stats.items()}}
+        res = {'total_cards': stats['total_cards'], 'total': stats['total'], 'global_freq': dict(gf), 'color_stats': c_stats, 'stats': {g: {'top': v['top'], 'total': v['total'], 'cnt': v['cnt']} for g, v in c_stats.items()}}
         print(json.dumps(res, indent=2))
     elif args.csv:
         w = csv.writer(sys.stdout); w.writerow(['Subtype', 'Count', 'Percent', 'Group', 'Distinctiveness'])

--- a/tests/test_mtg_subtypes_bug.py
+++ b/tests/test_mtg_subtypes_bug.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import MagicMock
+import sys
+import os
+
+# Add project root and scripts directory to path
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/..')
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../scripts')
+
+from scripts.mtg_analyze import analyze_subtypes
+import cardlib
+
+class TestMtgSubtypesBug(unittest.TestCase):
+
+    def test_analyze_subtypes_no_subtypes(self):
+        # Create a mock card with no subtypes
+        c = MagicMock(spec=cardlib.Card)
+        c.color_identity = "W"
+        c.subtypes = []
+        cards = [c]
+
+        # This should currently raise ZeroDivisionError because tot_gi will be 0
+        try:
+            stats = analyze_subtypes(cards)
+            self.assertEqual(stats['total_cards'], 1)
+        except ZeroDivisionError:
+            self.fail("analyze_subtypes raised ZeroDivisionError with no subtypes")
+        except Exception as e:
+            self.fail(f"analyze_subtypes raised unexpected exception: {e}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR improves the maintainability and reliability of the subtype analysis feature in the MTG toolkit.

### Changes:
1.  **Refactoring:** Removed approximately 15 lines of duplicated code from `handle_subtypes` in `scripts/mtg_analyze.py`. The logic is now centralized in `analyze_subtypes`, which is used by both the internal API and the CLI handler.
2.  **Robustness:** Updated `analyze_subtypes` to safely handle cards that might not have a `subtypes` attribute using `getattr`.
3.  **New Coverage:** Added `tests/test_mtg_subtypes_bug.py`, which provides regression testing for the subtype analysis logic when dealing with empty subtype lists, ensuring no `ZeroDivisionError` or other crashes occur.
4.  **Consistency:** Verified through manual testing and existing unit tests (`tests/test_mtg_subtypes.py`) that the CLI output (Table, JSON, CSV) remains unchanged for the end-user.

This change follows the Lead QA Automation Agent's priorities by addressing both Gap Analysis (new coverage for edge cases) and Test Hygiene (de-duplication and refactoring).

---
*PR created automatically by Jules for task [7385823128444452299](https://jules.google.com/task/7385823128444452299) started by @RainRat*