### PR TITLE
[DOCS] Document LLM API validation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,18 +495,25 @@ python3 scripts/mtg_eval.py --checkpoint checkpoint.pt --temp 1.0
     *   `-j`, `--json`: Output results in structured JSON format.
 
 ### `mtg_llm_validate.py`
-Validates the mechanical integrity of cards using a local Large Language Model (LLM). This tool asks the AI to judge if a card's text follows Magic's rules logic and provides a reason for its decision.
+Validates the mechanical integrity of cards using a Large Language Model (LLM). This tool asks the AI to judge if a card's rules text follows Magic's logic and provides a reason for its decision. It supports local models (via `transformers`) and remote APIs (e.g., OpenRouter, Ollama).
+
 ```bash
-# Validate cards in a file using the default model (TinyLlama)
+# Validate cards using the default local model (TinyLlama)
 python3 scripts/mtg_llm_validate.py generated_cards.txt
 
-# Validate specific cards and output valid ones to a JSON file
-python3 scripts/mtg_llm_validate.py generated.txt --grep "Grizzly Bears" --only-valid --json > valid.json
+# Use a remote API (e.g., OpenRouter)
+python3 scripts/mtg_llm_validate.py generated.txt --provider api --api-url "https://openrouter.ai/api/v1/chat/completions" --model "meta-llama/llama-3-8b-instruct" --api-key "YOUR_KEY"
+
+# Use a local Ollama API
+python3 scripts/mtg_llm_validate.py generated.txt --provider api --api-url "http://localhost:11434/v1/chat/completions" --model "llama3"
 ```
-*   **Requirements:** Requires `transformers`, `torch`, and `accelerate` (installed via `requirements.txt`).
+*   **Requirements:** Local model mode requires `transformers`, `torch`, and `accelerate`. API mode has no extra dependencies.
 *   **Options:**
-    *   `--model MODEL`: The HuggingFace model to use (Default: `TinyLlama/TinyLlama-1.1B-Chat-v1.0`).
-    *   `--device DEVICE`: Device to run on (`cuda`, `cpu`, or `mps`).
+    *   `--provider {transformers,api}`: Choose the LLM backend (Default: `transformers`).
+    *   `--api-url URL`: The API endpoint URL (Required for `api` provider).
+    *   `--api-key KEY`: Optional Bearer token for API authentication.
+    *   `--model MODEL`: The model name to use (Default: `TinyLlama/TinyLlama-1.1B-Chat-v1.0`).
+    *   `--device DEVICE`: Device to run local models on (`cuda`, `cpu`, or `mps`).
     *   `--batch-size N`: Number of cards to process at once.
     *   `--only-valid`: Filter output to only include cards the LLM judged as valid.
     *   Supports all **Advanced Filtering** flags and multiple output formats (`--json`, `--csv`, `--table`).


### PR DESCRIPTION
This PR improves the documentation for the `mtg_llm_validate.py` utility in `README.md`.

* **Type:** Documentation
* **What:** Updated the `mtg_llm_validate.py` section.
* **Why:** To inform users about the tool's ability to use remote LLM APIs (like OpenRouter or Ollama), which avoids the need for large local model downloads and heavy dependencies like `torch` and `transformers`.

Changes include:
- A revised description of supported LLM backends.
- New code examples for API-based validation.
- Clearer requirements documentation.
- Documentation for the `--provider`, `--api-url`, and `--api-key` CLI options.

---
*PR created automatically by Jules for task [8016939337106130026](https://jules.google.com/task/8016939337106130026) started by @RainRat*