### PR TITLE
Fix tokens field deduplication and b-side handling in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -58,7 +58,6 @@ FIELD_MAP = {
     'rating': {'header': 'Rating', 'align': 'r', 'aliases': ['power_rating']},
     'fair_cmc': {'header': 'Fair MV', 'align': 'r', 'aliases': ['fcmc', 'fair_cost', 'fair_mv', 'recommended_cmc']},
     'produced': {'header': 'Produced', 'align': 'l', 'aliases': ['produced_mana', 'mana_produced']},
-    'tokens': {'header': 'Tokens', 'align': 'l', 'aliases': ['creates']},
     'summary': {'header': 'Summary', 'align': 'l', 'aliases': ['view']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
@@ -131,8 +130,6 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return ", ".join(sorted(list(card.mechanics)))
     elif canon == 'actions':
         return ", ".join(sorted(list(card.actions)))
-    elif canon == 'tokens':
-        res = ", ".join([t['name'] for t in card.get_face_tokens()])
     elif canon == 'identity':
         res = card.color_identity
         if ansi_color and res:
@@ -204,10 +201,7 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return ""
 
     if card.bside:
-        if canon in ['rarity', 'set', 'pack', 'box', 'id_count', 'identity', 'mechanics', 'summary', 'tokens']:
-            if canon == 'tokens':
-                all_tokens = [t['name'] for t in card.tokens]
-                return ", ".join(all_tokens)
+        if canon == 'rarity':
             return str(res)
         b_res = get_field_value(card.bside, field, ansi_color, multi_sep=multi_sep)
         if res and b_res:


### PR DESCRIPTION
### What:
This PR fixes a logic bug in the `tokens` field of `scripts/mtg_query.py` and cleans up redundant logic in the `get_field_value` function.

1.  **Consolidated `FIELD_MAP`:** Removed a duplicate `'tokens'` key.
2.  **Fixed `tokens` Logic:** Removed an inferior `elif canon == 'tokens'` block that only processed the current card face. The remaining (superior) implementation now uses the recursive `card.tokens` property and deduplicates token names.
3.  **Refactored B-Side Handling:** Removed several fields (`set`, `pack`, `box`, `id_count`, `identity`, `mechanics`, `summary`) from the manual b-side exclusion list. These fields already perform recursive aggregation and return early in the main function body, making the subsequent `if card.bside` fallthrough block redundant and potentially buggy for these fields.

### Why:
*   **Accuracy:** Previously, the `tokens` field displayed duplicates for cards that mentioned the same token on both faces (e.g., transform cards).
*   **Performance & Readability:** Reducing indirection and removing unreachable code paths makes the card field resolution logic easier to maintain.
*   **Safety:** The changes are non-breaking; official regression tests pass, and manual verification with a multi-face token producer confirms correct behavior.

---
*PR created automatically by Jules for task [17665747747724781744](https://jules.google.com/task/17665747747724781744) started by @RainRat*