### PR TITLE
[DOCS] Replace MTG jargon with plain English in `mtg_query.py`

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -628,7 +628,7 @@ def handle_shell(args):
 
     use_color = args.color if args.color is not None else sys.stdout.isatty()
 
-    welcome = "MTG Interactive Shell. Type a card name for Oracle text, or /search for bulk queries."
+    welcome = "MTG Interactive Shell. Type a card name for official rules text, or /search for bulk queries."
     if use_color:
         welcome = utils.colorize(welcome, utils.Ansi.BOLD + utils.Ansi.CYAN)
     print(welcome)
@@ -659,7 +659,7 @@ def handle_shell(args):
                 _execute_search(matched_cards, s_args)
             elif line.startswith('/help'):
                 print("Commands:")
-                print("  <card name>   - Show Oracle text for a card.")
+                print("  <card name>   - Show official rules text for a card.")
                 print("  /search <q>   - Search for cards matching <q>.")
                 print("  /exit, /quit  - Exit the shell.")
             else:
@@ -867,11 +867,11 @@ def handle_functional(args):
 
     if not functional_reprints:
         if not args.quiet:
-            print("No functional reprints found.", file=sys.stderr)
+            print("No cards with the same mechanics found.", file=sys.stderr)
         return
 
     if not args.quiet:
-        print("Functional check complete.", file=sys.stderr)
+        print("Completed search for cards with the same mechanics.", file=sys.stderr)
 
     use_color = args.color if args.color is not None else sys.stdout.isatty()
 
@@ -887,7 +887,7 @@ def handle_functional(args):
     else:
         if not args.quiet:
             count_str = f"{len(functional_reprints)} match" if len(functional_reprints) == 1 else f"{len(functional_reprints)} matches"
-            utils.print_header("FUNCTIONAL REPRINT GROUPS", count=count_str, use_color=use_color)
+            utils.print_header("GROUPS WITH THE SAME MECHANICS", count=count_str, use_color=use_color)
 
         for group in functional_reprints:
             names = sorted(list(set(titlecase(c.name.replace(utils.dash_marker, '-')) for c in group)))
@@ -1147,15 +1147,15 @@ Usage Examples:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Usage Examples:
-  # List all functional reprints (same mechanics, different name)
+  # List all cards with the same mechanics (but different names)
   python3 scripts/mtg_query.py functional data/AllPrintings.json
 
-  # Find functional reprints of Goblins
+  # Find cards with the same mechanics as Goblins
   python3 scripts/mtg_query.py functional --grep "Goblin"
 """
     )
     p_functional.add_argument('infile', nargs='?', default='-',
-                            help='Input card data (JSON, CSV, XML, or encoded text) to check for functional reprints.')
+                            help='Input card data (JSON, CSV, XML, or encoded text) to check for cards with the same mechanics.')
     cli_utils.add_standard_filters(p_functional)
     cli_utils.add_standard_output_args(p_functional)
     p_functional.set_defaults(func=handle_functional)

--- a/tests/test_mtg_functional.py
+++ b/tests/test_mtg_functional.py
@@ -34,10 +34,10 @@ def test_functional_basic(tmp_path):
     cmd = ["python3", "scripts/mtg_query.py", "functional", str(test_file), "--no-color"]
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 0
-    assert "FUNCTIONAL REPRINT GROUPS (1 match)" in result.stdout
+    assert "GROUPS WITH THE SAME MECHANICS (1 match)" in result.stdout
     assert "Card A, Card B" in result.stdout
     # Standardized summary in stderr
-    assert "Functional check complete" in result.stderr
+    assert "Completed search for cards with the same mechanics" in result.stderr
 
 def test_functional_no_match(tmp_path):
     """Test output when no functional reprints are found."""
@@ -65,7 +65,7 @@ def test_functional_no_match(tmp_path):
 
     cmd = ["python3", "scripts/mtg_query.py", "functional", str(test_file), "--no-color"]
     result = subprocess.run(cmd, capture_output=True, text=True)
-    assert "No functional reprints found." in result.stderr
+    assert "No cards with the same mechanics found." in result.stderr
 
 def test_functional_json_output(tmp_path):
     """Test JSON output format."""


### PR DESCRIPTION
This change improves the accessibility of the `mtg_query.py` tool for a global audience by removing domain-specific jargon. 

Key improvements:
*   The interactive shell and help strings now use "**official rules text**" instead of "**Oracle text**".
*   The `functional` subcommand now refers to "**cards with the same mechanics**" instead of "**functional reprints**".
*   The corresponding test suite in `tests/test_mtg_functional.py` has been updated to ensure all assertions match the new terminology.

These changes follow the project's style guide for simplicity and plain English.

---
*PR created automatically by Jules for task [11139992804862239650](https://jules.google.com/task/11139992804862239650) started by @RainRat*