### PR TITLE
[FEAT] Mechanical Color Pie Integrity Validation and Filtering

### DIFF
--- a/lib/cli_utils.py
+++ b/lib/cli_utils.py
@@ -72,6 +72,8 @@ def add_standard_filters(parser):
     filter_group.add_argument('--action', action='append',
                         help='Only include cards with specific functional actions (Removal, Protection, Buffs, Card Advantage, Disruption, or Mana). '
                              'Supports multiple values (OR logic).')
+    filter_group.add_argument('--color-pie-break', action='store_true',
+                        help='Only include cards that violate the mechanical color pie (e.g. Green cards with Haste).')
     filter_group.add_argument('--deck-filter', '--decklist-filter', dest='deck',
                         help='Filter cards using a standard MTG decklist file. Also multiplies cards in the output based on their counts in the decklist.')
     filter_group.add_argument('--booster', type=int, default=0,
@@ -186,6 +188,7 @@ def load_and_filter_cards(args):
                                   loys=getattr(args, 'loy', None),
                                   mechanics=getattr(args, 'mechanic', None),
                                   actions=getattr(args, 'action', None),
+                                  color_pie_break=getattr(args, 'color_pie_break', False),
                                   identities=getattr(args, 'identity', None), 
                                   id_counts=getattr(args, 'id_count', None),
                                   decklist_file=getattr(args, 'deck', None),

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -846,6 +846,7 @@ def mtg_open_file(fname, verbose = False,
                   pows=None, tous=None, loys=None,
                   mechanics=None,
                   actions=None,
+                  color_pie_break=False,
                   identities=None, id_counts=None,
                   shuffle=False, seed=None,
                   decklist_file=None,
@@ -1175,7 +1176,7 @@ def mtg_open_file(fname, verbose = False,
                                    exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                    decklist_names=decklist_names)
 
-    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics or actions or identities or id_counts:
+    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics or actions or color_pie_break or identities or id_counts:
         # Sanitize queries to match internal representations (hyphens are dash_marker)
         greps = _compile_patterns(grep, sanitize=True)
         vgreps = _compile_patterns(vgrep, sanitize=True)
@@ -1370,6 +1371,12 @@ def mtg_open_file(fname, verbose = False,
                     elif ti in card_identity:
                         match_identity = True
                 if not match_identity:
+                    return False
+
+            # Color Pie Break filtering
+            if color_pie_break:
+                res = card.check_color_pie()
+                if not isinstance(res, str):
                     return False
 
             # Identity Count filtering

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -60,6 +60,7 @@ FIELD_MAP = {
     'produced': {'header': 'Produced', 'align': 'l', 'aliases': ['produced_mana', 'mana_produced']},
     'tokens': {'header': 'Tokens', 'align': 'l', 'aliases': ['creates']},
     'summary': {'header': 'Summary', 'align': 'l', 'aliases': ['view']},
+    'color_pie': {'header': 'Color Pie', 'align': 'l', 'aliases': ['break']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
 
@@ -198,6 +199,17 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return ", ".join(res)
     elif canon == 'summary':
         return card.summary(ansi_color=ansi_color).replace('\u2014', '-')
+    elif canon == 'color_pie':
+        status = card.check_color_pie()
+        if status is True:
+            res = "Valid"
+            if ansi_color: res = utils.colorize(res, utils.Ansi.BOLD + utils.Ansi.GREEN)
+        elif isinstance(status, str):
+            res = status
+            if ansi_color: res = utils.colorize(res, utils.Ansi.BOLD + utils.Ansi.RED)
+        else:
+            res = ""
+        return res
     elif canon == 'encoded':
         res = card.encode()
     else:
@@ -610,10 +622,14 @@ def _execute_oracle(cards, args):
 
             footer_lines.append(" \u2022 ".join(id_parts))
 
-            # 2. Design Metrics Line (Complexity, Rating, Fair MV)
+            # 2. Design Analytics Line (Complexity, Rating, Fair MV, Color Pie)
             comp_val = str(c.complexity_score)
             rate_val = f"{c.power_rating:.3f}"
             fair_val = str(c.recommended_cmc)
+            pie_val = ""
+            pie_status = c.check_color_pie()
+            if pie_status is True: pie_val = "Valid"
+            elif isinstance(pie_status, str): pie_val = pie_status
 
             if use_color:
                 comp_val = utils.colorize(comp_val, utils.Ansi.BOLD + utils.Ansi.MAGENTA)
@@ -628,9 +644,14 @@ def _execute_oracle(cards, args):
                 f_color = utils.Ansi.BOLD + (utils.Ansi.GREEN if c.cost.cmc >= c.recommended_cmc else utils.Ansi.RED)
                 fair_val = utils.colorize(fair_val, f_color)
 
+                if pie_status is True: pie_val = utils.colorize(pie_val, utils.Ansi.BOLD + utils.Ansi.GREEN)
+                elif isinstance(pie_status, str): pie_val = utils.colorize(pie_val, utils.Ansi.BOLD + utils.Ansi.RED)
+
             score_line = f"{fmt_label('COMPLEXITY:')} {comp_val}"
             if c.is_creature:
                 score_line += f" \u2022 {fmt_label('RATING:')} {rate_val} \u2022 {fmt_label('FAIR MV:')} {fair_val}"
+            if pie_val:
+                score_line += f" \u2022 {fmt_label('COLOR PIE:')} {pie_val}"
             footer_lines.append(score_line)
 
             # 3. Mechanics Line
@@ -1113,6 +1134,7 @@ def handle_compare_cards(args):
             ('Fair MV', 'fair_cmc'),
             ('Rating', 'rating'),
             ('Complexity', 'complexity'),
+            ('Color Pie', 'color_pie'),
             ('Text', 'text')
         ]
 
@@ -1234,7 +1256,7 @@ Note: If no input file is provided, data/AllPrintings.json is used if available.
     p_search.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
                         help='Comma-separated list of fields to extract. Available fields:\n'
                              '  - Basic: name, cost, cmc, type, stats, text, rarity\n'
-                             '  - Analysis: mechanics, actions, tokens, identity, complexity, rating, fair_mv\n'
+                             '  - Analysis: mechanics, actions, tokens, identity, complexity, rating, fair_mv, color_pie\n'
                              '  - Metadata: set, number, pack, box')
     p_search.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')

--- a/tests/test_mtg_mana_gaps.py
+++ b/tests/test_mtg_mana_gaps.py
@@ -119,6 +119,7 @@ class TestMtgManaGaps(unittest.TestCase):
                                     sets=None, rarities=None, colors=None, cmcs=None,
                                     pows=None, tous=None, loys=None, mechanics=None,
                                     actions=None,
+                                    color_pie_break=False,
                                     identities=None, id_counts=None, decklist_file=None, shuffle=False, seed=None,
                                     booster=0, box=0)
 


### PR DESCRIPTION
This PR implements a comprehensive Color Pie Integrity Validation and Filtering feature. 

Key enhancements:
1.  **Filtering:** Users can now use the `--color-pie-break` flag to filter any dataset for cards that violate mechanical color pie norms (e.g., a Blue creature with Deathtouch). This is implemented in the core card loading pipeline, making it available across most tools.
2.  **Query Integration:** The `mtg_query.py` tool now supports a `color_pie` field. This displays a color-coded status: Green "Valid" for cards that follow the pie, and Red violation details (e.g., "Color Pie Break: Deathtouch (Expected BGC)") for those that don't.
3.  **Detailed Views:** 
    *   The `oracle` detailed view now includes "COLOR PIE" in its Design Analytics block.
    *   The `compare` table includes a "Color Pie" row to highlight integrity differences between cards.
4.  **Robustness:** Fixed a regression in `tests/test_mtg_mana_gaps.py` and addressed potential runtime errors in `scripts/mtg_query.py` identified during verification.

This feature provides immediate utility for designers and AI evaluators to identify "pushed" or "broken" designs in large datasets.

---
*PR created automatically by Jules for task [15936497127468108911](https://jules.google.com/task/15936497127468108911) started by @RainRat*