### PR TITLE
Remove unreachable redundant color_pie logic in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -206,17 +206,6 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return ", ".join(res)
     elif canon == 'summary':
         return card.summary(ansi_color=ansi_color).replace('\u2014', '-')
-    elif canon == 'color_pie':
-        status = card.check_color_pie()
-        if status is True:
-            res = "Valid"
-            if ansi_color: res = utils.colorize(res, utils.Ansi.BOLD + utils.Ansi.GREEN)
-        elif isinstance(status, str):
-            res = status
-            if ansi_color: res = utils.colorize(res, utils.Ansi.BOLD + utils.Ansi.RED)
-        else:
-            res = ""
-        return res
     elif canon == 'encoded':
         res = card.encode()
     else:


### PR DESCRIPTION
The `get_field_value` function in `scripts/mtg_query.py` had a logic redundancy where the `color_pie` field was handled twice. The first occurrence returned early, rendering the second occurrence dead code. I removed the unreachable block to clean up the implementation. Verified with manual tests and the existing test suite.

---
*PR created automatically by Jules for task [12954919195856974668](https://jules.google.com/task/12954919195856974668) started by @RainRat*