### PR TITLE
[FEAT] Add mtg_eval.py for automated model quality assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,21 @@ python3 scripts/mtg_analyze.py summary encoded_output.txt summary.json
     *   `--color` / `--no-color`: Enable or disable ANSI color output.
     *   Supports all **Advanced Filtering** flags (e.g., `--limit`, `--sample`, `--grep`, `--cmc`, `--mechanic`).
 
+### `mtg_eval.py`
+Evaluates the quality of a trained AI model checkpoint by generating a sample of cards and automatically running the validation suite. It calculates a 'Mechanical Accuracy Score' based on how many cards follow Magic's rules logic (e.g., P/T on creatures, X-cost usage).
+```bash
+# Evaluate a checkpoint by generating 100 cards
+python3 scripts/mtg_eval.py checkpoint.pt --count 100
+
+# See details for cards that failed validation
+python3 scripts/mtg_eval.py checkpoint.pt --count 20 --dump
+```
+*   **Options:**
+    *   `-c N`, `--count N`: Number of cards to generate and evaluate (Default: 100).
+    *   `-t TEMP`, `--temp TEMP`: Sampling temperature (Default: 0.8).
+    *   `-d`, `--dump`: Print details for cards that failed validation.
+    *   `--seed N`: Random seed for sampling.
+
 ### `mtg_validate.py`
 Validates card data for rule and formatting consistency (e.g., checking creature stats or land costs). It works with all supported input formats (JSON, CSV, XML, encoded text, etc.).
 ```bash

--- a/scripts/mtg_eval.py
+++ b/scripts/mtg_eval.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+import sys
+import os
+import argparse
+import io
+import torch
+from contextlib import redirect_stdout
+
+# Add lib and root directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+rootdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../')
+sys.path.append(libdir)
+sys.path.append(rootdir)
+
+import utils
+import cardlib
+import mtg_validate
+import train
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Evaluate the quality of a trained MTG AI model checkpoint.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+This tool generates a sample of cards from a model checkpoint and automatically
+runs the validation suite to calculate a 'Mechanical Accuracy Score'.
+
+Usage Examples:
+  # Evaluate a specific checkpoint by generating 50 cards
+  python3 scripts/mtg_eval.py checkpoint.pt --count 50
+
+  # Evaluate and show details for cards that failed validation
+  python3 scripts/mtg_eval.py checkpoint.pt --count 20 --dump
+"""
+    )
+
+    parser.add_argument('checkpoint', help='Path to the model checkpoint (.pt file).')
+    parser.add_argument('-c', '--count', type=int, default=100,
+                        help='Number of cards to generate and evaluate (Default: 100).')
+    parser.add_argument('-t', '--temp', type=float, default=0.8,
+                        help='Sampling temperature (Default: 0.8).')
+    parser.add_argument('-d', '--dump', action='store_true',
+                        help='Show the text of cards that failed validation.')
+    parser.add_argument('--seed', type=int, help='Random seed for sampling.')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Enable detailed status messages.')
+    parser.add_argument('-q', '--quiet', action='store_true', help='Suppress status messages.')
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.checkpoint):
+        print(f"Error: Checkpoint file '{args.checkpoint}' not found.", file=sys.stderr)
+        sys.exit(1)
+
+    # 1. Load Model and Generate Cards
+    if not args.quiet:
+        print(f"Loading checkpoint and generating cards from {args.checkpoint}...", file=sys.stderr)
+
+    try:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        checkpoint = torch.load(args.checkpoint, map_location=device, weights_only=False)
+
+        chars = checkpoint['vocab']
+        char_to_idx = checkpoint['char_to_idx']
+        idx_to_char = checkpoint['idx_to_char']
+        vocab_size = len(chars)
+
+        train_args = checkpoint['args']
+        model = train.CharRNN(vocab_size, train_args.hidden_size, train_args.n_layers).to(device)
+        model.load_state_dict(checkpoint['model_state_dict'])
+
+        # We need to construct a sample_args object for generate_text
+        sample_args = argparse.Namespace(
+            temp=args.temp,
+            start_text="|",
+            seed=args.seed,
+            # Placeholder for forced attributes (all None)
+            name=None, supertypes=None, types=None, loyalty=None, subtypes=None,
+            rarity=None, powertoughness=None, manacost=None,
+            bodytext_prepend=None, bodytext_append=None
+        )
+
+        # Increase heuristic length if count is high (approx 250 chars per card)
+        gen_len = args.count * 250
+
+        generated_text = train.generate_text(model, char_to_idx, idx_to_char, vocab_size, device, sample_args, length=gen_len)
+
+    except Exception as e:
+        print(f"Error during sampling: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # 2. Parse into Card objects
+    raw_cards = generated_text.split(utils.cardsep)
+    cards = []
+    for rc in raw_cards:
+        if rc.strip() and rc.count('|') >= 8: # Basic heuristic for a full card
+            cards.append(cardlib.Card(rc))
+
+    # Ensure we only evaluate the requested count
+    cards = cards[:args.count]
+
+    if not cards:
+        print("Error: Could not parse any cards from the generated text. "
+              "Check if your model was trained with the standard encoding.", file=sys.stderr)
+        if args.verbose:
+            print(f"Raw output sample:\n{generated_text[:500]}...", file=sys.stderr)
+        sys.exit(1)
+
+    # 3. Validate
+    if not args.quiet:
+        print(f"Validating {len(cards)} generated cards...", file=sys.stderr)
+
+    ((total_all, total_good, total_bad, total_uncovered), values) = mtg_validate.process_props(
+        cards, dump=args.dump, quiet=args.quiet
+    )
+
+    # 4. Report
+    use_color = sys.stdout.isatty()
+
+    utils.print_header("MODEL EVALUATION REPORT", use_color=use_color)
+    print(f"  Checkpoint:  {args.checkpoint}")
+    print(f"  Generated:   {total_all} cards")
+    print(f"  Temperature: {args.temp}")
+    print()
+
+    # Accuracy Score
+    accuracy = (total_good / total_all * 100) if total_all > 0 else 0
+    score_color = utils.Ansi.BOLD
+    if accuracy >= 80: score_color += utils.Ansi.GREEN
+    elif accuracy >= 50: score_color += utils.Ansi.YELLOW
+    else: score_color += utils.Ansi.RED
+
+    score_str = f"Mechanical Accuracy Score: {accuracy:.1f}%"
+    if use_color:
+        score_str = utils.colorize(score_str, score_color)
+    print(f"  {score_str}")
+    print()
+
+    # Property Breakdown Table
+    import datalib
+    rows = [[
+        utils.colorize("Property", utils.Ansi.BOLD + utils.Ansi.UNDERLINE) if use_color else "Property",
+        "Success %",
+        "Status"
+    ]]
+
+    for prop in mtg_validate.props:
+        (total, good, bad) = values[prop]
+        if total > 0:
+            pct = (good / total * 100)
+            bar = datalib.get_bar_chart(pct, use_color, color=utils.Ansi.CYAN)
+            rows.append([prop, f"{pct:5.1f}%", bar])
+
+    datalib.add_separator_row(rows)
+    datalib.printrows(datalib.padrows(rows, aligns=['l', 'r', 'l']), indent=4)
+    print()
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_mtg_eval.py
+++ b/tests/test_mtg_eval.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import argparse
+import os
+import sys
+import io
+
+# Add lib and root directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+rootdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../')
+sys.path.append(libdir)
+sys.path.append(rootdir)
+
+from scripts import mtg_eval
+
+class TestMtgEval(unittest.TestCase):
+
+    @patch('os.path.exists')
+    @patch('torch.load')
+    @patch('train.CharRNN')
+    @patch('train.generate_text')
+    @patch('mtg_validate.process_props')
+    @patch('argparse.ArgumentParser.parse_args')
+    def test_mtg_eval_basic(self, mock_args, mock_validate, mock_generate, mock_rnn, mock_torch_load, mock_exists):
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_args.return_value = argparse.Namespace(
+            checkpoint='dummy.pt',
+            count=2,
+            temp=0.8,
+            dump=False,
+            seed=None,
+            verbose=False,
+            quiet=True
+        )
+
+        mock_torch_load.return_value = {
+            'vocab': ['a', 'b'],
+            'char_to_idx': {'a': 0, 'b': 1},
+            'idx_to_char': {0: 'a', 1: 'b'},
+            'model_state_dict': {},
+            'args': argparse.Namespace(hidden_size=64, n_layers=1)
+        }
+
+        # Mock CharRNN instance
+        mock_model = MagicMock()
+        mock_rnn.return_value = mock_model
+
+        # Generated text with 2 cards, 10 pipes each
+        mock_generate.return_value = "|5creature|4|6cat|7|8&^^/&^^|9text|3{W}|0O|1name|\n\n|5creature|4|6bird|7|8&^/&^|9flying|3{U}|0O|1bird|"
+
+        from scripts import mtg_validate
+        mock_values = {prop: (0, 0, 0) for prop in mtg_validate.props}
+        mock_values['types'] = (2, 2, 0)
+
+        mock_validate.return_value = (
+            (2, 2, 0, 0), # total_all, total_good, total_bad, total_uncovered
+            mock_values
+        )
+
+        # Run main
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            mtg_eval.main()
+            output = fake_out.getvalue()
+
+        self.assertIn("MODEL EVALUATION REPORT", output)
+        self.assertIn("Mechanical Accuracy Score: 100.0%", output)
+        self.assertIn("types", output)
+
+    @patch('os.path.exists')
+    def test_mtg_eval_missing_checkpoint(self, mock_exists):
+        mock_exists.return_value = False
+        with patch('argparse.ArgumentParser.parse_args') as mock_args:
+            mock_args.return_value = argparse.Namespace(checkpoint='missing.pt')
+            with patch('sys.stderr', new=io.StringIO()) as fake_err:
+                with self.assertRaises(SystemExit):
+                    mtg_eval.main()
+                self.assertIn("Error: Checkpoint file 'missing.pt' not found.", fake_err.getvalue())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### [FEAT] Add mtg_eval.py for automated model quality assessment

#### What:
Added `scripts/mtg_eval.py`, a new utility that bridges the gap between model training and performance analysis. It handles sampling and validation in a single command, calculating success rates for mechanical consistency (e.g., P/T on creatures, X-cost usage).

#### Why:
I noticed that while the project has robust training (`train.py`) and validation (`scripts/mtg_validate.py`) tools, the workflow for checking if a model is actually learning to design valid cards was manual and repetitive. A user would have to manually sample from a checkpoint, save to a file, and then run the validator. Furthermore, the existing `scripts/autosample.py` is a legacy script from the old Torch/Lua backend and is currently non-functional.

This new script provides a modern, Python-based evaluation loop that gives immediate feedback on model quality via a "Mechanical Accuracy Score".

#### Changes:
1.  **Created `scripts/mtg_eval.py`**: Integrated `train.py` sampling and `mtg_validate.py` properties check.
2.  **Added `tests/test_mtg_eval.py`**: A new unit test suite using mocks to verify the evaluation logic and error handling.
3.  **Updated `README.md`**: Added documentation and usage examples for the new utility.

#### Verification:
- Verified the script manually by training a tiny 1-epoch model and running `mtg_eval.py` on the resulting checkpoint.
- Ran the full project test suite (`pytest`) to ensure zero regressions.
- Verified that the new unit tests pass with `PYTHONPATH=lib:scripts:. python3 -m pytest tests/test_mtg_eval.py`.

---
*PR created automatically by Jules for task [1066494263362013010](https://jules.google.com/task/1066494263362013010) started by @RainRat*