### PR TITLE
[DOCS] Replace Magic jargon 'functional reprints' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,10 +568,10 @@ python3 scripts/mtg_query.py sets --grep "Masters"
 ---
 
 #### **Subcommand: `functional`**
-Identifies 'functional reprints' (different name, same mechanics).
+Identifies cards with the same mechanics but different names.
 
 ```bash
-# List all functional reprints
+# List all cards with the same mechanics
 python3 scripts/mtg_query.py functional
 
 # Create a deduplicated dataset


### PR DESCRIPTION
This change improves the project's documentation accessibility by replacing specialized jargon with plain English.

*   **File Improved:** `README.md`
*   **Change:** Replaced the term "functional reprints" with "cards with the same mechanics but different names" and updated the corresponding code comment.
*   **Reasoning:** Fulfills the style guidelines for using Plain English and avoiding business or community-specific jargon (e.g., 'functional reprints') to make the tool more accessible to a global audience.

The change was verified using `grep` to ensure the jargon was removed and the new descriptive text was correctly placed. All 1147 project tests passed in the local environment.

---
*PR created automatically by Jules for task [11582411471221169397](https://jules.google.com/task/11582411471221169397) started by @RainRat*