### PR TITLE
[FEAT] Add Mechanical Color Pie Validation to mtg_validate.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,10 +420,14 @@ Validates card data for rule and formatting consistency (e.g., checking creature
 # Basic validation
 python3 scripts/mtg_validate.py encoded_output.txt
 
+# Check for color pie violations (e.g. Blue cards with Deathtouch)
+python3 scripts/mtg_validate.py generated.txt --color-pie --dump
+
 # Print details for invalid cards
 python3 scripts/mtg_validate.py data/AllPrintings.json --dump
 ```
 *   **Options:**
+    *   `--color-pie`: Identify mechanics that don't match the card's color identity.
     *   `-d`, `--dump`: Print full details for cards that failed validation.
     *   `-n LIMIT`, `--limit LIMIT`: Only process the first N cards.
     *   `--shuffle`: Randomize the order of cards before validating.

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -50,6 +50,45 @@ ACTION_CATEGORIES = {
     ]
 }
 
+# Mapping of mechanics to their valid color identities (W, U, B, R, G, C=Colorless)
+# This represents the "Color Pie" for validation.
+MECHANIC_COLORS = {
+    'Deathtouch': 'BGC',
+    'Defender': 'WUBRGC',
+    'Double Strike': 'WRC',
+    'First Strike': 'WBRC',
+    'Flash': 'UGBC',
+    'Flying': 'WUBRC',
+    'Haste': 'RBGC',
+    'Hexproof': 'UGWC',
+    'Indestructible': 'WGBC',
+    'Lifelink': 'WBC',
+    'Menace': 'BRGC',
+    'Prowess': 'URWC',
+    'Reach': 'GRC',
+    'Trample': 'GRBC',
+    'Vigilance': 'WGC',
+    'Ward': 'WUGC',
+    'Scry': 'UWRBGC',
+    'Mill': 'UBC',
+    'Discard': 'BURC',
+    'Cycling': 'WUBRGC',
+    'Convoke': 'WGC',
+    'Flashback': 'URBWGC',
+    'Infect': 'BGUC',
+    'Toxic': 'BGWC',
+    'Uncast': 'UC', # "Counter target spell"
+}
+
+# Mapping of functional actions to valid colors
+ACTION_COLORS = {
+    'Protection': 'WGUC',
+    'Buffs': 'WGRBC',
+    'Card Advantage': 'UBGRWC',
+    'Disruption': 'BURWC',
+    'Mana': 'GRC' # Acceleration/Fixing
+}
+
 # Heuristic weights for calculating power rating
 KEYWORD_WEIGHTS = {
     'Flying': 1.5,
@@ -1033,6 +1072,37 @@ class Card:
             actions.add('Mana')
 
         return actions
+
+    def check_color_pie(self):
+        """
+        Validates the card's mechanics and actions against its color identity.
+        Returns True if the card is consistent with the color pie, a string message
+        if it has a break, and None if no relevant mechanics or actions were found to check.
+        """
+        identity = self.color_identity or 'C'
+        checked = False
+        violations = []
+
+        # 1. Check Mechanics
+        for mech in self.mechanics:
+            if mech in MECHANIC_COLORS:
+                checked = True
+                valid_colors = MECHANIC_COLORS[mech]
+                # A violation occurs if the card doesn't share ANY color with the valid set
+                if not any(c in valid_colors for c in identity):
+                    violations.append(f"{mech} (Expected {valid_colors})")
+
+        # 2. Check Actions
+        for act in self.actions:
+            if act in ACTION_COLORS:
+                checked = True
+                valid_colors = ACTION_COLORS[act]
+                if not any(c in valid_colors for c in identity):
+                    violations.append(f"{act} (Expected {valid_colors})")
+
+        if violations:
+            return "Color Pie Break: " + ", ".join(violations)
+        return True if checked else None
 
     @property
     def rarity_name(self):

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -365,6 +365,12 @@ def check_quotes(card):
                 retval = retval and thisval
     return retval
 
+def check_color_pie(card):
+    res = card.check_color_pie()
+    if isinstance(res, str):
+        return False
+    return res
+
 props = OrderedDict([
     ('types', check_types),
     ('pt', check_pt),
@@ -383,6 +389,7 @@ props = OrderedDict([
     ('shuffle', check_shuffle),
     ('activated', check_activated),
     ('triggered', check_triggered),
+    ('color_pie', check_color_pie),
 ])
 
 def process_props(cards, dump = False, uncovered = False, quiet = False):
@@ -411,7 +418,12 @@ def process_props(cards, dump = False, uncovered = False, quiet = False):
                     if card.name not in ['demonic pact', 'lavaclaw reaches',
                                          "ertai's trickery", 'rumbling aftershocks', # i hate these
                     ] and dump:
-                        print(('---- ' + prop + ' ----'))
+                        msg = '---- ' + prop + ' ----'
+                        if prop == 'color_pie':
+                            detail = card.check_color_pie()
+                            if isinstance(detail, str):
+                                msg += ' (' + detail + ')'
+                        print(msg)
                         print((card.encode()))
                         print((card.format()))
                 values[prop] = (total, good, bad)
@@ -441,7 +453,12 @@ def main(fname, oname = None, verbose = False, dump = False,
          mechanics=None,
          identities=None, id_counts=None,
          shuffle = False, seed = None, quiet = False, decklist_file = None,
-         booster = 0, sort = None, reverse_sort = False, limit = 0, use_color = None, box = 0):
+         booster = 0, sort = None, reverse_sort = False, limit = 0, use_color = None, box = 0,
+         color_pie = False):
+
+    if not color_pie:
+        if 'color_pie' in props:
+            del props['color_pie']
 
     # Use the robust mtg_open_file for all loading and filtering.
     cards = jdecode.mtg_open_file(fname, verbose=verbose, linetrans=not nolinetrans,
@@ -655,6 +672,8 @@ Usage Examples:
     proc_group = parser.add_argument_group('Processing Options')
     proc_group.add_argument('-d', '--dump', action='store_true',
                         help='Show the text of cards that failed validation (useful for debugging).')
+    proc_group.add_argument('--color-pie', action='store_true',
+                        help='Flag cards that violate the mechanical color pie.')
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Only process the first N cards.')
     proc_group.add_argument('--shuffle', action='store_true',
@@ -774,5 +793,6 @@ Usage Examples:
          mechanics=args.mechanic,
          identities=args.identity, id_counts=args.id_count,
          shuffle = args.shuffle, seed = args.seed, quiet = args.quiet, decklist_file = args.deck,
-         booster = args.booster, sort = args.sort, reverse_sort = args.reverse, limit = args.limit, use_color = args.color, box = args.box)
+         booster = args.booster, sort = args.sort, reverse_sort = args.reverse, limit = args.limit, use_color = args.color, box = args.box,
+         color_pie = args.color_pie)
     exit(0)

--- a/tests/test_color_pie_validation.py
+++ b/tests/test_color_pie_validation.py
@@ -1,0 +1,103 @@
+import unittest
+import sys
+import os
+
+# Add lib and scripts directories to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../scripts'))
+
+import cardlib
+
+class TestColorPieValidation(unittest.TestCase):
+
+    def test_mechanic_violations(self):
+        # Blue creature with Deathtouch (Break: Deathtouch is BGC)
+        break_card = cardlib.Card({
+            'name': 'Spy',
+            'manaCost': '{U}',
+            'types': ['Creature'],
+            'text': 'Deathtouch',
+            'pt': '1/1'
+        })
+        res = break_card.check_color_pie()
+        self.assertIsInstance(res, str)
+        self.assertIn('Deathtouch', res)
+
+        # Black creature with Deathtouch (Valid)
+        valid_card = cardlib.Card({
+            'name': 'Assassin',
+            'manaCost': '{B}',
+            'types': ['Creature'],
+            'text': 'Deathtouch',
+            'pt': '1/1'
+        })
+        self.assertTrue(valid_card.check_color_pie())
+
+    def test_uncast_violation(self):
+        # Green card with "uncast" (Break: Uncast is UC)
+        break_card = cardlib.Card({
+            'name': 'Nature\'s No',
+            'manaCost': '{G}',
+            'types': ['Instant'],
+            'text': 'uncast target spell'
+        })
+        res = break_card.check_color_pie()
+        self.assertIsInstance(res, str)
+        self.assertIn('Uncast', res)
+
+        # Blue card with "uncast" (Valid)
+        valid_card = cardlib.Card({
+            'name': 'Counterspell',
+            'manaCost': '{UU}',
+            'types': ['Instant'],
+            'text': 'uncast target spell'
+        })
+        self.assertTrue(valid_card.check_color_pie())
+
+    def test_mana_action(self):
+        # Blue creature that adds mana (Break: Mana is GRC)
+        break_card = cardlib.Card({
+            'name': 'Mana Merfolk',
+            'manaCost': '{U}',
+            'types': ['Creature'],
+            'text': 'T: Add {U}',
+            'pt': '1/1'
+        })
+        # Note: In our current implementation, 'Mana' action is mapped to 'GRC'
+        res = break_card.check_color_pie()
+        self.assertIsInstance(res, str)
+        self.assertIn('Mana', res)
+
+        # Green creature that adds mana (Valid)
+        valid_card = cardlib.Card({
+            'name': 'Llanowar Elves',
+            'manaCost': '{G}',
+            'types': ['Creature'],
+            'text': 'T: Add {G}',
+            'pt': '1/1'
+        })
+        self.assertTrue(valid_card.check_color_pie())
+
+    def test_no_relevant_features(self):
+        # Vanilla 2/2 for 2 (Should return None, as it has no mechanics/actions mapped in the color pie)
+        vanilla = cardlib.Card({
+            'name': 'Grizzly Bears',
+            'manaCost': '{1}{G}',
+            'types': ['Creature'],
+            'pt': '2/2'
+        })
+        self.assertIsNone(vanilla.check_color_pie())
+
+    def test_colorless_defender(self):
+        # Colorless artifact with Defender (Valid: Defender is WUBRGC)
+        wall = cardlib.Card({
+            'name': 'Wall',
+            'types': ['Artifact', 'Creature'],
+            'text': 'Defender',
+            'pt': '0/4'
+        })
+        self.assertTrue(wall.check_color_pie())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a new "Mechanical Color Pie Validation" feature to the MTG toolkit.

AI-generated cards often mix mechanics from different colors (e.g., a Mono-Blue card with Deathtouch). While the toolkit previously supported analyzing these trends, it had no way to automatically flag these "color pie breaks" during validation.

Key improvements:
1.  **Core Logic:** Added heuristic mappings of mechanics and functional actions to their canonical colors in `lib/cardlib.py`. The `check_color_pie` method evaluates if a card's features align with its color identity.
2.  **CLI Integration:** A new `--color-pie` flag in `scripts/mtg_validate.py` enables this check. Violations are reported as descriptive validation failures, which can be viewed in detail using the `--dump` flag.
3.  **Documentation:** Added examples to `README.md` showing how to use the new flag to filter generated datasets.
4.  **Testing:** Included a new unit test suite (`tests/test_color_pie_validation.py`) covering various violation types, valid cases, and edge cases like vanilla and colorless cards.

This feature provides immediate value for set designers and researchers looking to verify the flavor and mechanical integrity of generated content.

---
*PR created automatically by Jules for task [9884230063447596947](https://jules.google.com/task/9884230063447596947) started by @RainRat*