### PR TITLE
Fix /random command count logic in interactive shell

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -789,14 +789,6 @@ def handle_shell(args):
                 os.system('cls' if os.name == 'nt' else 'clear')
                 continue
 
-            if line.startswith('/random'):
-                random_card = [random.choice(all_cards)]
-                o_args = copy.copy(args)
-                o_args.query = None
-                if not hasattr(o_args, 'limit'): o_args.limit = 0
-                _execute_oracle(random_card, o_args)
-                continue
-
             if line.startswith('/search '):
                 query = line[8:].strip()
                 # Proper filtering for shell search


### PR DESCRIPTION
Consolidated duplicate `/random` command logic in the `mtg_query.py` interactive shell. Removed a redundant handler that always returned one card and shadowed the implementation that correctly parses a requested count. Verified that `/random [count]` now correctly samples the requested number of cards.

---
*PR created automatically by Jules for task [13201178205696038520](https://jules.google.com/task/13201178205696038520) started by @RainRat*