### PR TITLE
[UI/UX] Enhance multi-faced card clarity and mana production visibility in Oracle view

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -745,7 +745,7 @@ class Card:
                 produced.add(color)
 
         text = self.get_text(force_unpass=True).lower()
-        any_patterns = ["any color", "any chosen color", "one mana of any color", "any combination of colors"]
+        any_patterns = ["any color", "any chosen color", "one mana of any color", "any combination of colors", "any one color"]
         if any(p in text for p in any_patterns):
             return {"Any"}
 

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -475,14 +475,18 @@ def _execute_oracle(cards, args):
                 if is_bside:
                     # Subtle divider for secondary faces
                     print("  " + "." * 40)
-                    # For B-sides in detailed view, we show a mini-summary
+                    # For B-sides in detailed view, we show name, type, and stats
+                    face_name = face.display_name
+                    if use_color:
+                        face_name = utils.colorize(face_name, face._get_ansi_color())
+
                     face_info = face.get_type_line(separator='-')
                     stats = face._get_pt_display(ansi_color=use_color) or face._get_loyalty_display(ansi_color=use_color)
                     if stats:
                         face_info += f" • {stats}"
                     if use_color:
                         face_info = utils.colorize(face_info, utils.Ansi.GREEN)
-                    print("  " + face_info)
+                    print(f"  {face_name} \u2022 {face_info}")
                 else:
                     print("  " + "-" * 40)
 
@@ -515,6 +519,21 @@ def _execute_oracle(cards, args):
                 id_parts.append(f"{fmt_label('IDENTITY:')} {colored_id}")
             else:
                 id_parts.append(f"IDENTITY: {identity}")
+
+            produced = c.produced_colors
+            if produced:
+                # Sort in WUBRGC order
+                p_order = "WUBRGC"
+                p_list = sorted(list(produced), key=lambda x: p_order.find(x) if x in p_order else 99)
+                if "Any" in produced:
+                    p_str = "Any"
+                    if use_color:
+                        p_str = utils.colorize(p_str, utils.Ansi.BOLD + utils.Ansi.YELLOW)
+                elif use_color:
+                    p_str = "".join([utils.colorize(char, utils.Ansi.get_color_color(char)) for char in p_list])
+                else:
+                    p_str = "".join(p_list)
+                id_parts.append(f"{fmt_label('PRODUCED:')} {p_str}")
 
             url = utils.get_scryfall_url(c.set_code, c.number)
             if url:

--- a/testdata/mana_test.json
+++ b/testdata/mana_test.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "TST": {
+      "name": "Test Set",
+      "code": "TST",
+      "type": "expansion",
+      "cards": [
+        {
+          "name": "Llanowar Elves",
+          "manaCost": "{G}",
+          "rarity": "common",
+          "type": "Creature — Elf Druid",
+          "types": ["Creature"],
+          "subtypes": ["Elf", "Druid"],
+          "text": "{T}: Add {G}.",
+          "power": "1",
+          "toughness": "1",
+          "setCode": "TST"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR improves the usability and information density of the `oracle` command's detailed view.

Key improvements:
1. **Multi-faced Card Clarity**: Previously, B-sides only showed their type line and stats. They now display their full name, making it easier to identify transformed or split card faces.
2. **Mana Production Metadata**: A new `PRODUCED:` field has been added to the metadata footer. This field summarizes the colors a card can generate (in WUBRGC order), reducing the need to parse rules text for mana dorks or fixing lands.
3. **Improved Detection**: The `produced_colors` logic was enhanced to correctly identify the "any one color" pattern (e.g., Gilded Lotus).
4. **Visual Consistency**: Mana symbols in the `PRODUCED:` and `IDENTITY:` fields now use standard color-coding, and the `PRODUCED:` label matches the existing bold cyan hierarchy.

---
*PR created automatically by Jules for task [15493879479298871588](https://jules.google.com/task/15493879479298871588) started by @RainRat*