### PR TITLE
[FEAT] Add 'superior' subcommand to find strictly better cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
+*   `superior`: Find cards that are strictly better or generally superior to a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -605,6 +606,22 @@ python3 scripts/mtg_query.py compare --set MOM --rarity rare
 
 # Compare cards in a specific file
 python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
+```
+
+---
+
+#### **Subcommand: `superior`**
+Identifies "strictly better" or generally superior cards by comparing mana cost, stats, and abilities. A card is superior if it has easier or identical mana cost, better or equal stats, and its abilities are a superset of the reference card.
+
+```bash
+# Find cards better than Grizzly Bears
+python3 scripts/mtg_query.py superior "Grizzly Bears"
+
+# Find better cards that are also Goblins
+python3 scripts/mtg_query.py superior "Grizzly Bears" --grep "Goblin"
+
+# Find better cards in a specific set
+python3 scripts/mtg_query.py superior "Grizzly Bears" --set MOM
 ```
 
 ---

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1076,6 +1076,115 @@ def handle_functional(args):
             print(group[0].summary(ansi_color=use_color).replace('\u2014', '-'))
             print()
 
+def handle_superior(args):
+    # Smart positional argument handling
+    if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
+        temp = args.query
+        args.query = args.infile if args.infile != '-' else None
+        args.infile = temp
+
+    cards = cli_utils.load_and_filter_cards(args)
+    if not cards:
+        if not args.quiet:
+            print("No cards found in the dataset.", file=sys.stderr)
+        return
+
+    query = args.query
+    if not query:
+        if not args.quiet:
+            print("Error: No reference card name provided.", file=sys.stderr)
+        return
+
+    query_sanitized = query.lower().replace('-', utils.dash_marker)
+    target_card = next((c for c in cards if c.name.lower() == query_sanitized), None)
+    if not target_card:
+        # Try finding in the full dataset if not in the filtered pool
+        all_cards = jdecode.mtg_open_file(args.infile, verbose=False)
+        target_card = next((c for c in all_cards if c.name.lower() == query_sanitized), None)
+        if not target_card:
+            # Fuzzy match
+            search_names = {c.name.lower(): c for c in all_cards}
+            close = difflib.get_close_matches(query.lower(), list(search_names.keys()), n=1, cutoff=0.6)
+            if close:
+                target_card = search_names[close[0]]
+                if not args.quiet:
+                    print(f"Notice: Card '{query}' not found. Using best match: {target_card.display_name}", file=sys.stderr)
+
+    if not target_card:
+        if not args.quiet:
+            print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
+        return
+
+    def is_superior(candidate, target):
+        if candidate.name.lower() == target.name.lower():
+            return False
+
+        # 1. Type compatibility: must share at least one primary type
+        t_types = set(target.types)
+        c_types = set(candidate.types)
+        if not (t_types & c_types):
+            return False
+
+        # 2. Mana Cost comparison
+        t_cmc = target.cost.cmc
+        c_cmc = candidate.cost.cmc
+        if c_cmc > t_cmc:
+            return False
+
+        # Pip check: candidate must not require more of any color than target
+        t_pips = target.cost.allsymbols
+        c_pips = candidate.cost.allsymbols
+        for color in 'WUBRGC':
+            if c_pips.get(color, 0) > t_pips.get(color, 0):
+                return False
+
+        # 3. Stats check
+        # Creatures
+        if target.is_creature and candidate.is_creature:
+            t_p = utils.from_unary_single(target.pt_p) or 0
+            t_t = utils.from_unary_single(target.pt_t) or 0
+            c_p = utils.from_unary_single(candidate.pt_p) or 0
+            c_t = utils.from_unary_single(candidate.pt_t) or 0
+            if c_p < t_p or c_t < t_t:
+                return False
+
+        # Planeswalkers / Battles
+        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
+            t_l = utils.from_unary_single(target.loyalty) or 0
+            c_l = utils.from_unary_single(candidate.loyalty) or 0
+            if c_l < t_l:
+                return False
+
+        # 4. Mechanics and Actions: candidate must be a superset
+        if not target.mechanics.issubset(candidate.mechanics):
+            return False
+        if not target.actions.issubset(candidate.actions):
+            return False
+
+        # 5. Strictly better check: must be better in at least one metric
+        is_strictly_better = False
+        if c_cmc < t_cmc: is_strictly_better = True
+        for color in 'WUBRGC':
+            if c_pips.get(color, 0) < t_pips.get(color, 0): is_strictly_better = True
+        if target.is_creature and candidate.is_creature:
+            if c_p > t_p or c_t > t_t: is_strictly_better = True
+        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
+            if c_l > t_l: is_strictly_better = True
+        if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
+        if len(candidate.actions) > len(target.actions): is_strictly_better = True
+
+        return is_strictly_better
+
+    superior_cards = [c for c in cards if is_superior(c, target_card)]
+
+    if not superior_cards:
+        if not args.quiet:
+            print(f"No cards found that are superior to {target_card.display_name}.", file=sys.stderr)
+        return
+
+    # Use search display for results
+    _execute_search(superior_cards, args)
+
 def handle_random(args):
     cards = cli_utils.load_and_filter_cards(args)
     if not cards:
@@ -1549,6 +1658,41 @@ Usage Examples:
     cli_utils.add_standard_filters(p_compare)
     cli_utils.add_standard_output_args(p_compare)
     p_compare.set_defaults(func=handle_compare_cards)
+
+    # Superior Subparser
+    p_superior = subparsers.add_parser(
+        'superior',
+        help='Find cards that are strictly better or generally superior to a reference card.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Finds "strictly better" cards by comparing mana cost, stats, and abilities.
+A card is considered superior if it has easier or identical mana cost,
+equal or better stats (P/T or Loyalty), and its abilities are a superset
+of the reference card.
+
+Usage Examples:
+  # Find cards better than Grizzly Bears
+  python3 scripts/mtg_query.py superior "Grizzly Bears"
+
+  # Find better cards that are also Goblins
+  python3 scripts/mtg_query.py superior "Grizzly Bears" --grep "Goblin"
+
+  # Find better cards in a specific set
+  python3 scripts/mtg_query.py superior "Grizzly Bears" --set MOM
+"""
+    )
+    p_superior.add_argument('query', help='The card name to use as a reference for comparison.')
+    p_superior.add_argument('infile', nargs='?', default='-',
+                           help='Input card data file. Defaults to data/AllPrintings.json.')
+    cli_utils.add_standard_filters(p_superior)
+    cli_utils.add_standard_output_args(p_superior)
+    p_superior.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
+                           help='Fields to display in the output table.')
+    p_superior.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
+                           help='Sort the resulting superior cards.')
+    p_superior.add_argument('--delimiter', default=' | ',
+                        help='Separator used between fields in plain text output.')
+    p_superior.set_defaults(func=handle_superior)
 
     # Shell Subparser
     p_shell = subparsers.add_parser(

--- a/tests/test_mtg_superior.py
+++ b/tests/test_mtg_superior.py
@@ -1,0 +1,169 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import json
+import io
+
+# Add scripts and lib to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../scripts')))
+
+import mtg_query
+import cardlib
+import utils
+
+class TestMtgSuperior(unittest.TestCase):
+    def setUp(self):
+        # Create a small test dataset
+        self.test_data = {
+            "data": {
+                "TEST": {
+                    "name": "Test Set",
+                    "code": "TEST",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Grizzly Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Kalonian Tusker",
+                            "manaCost": "{G}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Boar"],
+                            "power": "3",
+                            "toughness": "3",
+                            "rarity": "uncommon"
+                        },
+                        {
+                            "name": "Better Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "3",
+                            "toughness": "2",
+                            "rarity": "uncommon"
+                        },
+                        {
+                            "name": "Cheaper Bears",
+                            "manaCost": "{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "rare"
+                        },
+                        {
+                            "name": "Flying Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "text": "Flying",
+                            "rarity": "rare"
+                        },
+                        {
+                            "name": "Hill Giant",
+                            "manaCost": "{3}{R}",
+                            "types": ["Creature"],
+                            "subtypes": ["Giant"],
+                            "power": "3",
+                            "toughness": "3",
+                            "rarity": "common"
+                        }
+                    ]
+                }
+            }
+        }
+        self.test_file = "test_superior.json"
+        with open(self.test_file, 'w') as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self):
+        if os.path.exists(self.test_file):
+            os.remove(self.test_file)
+
+    def test_superior_basic(self):
+        # Better Bears and Cheaper Bears and Flying Bears should be superior to Grizzly Bears
+        # Kalonian Tusker is NOT strictly superior to Grizzly Bears because {G}{G} is not a subset of {1}{G} (it requires more Green mana)
+        # Hill Giant is NOT superior (different types/colors/higher CMC)
+
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'superior', 'Grizzly Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Better Bears", output)
+            self.assertIn("Cheaper Bears", output)
+            self.assertIn("Flying Bears", output)
+            self.assertNotIn("Kalonian Tusker", output)
+            self.assertNotIn("Hill Giant", output)
+            self.assertNotIn("Grizzly Bears", output) # Should not include itself
+
+    def test_superior_pips(self):
+        # Verify pip logic: {G} is superior to {1}{G}
+        # {G}{G} is NOT superior to {1}{G} (needs 2 green vs 1)
+        # {G} is superior to {1}{G} (needs 1 green vs 1, and 1 generic vs 0)
+
+        # Add a card that requires more pips but same CMC
+        self.test_data['data']['TEST']['cards'].append({
+            "name": "Pip Bear",
+            "manaCost": "{G}{G}",
+            "types": ["Creature"],
+            "power": "2",
+            "toughness": "2",
+        })
+        with open(self.test_file, 'w') as f:
+            json.dump(self.test_data, f)
+
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            test_args = ['mtg_query.py', 'superior', 'Grizzly Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertNotIn("Pip Bear", output)
+
+    def test_superior_mechanics(self):
+        # Flying Bears (with Flying) should be superior to Grizzly Bears (no abilities)
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'superior', 'Grizzly Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Flying Bears", output)
+
+    def test_superior_no_results(self):
+        # Hill Giant has no superior cards in this set
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            test_args = ['mtg_query.py', 'superior', 'Hill Giant', self.test_file]
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_err.getvalue()
+            self.assertIn("No cards found that are superior to Hill Giant.", output)
+
+    def test_superior_not_found(self):
+        # Reference card does not exist
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            test_args = ['mtg_query.py', 'superior', 'Nonexistent Card', self.test_file]
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_err.getvalue()
+            self.assertIn("Error: Could not find reference card 'Nonexistent Card'", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**PR Title:** [FEAT] Add 'superior' subcommand to find strictly better cards

**Description:**
* **What:** Added a new `superior` subcommand to the `mtg_query.py` utility. This subcommand identifies cards that are "strictly better" or generally superior to a given reference card by comparing mana cost (CMC and pips), stats (P/T, Loyalty, or Defense), and abilities (mechanics and actions).
* **Why:** Finding strictly better cards is a fundamental task in Magic: The Gathering design and deck-building. While the existing `compare` subcommand allows for manual side-by-side analysis, there was no automated way to scan a dataset for superior alternatives. This addition creates immediate value for designers looking to audit power creep or find optimized alternatives in a card pool.

**Changes:**
1.  **scripts/mtg_query.py**: Added `handle_superior` function and registered the `superior` subcommand with standard filtering and output options.
2.  **README.md**: Documented the new subcommand with usage examples.
3.  **tests/test_mtg_superior.py**: Added a new test suite to verify superiority logic across various scenarios.


---
*PR created automatically by Jules for task [4041163240677461811](https://jules.google.com/task/4041163240677461811) started by @RainRat*