### PR TITLE
[UI/UX] Standardize card stats formatting in search and comparison views

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -100,15 +100,9 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if ansi_color:
             res = utils.colorize(res, utils.Ansi.GREEN)
     elif canon == 'pt':
-        res = utils.from_unary(card.pt) if card.pt else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_pt_display(ansi_color=ansi_color)
     elif canon == 'stats':
-        res = utils.from_unary(card.pt) if card.pt else ""
-        if not res:
-            res = utils.from_unary(card.loyalty) if card.loyalty else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_pt_display(ansi_color=ansi_color) or card._get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'power':
         res = utils.from_unary(card.pt_p) if card.pt_p else ""
         if res and ansi_color:
@@ -118,9 +112,7 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if res and ansi_color:
             res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'loyalty':
-        res = utils.from_unary(card.loyalty) if card.loyalty else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'text':
         res = card.get_text(force_unpass=True, ansi_color=ansi_color)
     elif canon == 'rarity':

--- a/tests/test_mtg_query_compare.py
+++ b/tests/test_mtg_query_compare.py
@@ -44,5 +44,5 @@ def test_query_compare_multi_face():
     assert "Double Back" in result.stdout
     # Check that they are identified as different in the table
     # Since Double Front matches the whole card (both faces) and Double Back matches only one face
-    assert "1/1 // 2/2" in result.stdout
-    assert "2/2" in result.stdout
+    assert "(1/1) // (2/2)" in result.stdout
+    assert "(2/2)" in result.stdout

--- a/tests/test_mtg_search_gaps.py
+++ b/tests/test_mtg_search_gaps.py
@@ -90,14 +90,14 @@ class TestMtgSearchGaps(unittest.TestCase):
         card = Card({"name": "Test", "power": "2", "toughness": "3", "types": ["Creature"]})
         self.assertEqual(get_field_value(card, "power"), "2")
         self.assertEqual(get_field_value(card, "toughness"), "3")
-        self.assertEqual(get_field_value(card, "pt"), "2/3")
+        self.assertEqual(get_field_value(card, "pt"), "(2/3)")
 
     def test_get_field_value_loyalty(self):
         from scripts.mtg_query import get_field_value
         from lib.cardlib import Card
         card = Card({"name": "Test", "loyalty": "5", "types": ["Planeswalker"]})
-        self.assertEqual(get_field_value(card, "loyalty"), "5")
-        self.assertEqual(get_field_value(card, "stats"), "5")
+        self.assertEqual(get_field_value(card, "loyalty"), "(5)")
+        self.assertEqual(get_field_value(card, "stats"), "(5)")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
This improvement addresses a minor friction point where card statistics were displayed as raw text in search results and comparison tables, differing from the more polished "official" look of the oracle rules text view.

**Context:** CLI
**Problem:** In the search table and comparison tool, stats like Power/Toughness or Defense appeared as raw numbers (e.g., `5` or `2/2`). This made them harder to distinguish from other numeric fields like CMC or collector numbers, especially in dense tables.
**Solution:** Refactored `get_field_value` in `scripts/mtg_query.py` to use the dedicated display methods from the `Card` model. This automatically applies the correct delimiters (`()` for most cards, `[[]]` for Battles) and ensures color-coding is handled consistently.

### Changes
- **scripts/mtg_query.py:** Updated `pt`, `stats`, and `loyalty` field logic to use `card._get_pt_display()` and `card._get_loyalty_display()`.
- **tests/test_mtg_query_compare.py:** Updated test assertions to account for new parentheses in multi-face comparison output.
- **tests/test_mtg_search_gaps.py:** Updated unit test assertions for `get_field_value` consistency.

---
*PR created automatically by Jules for task [18204183645622495885](https://jules.google.com/task/18204183645622495885) started by @RainRat*