### PR TITLE
[DOCS] Document missing random subcommand in mtg_query.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 #### **Commands:**
 *   `search`: Search card data and extract specific fields.
 *   `oracle`: Look up a card by name and display its full rules text.
+*   `random`: Display one or more random cards matching the filters.
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
@@ -557,6 +558,23 @@ python3 scripts/mtg_query.py oracle --set MOM --rarity rare --grep "Battle"
 # Find cards mechanically similar to a specific card
 python3 scripts/mtg_query.py oracle "Giant Growth" --similar
 ```
+
+---
+
+#### **Subcommand: `random`**
+Display one or more random cards from the dataset. Supports all **Advanced Filtering** flags.
+
+```bash
+# See a random card
+python3 scripts/mtg_query.py random
+
+# See 5 random rare creatures
+python3 scripts/mtg_query.py random 5 --rarity rare --grep "Creature"
+
+# Output 10 random Goblins in a table
+python3 scripts/mtg_query.py random 10 --grep "Goblin" --table
+```
+*   **Options:** `count`, `--table`, `--json`, `--jsonl`, `--csv`, `--summary`, `--fields`.
 
 ---
 


### PR DESCRIPTION
The `random` subcommand was functional in `scripts/mtg_query.py` but missing from the project's primary documentation. This PR updates `README.md` to include:

1.  **Command Overview:** Added `random` to the list of `mtg_query.py` commands.
2.  **Detailed Section:** Created a `#### **Subcommand: random**` section with:
    *   **Usage Examples:** Demonstrating how to pick a random card, sample multiple cards with filters (e.g., 5 random rare creatures), and output results in a table.
    *   **Options List:** Documenting supported flags like `count`, `--table`, `--json`, `--jsonl`, `--csv`, `--summary`, and `--fields`.

These changes improve the accessibility of the toolkit by ensuring all core query features are discoverable and easy to use.

---
*PR created automatically by Jules for task [7912231184091383613](https://jules.google.com/task/7912231184091383613) started by @RainRat*