### PR TITLE
[TEST] Fix multi-line X-cost validation and add coverage

### DIFF
--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -153,7 +153,8 @@ def check_X(card):
             elif 'contain {X' in linetext or 'with {X' in linetext:
                 correct = True
                 
-            elif ('additional cost' in linetext
+            elif (defs > 0
+                  or 'additional cost' in linetext
                   or 'morph' in linetext
                   or 'kicker' in linetext):
                 cost_lines += 1

--- a/tests/test_mtg_validate_gaps.py
+++ b/tests/test_mtg_validate_gaps.py
@@ -56,6 +56,15 @@ class TestMtgValidateGaps(unittest.TestCase):
         c = cardlib.Card({"name": "Polukranos", "types": ["Creature"], "text": "{X}{X}{G}: Monstrosity X."})
         self.assertTrue(mtg_validate.check_X(c))
 
+    def test_check_X_multi_line(self):
+        # Card where X is defined on one line and used on another
+        c = cardlib.Card({
+            "name": "X Manager",
+            "types": ["Enchantment"],
+            "text": "X is the number of creatures you control.\nAt the beginning of your upkeep, gain X life."
+        })
+        self.assertTrue(mtg_validate.check_X(c))
+
     def test_check_triggered_variants(self):
         c = cardlib.Card({"name": "Upkeep", "types": ["Enchantment"], "text": "At the beginning of your upkeep, gain 1 life."})
         self.assertTrue(mtg_validate.check_triggered(c))


### PR DESCRIPTION
This PR fixes a bug in the card validator where cards with 'X' defined on a separate line from its usage were being incorrectly flagged as invalid.

Changes:
- Modified `check_X` in `scripts/mtg_validate.py` to count lines containing 'X is' or other definition patterns as valid definition lines (`cost_lines`).
- Added `test_check_X_multi_line` to `tests/test_mtg_validate_gaps.py` to verify the fix.
- Verified that all validation tests pass.

---
*PR created automatically by Jules for task [10778766740209487420](https://jules.google.com/task/10778766740209487420) started by @RainRat*