### PR TITLE
[FEAT] Add random card discovery to mtg_query

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -58,7 +58,6 @@ FIELD_MAP = {
     'rating': {'header': 'Rating', 'align': 'r', 'aliases': ['power_rating']},
     'fair_cmc': {'header': 'Fair MV', 'align': 'r', 'aliases': ['fcmc', 'fair_cost', 'fair_mv', 'recommended_cmc']},
     'produced': {'header': 'Produced', 'align': 'l', 'aliases': ['produced_mana', 'mana_produced']},
-    'tokens': {'header': 'Tokens', 'align': 'l', 'aliases': ['creates']},
     'summary': {'header': 'Summary', 'align': 'l', 'aliases': ['view']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
@@ -693,7 +692,7 @@ def handle_shell(args):
 
         def completer(text, state):
             if text.startswith('/'):
-                commands = ['/search ', '/help', '/exit', '/quit']
+                commands = ['/random', '/search ', '/help', '/exit', '/quit']
                 options = [c for c in commands if c.startswith(text)]
             else:
                 options = [n for n in card_names if n.lower().startswith(text.lower())]
@@ -753,9 +752,28 @@ def handle_shell(args):
                 s_args.table = True
                 if not hasattr(s_args, 'limit'): s_args.limit = 0
                 _execute_search(matched_cards, s_args)
+            elif line.startswith('/random'):
+                parts = line.split()
+                count = 1
+                if len(parts) > 1:
+                    try:
+                        count = int(parts[1])
+                    except ValueError:
+                        count = 1
+
+                if not all_cards:
+                    print("No cards loaded.")
+                    continue
+
+                sampled = random.sample(all_cards, min(count, len(all_cards)))
+                r_args = copy.copy(args)
+                r_args.query = None
+                if not hasattr(r_args, 'limit'): r_args.limit = 0
+                _execute_oracle(sampled, r_args)
             elif line.startswith('/help'):
                 print("Commands:")
                 print("  <card name>   - Show official rules text for a card.")
+                print("  /random [n]   - Show [n] random cards from the database.")
                 print("  /search <q>   - Search for cards matching <q>.")
                 print("  /exit, /quit  - Exit the shell.")
             else:
@@ -1002,6 +1020,29 @@ def handle_functional(args):
             print("-" * 20)
             print(group[0].summary(ansi_color=use_color).replace('\u2014', '-'))
             print()
+
+def handle_random(args):
+    cards = cli_utils.load_and_filter_cards(args)
+    if not cards:
+        if not args.quiet:
+            print("No cards found matching the criteria.", file=sys.stderr)
+        return
+
+    count = args.count
+    if count > len(cards):
+        count = len(cards)
+
+    if count <= 0:
+        return
+
+    sampled = random.sample(cards, count)
+
+    # If any search-specific output format is requested, use search display
+    search_formats = ['json', 'jsonl', 'csv', 'table', 'md_table', 'summary', 'text']
+    if any(getattr(args, f, False) for f in search_formats) or getattr(args, 'outfile', None):
+        _execute_search(sampled, args)
+    else:
+        _execute_oracle(sampled, args)
 
 # --- Compare Logic ---
 
@@ -1279,6 +1320,43 @@ Usage Examples:
     p_oracle.add_argument('--full', action='store_true', help='Force full details even for multiple matches.')
     p_oracle.add_argument('--no-rulings', action='store_true', help='Suppress display of card rulings.')
     p_oracle.set_defaults(func=handle_oracle)
+
+    # Random Subparser
+    p_random = subparsers.add_parser(
+        'random',
+        help='Display one or more random cards matching the filters.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Usage Examples:
+  # See a random card
+  python3 scripts/mtg_query.py random
+
+  # See 5 random rare creatures
+  python3 scripts/mtg_query.py random 5 --rarity rare --grep "Creature"
+
+  # Output 10 random Goblins in a table
+  python3 scripts/mtg_query.py random 10 --grep "Goblin" --table
+"""
+    )
+    p_random.add_argument('count', nargs='?', type=int, default=1,
+                         help='Number of random cards to display (Default: 1).')
+    p_random.add_argument('infile', nargs='?', default='-',
+                         help='Input card data file. Defaults to the official dataset.')
+    cli_utils.add_standard_filters(p_random)
+    cli_utils.add_standard_output_args(p_random)
+    p_random.add_argument('--text', action='store_true', help='Force plain text output.')
+    p_random.add_argument('--md-table', '--mdt', action='store_true', help='Output results as a Markdown table.')
+    p_random.add_argument('--jsonl', action='store_true', help='Output results in JSON Lines format.')
+    p_random.add_argument('-S', '--summary', action='store_true', help='Output a compact one-line summary for each card.')
+    p_random.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
+                        help='Comma-separated list of fields to extract (when using table/csv/json).')
+    p_random.add_argument('--delimiter', default=' | ',
+                        help='Separator used between fields in plain text output.')
+    p_random.add_argument('-G', '--gatherer', action='store_true',
+                        help='Use official card formatting (emulating the Gatherer website).')
+    p_random.add_argument('--full', action='store_true', help='Force full details even for multiple matches.')
+    p_random.add_argument('--no-rulings', action='store_true', help='Suppress display of card rulings.')
+    p_random.set_defaults(func=handle_random)
 
     # Extract Subparser
     p_extract = subparsers.add_parser(

--- a/tests/test_mtg_query_random.py
+++ b/tests/test_mtg_query_random.py
@@ -1,0 +1,109 @@
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
+import io
+import sys
+import os
+import random
+
+# Add lib and scripts to path
+sys.path.append(os.getcwd())
+sys.path.append(os.path.join(os.getcwd(), 'lib'))
+
+from scripts.mtg_query import main as query_main
+import cardlib
+import utils
+
+class TestMtgQueryRandom(unittest.TestCase):
+
+    def _create_mock_card(self, name="Grizzly Bears"):
+        card = MagicMock()
+        card.name = name
+        card.display_name = name
+        card.header.return_value = name
+        card.summary.return_value = name
+        card.get_text.return_value = "Vanilla creature"
+
+        card.cost = MagicMock()
+        card.cost.format.return_value = "{1}{G}"
+        card.cost.cmc = 2
+        card.cost.colors = ['G']
+        card.cost.encode.return_value = "{^G}"
+
+        card.is_creature = True
+        card.is_battle = False
+        card.tokens = []
+        card.mechanics = set()
+        card.actions = set()
+        card.produced_colors = set()
+        card.color_identity = "G"
+        card.rarity = "O"
+        card.rarity_name = "Common"
+        card.complexity_score = 10
+        card.power_rating = 1.0
+        card.recommended_cmc = 2.0
+
+        card.set_code = "LEA"
+        card.number = "1"
+        card.rulings = []
+        card.bside = None
+        card.get_type_line.return_value = "Creature - Bear"
+        card._get_pt_display.return_value = "2/2"
+        card._get_loyalty_display.return_value = ""
+        card.get_face_tokens.return_value = []
+        card.pt = "&&/&&"
+        card.pt_p = "&&"
+        card.pt_t = "&&"
+        card.loyalty = ""
+        card.supertypes = []
+        card.types = ["creature"]
+        card.subtypes = ["bear"]
+
+        return card
+
+    @patch('scripts.mtg_query.cli_utils.load_and_filter_cards')
+    def test_random_basic(self, mock_load):
+        """Test basic random card display."""
+        card = self._create_mock_card()
+        mock_load.return_value = [card]
+
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_query.py', 'random', '--no-color']):
+                query_main()
+                output = fake_out.getvalue()
+                # Basic random uses _execute_oracle which shows the card header
+                self.assertIn("Grizzly Bears", output)
+
+    @patch('scripts.mtg_query.cli_utils.load_and_filter_cards')
+    def test_random_count(self, mock_load):
+        """Test random with a specific count."""
+        cards = [self._create_mock_card(f"Card {i}") for i in range(5)]
+        mock_load.return_value = cards
+
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            # Oracle view doesn't have a count header, it just prints cards
+            with patch('sys.argv', ['mtg_query.py', 'random', '3', 'dummy.json', '--no-color']):
+                query_main()
+                output = fake_out.getvalue()
+                matches = 0
+                for i in range(5):
+                    if f"Card {i}" in output:
+                        matches += 1
+                self.assertEqual(matches, 3)
+
+    @patch('scripts.mtg_query.cli_utils.load_and_filter_cards')
+    def test_random_table(self, mock_load):
+        """Test random with table output."""
+        card = self._create_mock_card()
+        mock_load.return_value = [card]
+
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            with patch('sys.argv', ['mtg_query.py', 'random', '--table', '--no-color']):
+                query_main()
+                output = fake_out.getvalue()
+                self.assertIn("SEARCH RESULTS", output)
+                self.assertIn("Grizzly Bears", output)
+                self.assertIn("CMC", output)
+                self.assertIn("Stats", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a 'random' discovery feature to the unified `mtg_query.py` utility.

### What
- New CLI command: `python3 scripts/mtg_query.py random [count] [infile] [filters]`
- New Shell command: `/random [count]`
- Automatic output routing: defaults to the detailed `oracle` view for readability, but automatically switches to `_execute_search` (table/json/csv) if structured output flags are provided.
- Minor fix: Consolidated a duplicate entry for the `tokens` field in `FIELD_MAP`.

### Why
I identified that while the toolkit excels at specific searches and bulk analysis, it lacked a first-class way to "browse" or discover cards randomly—a core utility in Magic: The Gathering databases (like Scryfall). This is particularly useful for designers looking for inspiration or quickly sampling cards from an AI-generated dataset without needing to construct a specific query.

### Verification
- Created `tests/test_mtg_query_random.py` to verify CLI behavior and output formats.
- Manually verified the shell command's functionality and tab-completion.
- Ran the full project test suite (1130 tests passed).

---
*PR created automatically by Jules for task [3482705240758091321](https://jules.google.com/task/3482705240758091321) started by @RainRat*