### PR TITLE
[UI/UX] Unify table header styling in mtg_query search command

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -356,7 +356,10 @@ def _execute_search(cards, args):
                 writer.writerow([get_field_value(c, f, ansi_color=False) for f in field_list])
     elif getattr(args, 'table', False) or getattr(args, 'md_table', False):
         header = [FIELD_MAP.get(get_field_canonical_name(f), {}).get('header', f) for f in field_list]
-        rows = [header]
+        display_header = header
+        if getattr(args, 'table', False) and use_color:
+            display_header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
+        rows = [display_header]
         for c in cards:
             rows.append([get_field_value(c, f, ansi_color=use_color) for f in field_list])
         


### PR DESCRIPTION
**Context:** CLI

**Problem:** The `search` subcommand in `mtg_query.py` displayed plain text table headers, which lacked visual hierarchy and consistency with other commands like `compare` that used bold and underlined styling. This made it harder to distinguish between metadata (headers) and card data in dense terminal output.

**Solution:** Updated the `_execute_search` function to apply `BOLD + UNDERLINE` styling to table headers when ANSI color is enabled and a standard table (not Markdown) is being generated. This improves readability and provides a consistent "look and feel" across the toolkit's query tools.

**Changes:**
```python
<<<<<<< SEARCH
    elif getattr(args, 'table', False) or getattr(args, 'md_table', False):
        header = [FIELD_MAP.get(get_field_canonical_name(f), {}).get('header', f) for f in field_list]
        rows = [header]
        for c in cards:
            rows.append([get_field_value(c, f, ansi_color=use_color) for f in field_list])
=======
    elif getattr(args, 'table', False) or getattr(args, 'md_table', False):
        header = [FIELD_MAP.get(get_field_canonical_name(f), {}).get('header', f) for f in field_list]
        display_header = header
        if getattr(args, 'table', False) and use_color:
            display_header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
        rows = [display_header]
        for c in cards:
            rows.append([get_field_value(c, f, ansi_color=use_color) for f in field_list])
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [17768310487151535148](https://jules.google.com/task/17768310487151535148) started by @RainRat*