### PR TITLE
[TEST] Refactor mtg_query functional tests and add multi-face coverage

### DIFF
--- a/tests/test_mtg_functional.py
+++ b/tests/test_mtg_functional.py
@@ -1,85 +1,136 @@
-import subprocess
 import json
+import io
+import sys
+import os
+import unittest
+import tempfile
+from unittest.mock import patch
+from scripts.mtg_query import main as query_main
 
-def test_functional_basic(tmp_path):
-    """Test basic functional reprint detection."""
-    d = tmp_path / "subdir"
-    d.mkdir()
-    test_file = d / "test_functional.json"
+class TestMtgFunctional(unittest.TestCase):
 
-    with open(test_file, "w") as f:
-        json.dump([
-            {
-                "name": "Card A",
-                "manaCost": "{1}{W}",
-                "types": ["Creature"],
-                "subtypes": ["Human"],
-                "power": "2",
-                "toughness": "2",
-                "text": "First strike",
-                "rarity": "Common"
-            },
-            {
-                "name": "Card B",
-                "manaCost": "{1}{W}",
-                "types": ["Creature"],
-                "subtypes": ["Human"],
-                "power": "2",
-                "toughness": "2",
-                "text": "First strike",
-                "rarity": "Common"
-            }
-        ], f)
+    def run_main(self, args):
+        with patch('sys.argv', ['mtg_query.py', 'functional'] + args):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                with patch('sys.stderr', new=io.StringIO()) as fake_err:
+                    try:
+                        query_main()
+                        code = 0
+                    except SystemExit as e:
+                        code = e.code if isinstance(e.code, int) else 0
+                    return code, fake_out.getvalue(), fake_err.getvalue()
 
-    cmd = ["python3", "scripts/mtg_query.py", "functional", str(test_file), "--no-color"]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    assert result.returncode == 0
-    assert "FUNCTIONAL REPRINT GROUPS (1 match)" in result.stdout
-    assert "Card A, Card B" in result.stdout
-    # Standardized summary in stderr
-    assert "Functional check complete" in result.stderr
+    def test_functional_basic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_functional.json")
+            with open(test_file, "w") as f:
+                json.dump([
+                    {
+                        "name": "Card A",
+                        "manaCost": "{1}{W}",
+                        "types": ["Creature"],
+                        "subtypes": ["Human"],
+                        "power": "2",
+                        "toughness": "2",
+                        "text": "First strike",
+                        "rarity": "Common"
+                    },
+                    {
+                        "name": "Card B",
+                        "manaCost": "{1}{W}",
+                        "types": ["Creature"],
+                        "subtypes": ["Human"],
+                        "power": "2",
+                        "toughness": "2",
+                        "text": "First strike",
+                        "rarity": "Common"
+                    }
+                ], f)
 
-def test_functional_no_match(tmp_path):
-    """Test output when no functional reprints are found."""
-    test_file = tmp_path / "test_no_functional.json"
-    with open(test_file, "w") as f:
-        json.dump([
-            {
-                "name": "Card A",
-                "manaCost": "{1}{W}",
-                "types": ["Creature"],
-                "subtypes": ["Human"],
-                "power": "2",
-                "toughness": "2",
-                "text": "First strike",
-                "rarity": "Common"
-            },
-            {
-                "name": "Card C",
-                "manaCost": "{U}",
-                "types": ["Instant"],
-                "text": "Draw a card.",
-                "rarity": "Common"
-            }
-        ], f)
+            code, out, err = self.run_main([test_file, "--no-color"])
+            self.assertEqual(code, 0)
+            self.assertIn("FUNCTIONAL REPRINT GROUPS (1 match)", out)
+            self.assertIn("Card A, Card B", out)
+            self.assertIn("Functional check complete", err)
 
