### PR TITLE
[DOCS] Improve CLI help for the audit subcommand

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1685,7 +1685,29 @@ thematic language used for each part of the color pie.
     p_prof.set_defaults(func=handle_profile)
 
     # audit
-    p_audit = subparsers.add_parser('audit', help='Perform a comprehensive design health audit of a card dataset.')
+    p_audit = subparsers.add_parser(
+        'audit',
+        help='Perform a comprehensive design health audit of a card dataset.',
+        description="""
+Performs a comprehensive 'Health Check' for card datasets. It evaluates
+core design metrics and identifies potential issues.
+
+The audit includes:
+- Core Metrics: Creature density, average mana cost, and complexity.
+- Functional Coverage: Density of removal, card advantage, and mana fixing.
+- Complexity Analysis: Identification of the most wordy or complex cards.
+- Rules Integrity: Detection of mechanical color pie violations.
+""",
+        epilog="""
+Examples:
+  # Perform a health audit for a generated set
+  python3 scripts/mtg_analyze.py audit generated.txt
+
+  # Audit a specific set and output results to JSON
+  python3 scripts/mtg_analyze.py audit data/AllPrintings.json --set MOM --json > audit.json
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     add_std(p_audit)
     p_audit.set_defaults(func=handle_audit)
 


### PR DESCRIPTION
The `audit` subcommand in `scripts/mtg_analyze.py` previously had a very brief help string that didn't explain what it actually checked. 

This change:
1. Adds a detailed `description` explaining the specific design metrics calculated by the audit (Core Metrics, Functional Coverage, Complexity, and Rules Integrity).
2. Adds an `epilog` with practical usage examples for both AI-generated and official datasets.
3. Uses `RawDescriptionHelpFormatter` to ensure the multi-line text displays correctly.

These improvements align with the project's 'Plain English' style guidelines and make the toolkit more accessible to new users.

---
*PR created automatically by Jules for task [9030827988617060735](https://jules.google.com/task/9030827988617060735) started by @RainRat*