### PR TITLE
[DOCS] Remove MTG jargon 'functional reprints' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,10 +568,10 @@ python3 scripts/mtg_query.py sets --grep "Masters"
 ---
 
 #### **Subcommand: `functional`**
-Identifies 'functional reprints' (different name, same mechanics).
+Identifies cards with the same mechanics but different names.
 
 ```bash
-# List all functional reprints
+# List all cards with the same mechanics
 python3 scripts/mtg_query.py functional
 
 # Create a deduplicated dataset


### PR DESCRIPTION
### Documentation Improvement: Removing MTG Jargon

This PR improves the readability and accessibility of the project documentation by replacing specialized Magic: The Gathering jargon with plain English descriptions.

**Changes:**
- Updated `README.md` to replace "functional reprints" with "cards with the same mechanics but different names" and "cards with the same mechanics".
- Ensured consistency between the documentation and the jargon-free CLI help strings.

**Why:**
- **Accessibility:** Using plain English makes the project more approachable for international users and developers who may not be familiar with niche Magic: The Gathering terminology.
- **Clarity:** "Cards with the same mechanics" is a more descriptive and accurate term for a general audience.
- **Consistency:** Aligns the README with recent improvements to internal tool help text.

**Verification:**
- Verified that all 1127 tests pass (`PYTHONPATH=lib:scripts:. python3 -m pytest`).
- Confirmed that no other instances of "functional reprint" remain in the README.
- Followed the "exactly one documentation improvement" rule by focusing on this specific terminology update.

---
*PR created automatically by Jules for task [15923218853095337771](https://jules.google.com/task/15923218853095337771) started by @RainRat*