### PR TITLE
Inline _normalized_color_identity in mtg_analyze.py

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -61,23 +61,17 @@ GUILD_LABELS = {
 
 # --- Shared Helpers ---
 
-def _normalized_color_identity(card):
-    identity = getattr(card, 'color_identity', '')
-    if isinstance(identity, str):
-        if identity:
-            return identity
-    elif isinstance(identity, (list, tuple)):
-        if identity:
-            return ''.join(identity)
-    colors = getattr(getattr(card, 'cost', None), 'colors', None)
-    if colors:
-        return ''.join(colors)
-    return ''
-
-
 def get_color_group(card):
     """Categorizes a card by color identity (W, U, B, R, G, Multi, Colorless)."""
-    identity = _normalized_color_identity(card)
+    identity = getattr(card, 'color_identity', '')
+    if isinstance(identity, str) and identity:
+        pass
+    elif isinstance(identity, (list, tuple)) and identity:
+        identity = ''.join(identity)
+    else:
+        colors = getattr(getattr(card, 'cost', None), 'colors', None)
+        identity = ''.join(colors) if colors else ''
+
     if len(identity) > 1: return 'M'
     if len(identity) == 1: return identity[0]
     return 'A'


### PR DESCRIPTION
This PR resolves an instance of **Premature Abstraction** in `scripts/mtg_analyze.py`. 

The private helper function `_normalized_color_identity(card)` was used exactly once within `get_color_group(card)`. By inlining this logic, we reduce the cognitive load and complexity of the module without changing its behavior. 

The inlined logic has been slightly simplified while maintaining safety:
- It uses the standard `Card.color_identity` property.
- it handles cases where `color_identity` might be a string, list, or tuple.
- It preserves the fallback to `card.cost.colors` for cards missing an explicit identity.
- It ensures compatibility with mocked card objects in test suites.

Verified by running `tests/test_mtg_colorpie.py`, `tests/test_mtg_stats.py`, `tests/test_mtg_grid.py`, `tests/test_mtg_types.py`, `tests/test_mtg_lexicon.py`, and `tests/test_mtg_subtypes.py`. All 45 tests passed.

---
*PR created automatically by Jules for task [9563640437884266021](https://jules.google.com/task/9563640437884266021) started by @RainRat*