### PR TITLE
[TEST] Increase coverage for lib/cardlib.py to 100%

### DIFF
--- a/tests/test_cardlib_final_gaps.py
+++ b/tests/test_cardlib_final_gaps.py
@@ -1,0 +1,83 @@
+import pytest
+from lib.cardlib import Card, cap
+
+def test_cap_empty_string():
+    assert cap("") == ""
+
+def test_card_actions_with_bside_recursion():
+    card_json = {
+        "name": "Side A",
+        "types": ["Instant"],
+        "rarity": "Common",
+        "text": "Destroy target creature.",
+        "bside": {
+            "name": "Side B",
+            "types": ["Instant"],
+            "text": "Draw a card."
+        }
+    }
+    card = Card(card_json)
+    actions = card.actions
+    assert "Removal" in actions
+    assert "Card Advantage" in actions
+
+def test_card_header_with_bside_recursion():
+    card_json = {
+        "name": "Side A",
+        "types": ["Land"],
+        "rarity": "Common",
+        "bside": {
+            "name": "Side B",
+            "types": ["Land"],
+            "rarity": "Common"
+        }
+    }
+    card = Card(card_json)
+    header = card.header()
+    assert "Side A" in header
+    assert "Side B" in header
+    assert " // " in header
+
+def test_card_summary_functional_actions_ansi():
+    card_json = {
+        "name": "Murder",
+        "manaCost": "{1}{B}{B}",
+        "types": ["Instant"],
+        "rarity": "Common",
+        "text": "Destroy target creature."
+    }
+    card = Card(card_json)
+    summary = card.summary(ansi_color=True)
+    assert "Removal" in summary
+    assert "\033[" in summary
+
+def test_card_to_dict_includes_produced_colors():
+    card_json = {
+        "name": "Mountain",
+        "types": ["Land"],
+        "subtypes": ["Mountain"],
+        "rarity": "Basic Land"
+    }
+    card = Card(card_json)
+    d = card.to_dict()
+    assert "producedColors" in d
+    assert "R" in d["producedColors"]
+
+def test_card_cap_with_special_markers():
+    # @ is this_marker, \v is reserved_marker
+    assert cap("@") == "@"
+    assert cap("\v") == "\v"
+
+def test_card_summary_creature_fair_mv_ansi():
+    card_json = {
+        "name": "Bear",
+        "manaCost": "{1}{G}",
+        "types": ["Creature"],
+        "power": "2",
+        "toughness": "2",
+        "rarity": "Common"
+    }
+    card = Card(card_json)
+    summary = card.summary(ansi_color=True)
+    assert "Fair MV" in summary
+    assert "\033[" in summary


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added comprehensive unit tests to cover the remaining 27% of `lib/cardlib.py`, specifically targeting:
    * The `cap()` utility function for empty strings and special markers.
    * Recursive action and header logic for multi-face cards (`bside`).
    * Functional action and Fair MV summaries with ANSI color formatting.
    * Metadata and produced color extraction in `to_dict()`.
* **Why:** To ensure the core card representation library is fully verified, preventing regressions in card parsing, transformation, and display logic.

---
*PR created automatically by Jules for task [18145722180652554914](https://jules.google.com/task/18145722180652554914) started by @RainRat*