### PR TITLE
[TEST] Enhance color pie validation logic and test coverage

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -33,7 +33,8 @@ ACTION_CATEGORIES = {
         r'\bdestroy\b', r'\bexile target\b', r'sacrifice (a|target|an)\b',
         r'deals? \d+ damage to (target|each) (creature|planeswalker|permanent)',
         r'deals? &[\^]+ damage to (target|each) (creature|planeswalker|permanent)',
-        r'return (target|each) [^:]* to (its|their) owner\'s hand'
+        r'return (target|each) [^:]* to (its|their) owner\'s hand',
+        r'gets? \-&[\^]+/\-&[\^]+'
     ],
     'Protection': [
         r'\bhexproof\b', r'\bindestructible\b', r'\bward\b', r'\bprotection from\b', r'\bshroud\b', r'\bregenerate\b'
@@ -57,7 +58,7 @@ MECHANIC_COLORS = {
     'Defender': 'WUBRGC',
     'Double Strike': 'WRC',
     'First Strike': 'WBRC',
-    'Flash': 'UGBC',
+    'Flash': 'UGWBC',
     'Flying': 'WUBRC',
     'Haste': 'RBGC',
     'Hexproof': 'UGWC',
@@ -68,7 +69,7 @@ MECHANIC_COLORS = {
     'Reach': 'GRC',
     'Trample': 'GRBC',
     'Vigilance': 'WGC',
-    'Ward': 'WUGC',
+    'Ward': 'WUBRGC',
     'Scry': 'UWRBGC',
     'Mill': 'UBC',
     'Discard': 'BURC',
@@ -82,11 +83,12 @@ MECHANIC_COLORS = {
 
 # Mapping of functional actions to valid colors
 ACTION_COLORS = {
-    'Protection': 'WGUC',
+    'Removal': 'WBRGUC',
+    'Protection': 'WUBRGC',
     'Buffs': 'WGRBC',
     'Card Advantage': 'UBGRWC',
     'Disruption': 'BURWC',
-    'Mana': 'GRC' # Acceleration/Fixing
+    'Mana': 'GRRC' # Acceleration/Fixing (R for rituals)
 }
 
 # Heuristic weights for calculating power rating

--- a/tests/test_qa_color_pie_comprehensive.py
+++ b/tests/test_qa_color_pie_comprehensive.py
@@ -1,0 +1,84 @@
+import pytest
+from lib.cardlib import Card
+
+def test_white_flash_no_break():
+    # Test that White cards with Flash are no longer flagged as breaks
+    card_json = {
+        "name": "White Flash Creature",
+        "manaCost": "{1}{W}",
+        "types": ["Creature"],
+        "power": "&^^",
+        "toughness": "&^^",
+        "text": "Flash"
+    }
+    card = Card(card_json)
+    assert card.check_color_pie() is True
+
+def test_black_red_ward_no_break():
+    # Black card with Ward
+    card_b = Card({
+        "name": "Black Ward",
+        "manaCost": "{B}",
+        "types": ["Creature"],
+        "power": "&^",
+        "toughness": "&^",
+        "text": "Ward {2}"
+    })
+    assert card_b.check_color_pie() is True
+
+    # Red card with Ward
+    card_r = Card({
+        "name": "Red Ward",
+        "manaCost": "{R}",
+        "types": ["Creature"],
+        "power": "&^",
+        "toughness": "&^",
+        "text": "Ward {1}"
+    })
+    assert card_r.check_color_pie() is True
+
+def test_red_mana_ritual_no_break():
+    # Red card with mana ritual
+    card = Card({
+        "name": "Red Ritual",
+        "manaCost": "{R}",
+        "types": ["Sorcery"],
+        "text": "Add {R}{R}{R}."
+    })
+    assert "Mana" in card.actions
+    assert card.check_color_pie() is True
+
+def test_neg_n_removal_detection():
+    # Card with -N/-N effect should be identified as Removal
+    card = Card({
+        "name": "Death's Caress",
+        "manaCost": "{B}",
+        "types": ["Instant"],
+        "text": "Target creature gets -&^^/-&^^ until end of turn."
+    })
+    assert "Removal" in card.actions
+    assert card.check_color_pie() is True
+
+def test_colorless_no_incorrect_flag():
+    # Artifact with standard mechanic
+    card = Card({
+        "name": "Steel Wall",
+        "manaCost": "{1}",
+        "types": ["Artifact", "Creature"],
+        "power": "0",
+        "toughness": "4",
+        "text": "Defender"
+    })
+    # Identity is 'C'. Defender allows 'C'.
+    assert card.check_color_pie() is True
+
+    card_flying = Card({
+        "name": "Flying Thopter",
+        "manaCost": "{2}",
+        "types": ["Artifact", "Creature"],
+        "power": "1",
+        "toughness": "1",
+        "text": "Flying"
+    })
+    # Flying allows 'C'.
+    assert card_flying.check_color_pie() is True


### PR DESCRIPTION
This PR improves the accuracy of the color pie validation logic in `lib/cardlib.py` and adds a new test suite to ensure comprehensive coverage.

Key changes:
1.  **Enhanced Detection:** Added a regex to `ACTION_CATEGORIES['Removal']` to correctly identify `-N/-N` effects as removal actions.
2.  **Modernized Color Pie:** Updated `MECHANIC_COLORS` and `ACTION_COLORS` to align with modern Magic: The Gathering design principles, notably allowing White cards to have Flash and Black/Red cards to have Ward without triggering color pie break warnings.
3.  **Expanded Action Mapping:** Included `Removal` in the `ACTION_COLORS` mapping and added Red to the `Mana` action category to account for rituals.
4.  **Comprehensive Testing:** Introduced `tests/test_qa_color_pie_comprehensive.py`, which validates these changes against various card scenarios (White Flash, Black/Red Ward, Red Rituals, and Black `-N/-N` removal).

These updates reduce false positives in the design health check (`mtg_analyze.py audit`) and improve the utility of the color pie validation feature.

---
*PR created automatically by Jules for task [9475368276418328788](https://jules.google.com/task/9475368276418328788) started by @RainRat*