### PR TITLE
[TEST] Fix logic duplication in token extraction and add regression tests

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -835,64 +835,6 @@ class Card:
         return count
 
     @property
-    def tokens(self):
-        """Returns a list of token definitions extracted from the card's rules text."""
-        found = self.get_face_tokens()
-        if self.bside:
-            found.extend(self.bside.tokens)
-        return found
-
-    def get_face_tokens(self):
-        """Returns a list of token definitions extracted from this card face."""
-        text = self.get_text(force_unpass=True).replace('\n', ' ').strip()
-        found = []
-
-        # 1. Standard Creature Tokens
-        # e.g., "Create a 2/2 white Knight creature token with vigilance."
-        c_regex = r"(?:[Cc]reate)\s+(?:[Aa]n?|two|three|four|five|X)\s+([0-9/X+&^]+)\s+([a-zA-Z\s,]+)\s+token[s]?(?:\s+with\s+([^,.]+))?"
-        for m in re.finditer(c_regex, text):
-            pt, ct, ab = m.group(1), m.group(2).strip(), m.group(3).strip() if m.group(3) else ""
-            if ct.lower().endswith(' creature'):
-                ct = ct[:-9]
-
-            # Extract colors from the type string
-            colors = [c.capitalize() for c in ['white', 'blue', 'black', 'red', 'green', 'colorless'] if c in ct.lower()]
-
-            # Clean up types by removing colors and other markers
-            ty = ct
-            for x in ['white', 'blue', 'black', 'red', 'green', 'colorless', 'multi', 'and', ',']:
-                ty = re.sub(r'\b' + x + r'\b' if x.isalpha() else re.escape(x), '', ty, flags=re.IGNORECASE)
-            ty = " ".join([t.capitalize() for t in ty.split()])
-
-            found.append({
-                'name': f"{pt} {', '.join(colors) if colors else 'Colorless'} {ty} Token",
-                'pt': pt,
-                'color': ", ".join(colors) if colors else "Colorless",
-                'type': f"{ty} Creature".strip(),
-                'abilities': ab
-            })
-
-        # 2. Predefined Named Tokens
-        # e.g., "Create a Treasure token."
-        ntks = ['Treasure', 'Food', 'Clue', 'Blood', 'Map', 'Role', 'Incubator', 'Powerstone', 'Walker']
-        n_regex = r"(?:[Cc]reate)\s+(?:[Aa]n?|two|three|four|five|X)\s+(" + "|".join(ntks) + r")\s+token[s]?"
-        for m in re.finditer(n_regex, text, re.IGNORECASE):
-            n = m.group(1).capitalize()
-            t = {'name': f"{n} Token", 'pt': "", 'color': "Colorless", 'type': n, 'abilities': ""}
-            if n == 'Treasure':
-                t['type'] = 'Artifact'
-                t['abilities'] = 'Sacrifice this artifact: Add one mana of any color.'
-            elif n == 'Food':
-                t['type'] = 'Artifact'
-                t['abilities'] = '{2}, {T}, Sacrifice this artifact: gain 3 life.'
-            elif n == 'Clue':
-                t['type'] = 'Artifact'
-                t['abilities'] = '{2}, Sac: Draw a card.'
-            found.append(t)
-
-        return found
-
-    @property
     def display_name(self):
         """Returns the card name formatted for display (titlecased and unpassed)."""
         return titlecase(transforms.name_unpass_1_dashes(self.name))

--- a/tests/test_mtg_tokens.py
+++ b/tests/test_mtg_tokens.py
@@ -17,8 +17,8 @@ def test_mtg_tokens_basic():
     tokens = json.loads(result.stdout)
 
     # Verify we found the expected number of unique tokens
-    # (1/1 Soldier, 2/2 Drake, 3/3 Beast, Food, Treasure)
-    assert len(tokens) == 5
+    # (1/1 Soldier, 2/2 Drake, 3/3 Beast, Food, Treasure, 4/4 Rhino)
+    assert len(tokens) == 6
 
     # Verify specific token properties
     names = [t['name'] for t in tokens]

--- a/tests/test_mtg_tokens_chained.py
+++ b/tests/test_mtg_tokens_chained.py
@@ -1,0 +1,38 @@
+import pytest
+from lib.cardlib import Card
+
+def test_chained_token_creation():
+    """Verify that multiple tokens created in a single sentence are correctly identified."""
+    card_json = {
+        "name": "Multi Token Generator",
+        "manaCost": "{4}{W}{G}",
+        "types": ["Sorcery"],
+        "text": "Create two 1/1 white Soldier creature tokens and a 4/4 green Rhino creature token with trample.",
+        "rarity": "rare"
+    }
+    card = Card(card_json)
+    tokens = card.tokens
+    token_names = [t['name'] for t in tokens]
+
+    assert len(tokens) == 2
+    assert "1/1 White Soldier Token" in token_names
+    assert "4/4 Green Rhino Token" in token_names
+
+    # Verify rhino properties
+    rhino = next(t for t in tokens if "Rhino" in t['name'])
+    assert rhino['pt'] == "4/4"
+    assert rhino['color'] == "Green"
+    assert rhino['abilities'] == "trample"
+
+def test_chained_token_creation_case_variation():
+    """Verify robust handling of 'and' with different casing."""
+    card_json = {
+        "name": "Another Generator",
+        "types": ["Sorcery"],
+        "text": "Create a 1/1 white Spirit creature token with flying AND a 1/1 colorless Spirit creature token.",
+        "rarity": "uncommon"
+    }
+    card = Card(card_json)
+    token_names = [t['name'] for t in card.tokens]
+    assert "1/1 White Spirit Token" in token_names
+    assert "1/1 Colorless Spirit Token" in token_names


### PR DESCRIPTION
This PR addresses a logic duplication issue in `lib/cardlib.py` where the `tokens` property and `get_face_tokens` method were defined twice. The second (inferior) implementation shadowed the first, leading to bugs in identifying tokens from complex rules text—specifically chained creation phrases like "Create two 1/1 white Soldier creature tokens and a 4/4 green Rhino creature token".

**Changes:**
- **Refactor:** Removed the redundant shadowing methods at the end of the `Card` class. The class now correctly uses the centralized `extract_tokens_from_text` helper.
- **New Coverage:** Added `tests/test_mtg_tokens_chained.py` which specifically tests multi-token creation in various formats and casings.
- **Bug Fix:** Updated `tests/test_mtg_tokens.py` expectations; the sample dataset now correctly identifies 6 unique tokens instead of 5, as the '4/4 Green Rhino' was previously missed.

All tests passed, ensuring improved reliability and maintainability of the card analysis toolkit.

---
*PR created automatically by Jules for task [13466455408037620608](https://jules.google.com/task/13466455408037620608) started by @RainRat*