### PR TITLE
[FEAT] Integrated Color Pie Break Detection and Filtering

### DIFF
--- a/lib/cli_utils.py
+++ b/lib/cli_utils.py
@@ -72,6 +72,8 @@ def add_standard_filters(parser):
     filter_group.add_argument('--action', action='append',
                         help='Only include cards with specific functional actions (Removal, Protection, Buffs, Card Advantage, Disruption, or Mana). '
                              'Supports multiple values (OR logic).')
+    filter_group.add_argument('--color-pie-break', action='store_true',
+                        help='Only include cards that violate the mechanical color pie (e.g., Blue cards with Deathtouch).')
     filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     filter_group.add_argument('--booster', type=int, default=0,
@@ -186,6 +188,7 @@ def load_and_filter_cards(args):
                                   loys=getattr(args, 'loy', None),
                                   mechanics=getattr(args, 'mechanic', None),
                                   actions=getattr(args, 'action', None),
+                                  color_pie_break=getattr(args, 'color_pie_break', False),
                                   identities=getattr(args, 'identity', None), 
                                   id_counts=getattr(args, 'id_count', None),
                                   decklist_file=getattr(args, 'deck', None),

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -846,6 +846,7 @@ def mtg_open_file(fname, verbose = False,
                   pows=None, tous=None, loys=None,
                   mechanics=None,
                   actions=None,
+                  color_pie_break=False,
                   identities=None, id_counts=None,
                   shuffle=False, seed=None,
                   decklist_file=None,
@@ -1175,7 +1176,7 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
-    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics or actions or identities or id_counts:
+    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics or actions or identities or id_counts or color_pie_break:
         # Sanitize queries to match internal representations (hyphens are dash_marker)
         greps = _compile_patterns(grep, sanitize=True)
         vgreps = _compile_patterns(vgrep, sanitize=True)
@@ -1380,6 +1381,13 @@ def mtg_open_file(fname, verbose = False,
                         match_id_count = True
                         break
                 if not match_id_count:
+                    return False
+
+            # Color Pie Break filtering
+            if color_pie_break:
+                res = card.check_color_pie()
+                # If it's a string, it's a break
+                if not isinstance(res, str):
                     return False
 
             return True

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -58,7 +58,7 @@ FIELD_MAP = {
     'rating': {'header': 'Rating', 'align': 'r', 'aliases': ['power_rating']},
     'fair_cmc': {'header': 'Fair MV', 'align': 'r', 'aliases': ['fcmc', 'fair_cost', 'fair_mv', 'recommended_cmc']},
     'produced': {'header': 'Produced', 'align': 'l', 'aliases': ['produced_mana', 'mana_produced']},
-    'tokens': {'header': 'Tokens', 'align': 'l', 'aliases': ['creates']},
+    'color_pie': {'header': 'Color Pie', 'align': 'l', 'aliases': ['break', 'violation']},
     'summary': {'header': 'Summary', 'align': 'l', 'aliases': ['view']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
@@ -196,6 +196,18 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
                 res.append(n)
                 seen.add(n)
         return ", ".join(res)
+    elif canon == 'color_pie':
+        res = card.check_color_pie()
+        if res is True or res is None:
+            res = "Valid"
+            if ansi_color:
+                res = utils.colorize(res, utils.Ansi.BOLD + utils.Ansi.GREEN)
+        else:
+            if ansi_color:
+                res = utils.colorize(str(res), utils.Ansi.BOLD + utils.Ansi.RED)
+            else:
+                res = str(res)
+        return res
     elif canon == 'summary':
         return card.summary(ansi_color=ansi_color).replace('\u2014', '-')
     elif canon == 'encoded':
@@ -656,6 +668,13 @@ def _execute_oracle(cards, args):
                 if use_color:
                     tok_val = utils.colorize(tok_val, utils.Ansi.CYAN)
                 footer_lines.append(f"{fmt_label('TOKENS:')} {tok_val}")
+
+            cp_res = c.check_color_pie()
+            if isinstance(cp_res, str):
+                cp_val = cp_res
+                if use_color:
+                    cp_val = utils.colorize(cp_val, utils.Ansi.BOLD + utils.Ansi.RED)
+                footer_lines.append(f"{fmt_label('COLOR PIE:')} {cp_val}")
 
             print() # Spacer before footer
             for line in footer_lines:
@@ -1234,7 +1253,7 @@ Note: If no input file is provided, data/AllPrintings.json is used if available.
     p_search.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
                         help='Comma-separated list of fields to extract. Available fields:\n'
                              '  - Basic: name, cost, cmc, type, stats, text, rarity\n'
-                             '  - Analysis: mechanics, actions, tokens, identity, complexity, rating, fair_mv\n'
+                             '  - Analysis: mechanics, actions, tokens, identity, complexity, rating, fair_mv, color_pie\n'
                              '  - Metadata: set, number, pack, box')
     p_search.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')


### PR DESCRIPTION
This feature adds the ability to filter and identify cards that violate the mechanical color pie (e.g., Blue cards with Deathtouch) across the toolkit. It introduces a new `--color-pie-break` filter to all scripts using `cli_utils`, and exposes a `color_pie` field in `mtg_query.py` for tabular and detailed output.

I noticed that while `mtg_validate.py` could check for color pie breaks, there was no way to filter for them during search or see the specific violation details directly in `mtg_query.py`. This adds a powerful "Symmetry" between validation and exploration, allowing users to quickly find and inspect "broken" designs in AI-generated datasets or official data.

---
*PR created automatically by Jules for task [6346790707180886277](https://jules.google.com/task/6346790707180886277) started by @RainRat*