-    cmd = ["python3", "scripts/mtg_query.py", "functional", str(test_file), "--no-color"]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    assert "No functional reprints found." in result.stderr
+    def test_functional_no_match(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_no_functional.json")
+            with open(test_file, "w") as f:
+                json.dump([
+                    {
+                        "name": "Card A",
+                        "manaCost": "{1}{W}",
+                        "types": ["Creature"],
+                        "subtypes": ["Human"],
+                        "power": "2",
+                        "toughness": "2",
+                        "text": "First strike",
+                        "rarity": "Common"
+                    },
+                    {
+                        "name": "Card C",
+                        "manaCost": "{U}",
+                        "types": ["Instant"],
+                        "text": "Draw a card.",
+                        "rarity": "Common"
+                    }
+                ], f)
 
-def test_functional_json_output(tmp_path):
-    """Test JSON output format."""
-    test_file = tmp_path / "test_functional_json.json"
-    with open(test_file, "w") as f:
-        json.dump([
-            {"name": "A", "manaCost": "{W}", "types": ["Creature"], "power": "1", "toughness": "1"},
-            {"name": "B", "manaCost": "{W}", "types": ["Creature"], "power": "1", "toughness": "1"}
-        ], f)
+            code, out, err = self.run_main([test_file, "--no-color"])
+            self.assertIn("No functional reprints found.", err)
 
-    cmd = ["python3", "scripts/mtg_query.py", "functional", str(test_file), "--json"]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    assert result.returncode == 0
-    data = json.loads(result.stdout)
-    assert len(data) == 1
-    assert "A" in data[0]['names']
-    assert "B" in data[0]['names']
+    def test_functional_json_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_functional_json.json")
+            with open(test_file, "w") as f:
+                json.dump([
+                    {"name": "A", "manaCost": "{W}", "types": ["Creature"], "power": "1", "toughness": "1"},
+                    {"name": "B", "manaCost": "{W}", "types": ["Creature"], "power": "1", "toughness": "1"}
+                ], f)
+
+            code, out, err = self.run_main([test_file, "--json"])
+            self.assertEqual(code, 0)
+            data = json.loads(out)
+            self.assertEqual(len(data), 1)
+            self.assertIn("A", data[0]['names'])
+            self.assertIn("B", data[0]['names'])
+
+    def test_functional_multi_face(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_functional_multi.json")
+            with open(test_file, "w") as f:
+                json.dump([
+                    {
+                        "name": "Split A",
+                        "manaCost": "{R}",
+                        "types": ["Instant"],
+                        "text": "Deal 1 damage.",
+                        "bside": {
+                            "name": "Split A (Back)",
+                            "manaCost": "{G}",
+                            "types": ["Sorcery"],
+                            "text": "Draw a card."
+                        }
+                    },
+                    {
+                        "name": "Split B",
+                        "manaCost": "{R}",
+                        "types": ["Instant"],
+                        "text": "Deal 1 damage.",
+                        "bside": {
+                            "name": "Split B (Back)",
+                            "manaCost": "{G}",
+                            "types": ["Sorcery"],
+                            "text": "Draw a card."
+                        }
+                    }
+                ], f)
+
+            code, out, err = self.run_main([test_file, "--no-color"])
+            self.assertEqual(code, 0)
+            self.assertIn("FUNCTIONAL REPRINT GROUPS (1 match)", out)
+            self.assertIn("Split A, Split B", out)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR improves the test suite for `mtg_query.py` by:
1.  **Refactoring** `tests/test_mtg_functional.py` to move away from `subprocess.run` in favor of direct `main()` execution. This allows `pytest-cov` to accurately record coverage for the `functional` subcommand logic.
2.  **Closing a coverage gap** by adding `test_functional_multi_face`, which ensures that the functional reprint detection correctly handles and compares multi-faced cards (e.g., split cards) using their `bside` property.
3.  **Improving Test Hygiene** by standardizing the test structure to use `unittest.TestCase` and `unittest.mock.patch`, following project best practices.

---
*PR created automatically by Jules for task [4508909569857615729](https://jules.google.com/task/4508909569857615729) started by @RainRat*