### PR TITLE
Fix field duplication for multi-faced cards in mtg_query

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -207,16 +207,16 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
     elif canon == 'summary':
         return card.summary(ansi_color=ansi_color).replace('\u2014', '-')
     elif canon == 'encoded':
-        res = card.encode()
+        return card.encode()
     else:
         return ""
 
     if card.bside:
-        if canon in ['rarity', 'set', 'pack', 'box', 'id_count', 'identity', 'mechanics', 'summary']:
+        if canon in ['rarity', 'set', 'pack', 'box', 'id_count', 'identity', 'mechanics', 'summary', 'tokens', 'actions']:
             return str(res)
         b_res = get_field_value(card.bside, field, ansi_color, multi_sep=multi_sep)
         if res and b_res:
-            sep = "\n\n" if canon in ['text', 'encoded'] else multi_sep
+            sep = "\n\n" if canon == 'text' else multi_sep
             return f"{res}{sep}{b_res}"
         return str(res or b_res)
     return str(res)


### PR DESCRIPTION
Identified and fixed a logic bug where the 'encoded' field duplicated B-side data for multi-faced cards. This occurred because the handler fell through to a recursive block despite the property itself being recursive. Following code review, the B-side skip list was also updated to prevent similar duplication issues for 'tokens' and 'actions' fields, and standard fields were restored to the list to maintain output quality for card-wide properties. Verified the fix with reproduction scripts and ensured all 1155 tests in the suite pass.

---
*PR created automatically by Jules for task [12473697014827161942](https://jules.google.com/task/12473697014827161942) started by @RainRat*