### PR TITLE
Consolidate redundant token logic and clean up field retrieval in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -58,7 +58,6 @@ FIELD_MAP = {
     'rating': {'header': 'Rating', 'align': 'r', 'aliases': ['power_rating']},
     'fair_cmc': {'header': 'Fair MV', 'align': 'r', 'aliases': ['fcmc', 'fair_cost', 'fair_mv', 'recommended_cmc']},
     'produced': {'header': 'Produced', 'align': 'l', 'aliases': ['produced_mana', 'mana_produced']},
-    'tokens': {'header': 'Tokens', 'align': 'l', 'aliases': ['creates']},
     'summary': {'header': 'Summary', 'align': 'l', 'aliases': ['view']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
@@ -131,8 +130,6 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return ", ".join(sorted(list(card.mechanics)))
     elif canon == 'actions':
         return ", ".join(sorted(list(card.actions)))
-    elif canon == 'tokens':
-        res = ", ".join([t['name'] for t in card.get_face_tokens()])
     elif canon == 'identity':
         res = card.color_identity
         if ansi_color and res:
@@ -204,10 +201,7 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return ""
 
     if card.bside:
-        if canon in ['rarity', 'set', 'pack', 'box', 'id_count', 'identity', 'mechanics', 'summary', 'tokens']:
-            if canon == 'tokens':
-                all_tokens = [t['name'] for t in card.tokens]
-                return ", ".join(all_tokens)
+        if canon in ['rarity', 'set', 'pack', 'box', 'id_count']:
             return str(res)
         b_res = get_field_value(card.bside, field, ansi_color, multi_sep=multi_sep)
         if res and b_res:


### PR DESCRIPTION
Consolidated the duplicate `'tokens'` definition in `FIELD_MAP`, removed redundant face-only logic in `get_field_value`, and eliminated unreachable code for recursive fields in the b-side handling block. This improves code maintainability and readability by eliminating logic duplication and ensuring consistent behavior for multi-face cards. No external behavior was changed, as confirmed by existing tests and manual verification of aliases and recursive fields.

---
*PR created automatically by Jules for task [4913911868660653443](https://jules.google.com/task/4913911868660653443) started by @RainRat*