### PR TITLE
[FEAT] Add inferior subcommand for power-level comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,8 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
-*   `superior`: Find cards that are strictly better or generally superior to a reference card.
+*   `superior`: Find cards that are strictly better than a reference card.
+*   `inferior`: Find cards that are strictly worse than a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -629,7 +630,7 @@ python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
 ---
 
 #### **Subcommand: `superior`**
-Identifies "strictly better" or generally superior cards by comparing mana cost, stats, and abilities. A card is superior if it has easier or identical mana cost, better or equal stats, and its abilities are a superset of the reference card.
+Identifies "strictly better" cards by comparing mana cost, stats, and abilities. A card is superior if it has easier or identical mana cost, better or equal stats, and its abilities are a superset of the reference card.
 
 ```bash
 # Find cards better than Grizzly Bears
@@ -640,6 +641,19 @@ python3 scripts/mtg_query.py superior "Grizzly Bears" --grep "Goblin"
 
 # Find better cards in a specific set
 python3 scripts/mtg_query.py superior "Grizzly Bears" --set MOM
+```
+
+---
+
+#### **Subcommand: `inferior`**
+Identifies "strictly worse" cards by comparing mana cost, stats, and abilities. A card is inferior if it has harder or identical mana cost, worse or equal stats, and its abilities are a subset of the reference card.
+
+```bash
+# Find cards worse than Grizzly Bears
+python3 scripts/mtg_query.py inferior "Grizzly Bears"
+
+# Find worse cards in a specific set
+python3 scripts/mtg_query.py inferior "Grizzly Bears" --set MOM
 ```
 
 ---
@@ -666,6 +680,9 @@ python3 scripts/mtg_query.py shell my_cards.json --fields "name,cost,type,pt,rar
 *   **In-Shell Commands:**
     *   `<card name>`: Type any card name to see its official rules text.
     *   `/search <query>`: Perform a bulk search and display results in a table.
+    *   `/random [count]`: Show random cards from the dataset.
+    *   `/superior <name>`: Show cards strictly better than the specified card.
+    *   `/inferior <name>`: Show cards strictly worse than the specified card.
     *   `/help`: Show available commands.
     *   `exit` or `quit`: Leave the shell.
 

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -724,7 +724,7 @@ def handle_shell(args):
 
         def completer(text, state):
             if text.startswith('/'):
-                commands = ['/search ', '/help', '/exit', '/quit', '/random', '/clear', '/q']
+                commands = ['/search ', '/help', '/exit', '/quit', '/random', '/clear', '/q', '/superior ', '/inferior ']
                 options = [c for c in commands if c.startswith(text)]
             else:
                 options = [n for n in card_names if n.lower().startswith(text.lower())]
@@ -812,11 +812,29 @@ def handle_shell(args):
                 r_args.query = None
                 if not hasattr(r_args, 'limit'): r_args.limit = 0
                 _execute_oracle(sampled, r_args)
+            elif line.startswith('/superior '):
+                query = line[10:].strip()
+                s_args = copy.copy(args)
+                s_args.query = query
+                s_args.fields = getattr(args, 'fields', 'name,cost,type,stats')
+                s_args.table = True
+                if not hasattr(s_args, 'limit'): s_args.limit = 0
+                handle_superior(s_args)
+            elif line.startswith('/inferior '):
+                query = line[10:].strip()
+                i_args = copy.copy(args)
+                i_args.query = query
+                i_args.fields = getattr(args, 'fields', 'name,cost,type,stats')
+                i_args.table = True
+                if not hasattr(i_args, 'limit'): i_args.limit = 0
+                handle_inferior(i_args)
             elif line.startswith('/help'):
                 print("Commands:")
                 print("  <card name>     - Show official rules text for a specific card.")
                 print("  /search <q>     - Search for cards matching <q> (displays a table).")
                 print("  /random         - Show a random card from the dataset.")
+                print("  /superior <n>   - Show cards strictly better than <n>.")
+                print("  /inferior <n>   - Show cards strictly worse than <n>.")
                 print("  /clear          - Clear the terminal screen.")
                 print("  /help           - Show this help message.")
                 print("  /exit, /quit, q - Exit the interactive shell.")
@@ -1007,6 +1025,104 @@ def get_functional_key(card):
         key = (key, get_functional_key(card.bside))
     return key
 
+def _is_strictly_better(candidate, target):
+    """
+    Returns True if candidate is strictly better than target.
+    Logic: shared types, easier or same cost, equal or better stats, superset of abilities.
+    """
+    if candidate.name.lower() == target.name.lower():
+        return False
+
+    # 1. Type compatibility: must share at least one primary type
+    t_types = set(target.types)
+    c_types = set(candidate.types)
+    if not (t_types & c_types):
+        return False
+
+    # If target is creature/planeswalker/battle, candidate must also be one
+    if target.is_creature and not candidate.is_creature:
+        return False
+    if target.is_planeswalker and not candidate.is_planeswalker:
+        return False
+    if target.is_battle and not candidate.is_battle:
+        return False
+
+    # 2. Mana Cost comparison
+    t_cmc = target.cost.cmc
+    c_cmc = candidate.cost.cmc
+    if c_cmc > t_cmc:
+        return False
+
+    # Color requirement check: match each candidate pip requirement to a target requirement
+    def parse_colored_reqs(cost):
+        reqs = []
+        for sym, count in cost.allsymbols.items():
+            if count <= 0:
+                continue
+            colors = set(c for c in sym if c in 'WUBRGC')
+            if colors:
+                for _ in range(count):
+                    reqs.append(colors)
+        return reqs
+
+    c_reqs = parse_colored_reqs(candidate.cost)
+    t_reqs = parse_colored_reqs(target.cost)
+
+    def match_mana(c_idx, used_t_indices, found_strict):
+        if c_idx == len(c_reqs):
+            return True, found_strict
+        c_req = c_reqs[c_idx]
+        for t_idx, t_req in enumerate(t_reqs):
+            if t_idx not in used_t_indices:
+                if t_req.issubset(c_req):
+                    is_strict = len(t_req) < len(c_req)
+                    used_t_indices.add(t_idx)
+                    success, strict = match_mana(c_idx + 1, used_t_indices, found_strict or is_strict)
+                    if success:
+                        return True, strict
+                    used_t_indices.remove(t_idx)
+        return False, False
+
+    success, strict_mana = match_mana(0, set(), False)
+    if not success:
+        return False
+
+    # 3. Stats check
+    # Creatures
+    if target.is_creature and candidate.is_creature:
+        t_p = utils.from_unary_single(target.pt_p) or 0
+        t_t = utils.from_unary_single(target.pt_t) or 0
+        c_p = utils.from_unary_single(candidate.pt_p) or 0
+        c_t = utils.from_unary_single(candidate.pt_t) or 0
+        if c_p < t_p or c_t < t_t:
+            return False
+
+    # Planeswalkers / Battles
+    if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
+        t_l = utils.from_unary_single(target.loyalty) or 0
+        c_l = utils.from_unary_single(candidate.loyalty) or 0
+        if c_l < t_l:
+            return False
+
+    # 4. Mechanics and Actions: candidate must be a superset
+    if not target.mechanics.issubset(candidate.mechanics):
+        return False
+    if not target.actions.issubset(candidate.actions):
+        return False
+
+    # 5. Strictly better check: must be better in at least one metric
+    is_strictly_better = False
+    if (c_cmc < t_cmc) or (len(c_reqs) < len(t_reqs)) or strict_mana:
+        is_strictly_better = True
+    if target.is_creature and candidate.is_creature:
+        if c_p > t_p or c_t > t_t: is_strictly_better = True
+    if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
+        if c_l > t_l: is_strictly_better = True
+    if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
+    if len(candidate.actions) > len(target.actions): is_strictly_better = True
+
+    return is_strictly_better
+
 def handle_functional(args):
     cards = cli_utils.load_and_filter_cards(args)
     if not cards:
@@ -1104,101 +1220,7 @@ def handle_superior(args):
             print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
         return
 
-    def is_superior(candidate, target):
-        if candidate.name.lower() == target.name.lower():
-            return False
-
-        # 1. Type compatibility: must share at least one primary type
-        t_types = set(target.types)
-        c_types = set(candidate.types)
-        if not (t_types & c_types):
-            return False
-
-        # If target is creature/planeswalker/battle, candidate must also be one
-        if target.is_creature and not candidate.is_creature:
-            return False
-        if target.is_planeswalker and not candidate.is_planeswalker:
-            return False
-        if target.is_battle and not candidate.is_battle:
-            return False
-
-        # 2. Mana Cost comparison
-        t_cmc = target.cost.cmc
-        c_cmc = candidate.cost.cmc
-        if c_cmc > t_cmc:
-            return False
-
-        # Color requirement check: match each candidate pip requirement to a target requirement
-        def parse_colored_reqs(cost):
-            reqs = []
-            for sym, count in cost.allsymbols.items():
-                if count <= 0:
-                    continue
-                colors = set(c for c in sym if c in 'WUBRGC')
-                if colors:
-                    for _ in range(count):
-                        reqs.append(colors)
-            return reqs
-
-        c_reqs = parse_colored_reqs(candidate.cost)
-        t_reqs = parse_colored_reqs(target.cost)
-
-        def match_mana(c_idx, used_t_indices, found_strict):
-            if c_idx == len(c_reqs):
-                return True, found_strict
-            c_req = c_reqs[c_idx]
-            for t_idx, t_req in enumerate(t_reqs):
-                if t_idx not in used_t_indices:
-                    if t_req.issubset(c_req):
-                        is_strict = len(t_req) < len(c_req)
-                        used_t_indices.add(t_idx)
-                        success, strict = match_mana(c_idx + 1, used_t_indices, found_strict or is_strict)
-                        if success:
-                            return True, strict
-                        used_t_indices.remove(t_idx)
-            return False, False
-
-        success, strict_mana = match_mana(0, set(), False)
-        if not success:
-            return False
-
-        # 3. Stats check
-        # Creatures
-        if target.is_creature and candidate.is_creature:
-            t_p = utils.from_unary_single(target.pt_p) or 0
-            t_t = utils.from_unary_single(target.pt_t) or 0
-            c_p = utils.from_unary_single(candidate.pt_p) or 0
-            c_t = utils.from_unary_single(candidate.pt_t) or 0
-            if c_p < t_p or c_t < t_t:
-                return False
-
-        # Planeswalkers / Battles
-        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
-            t_l = utils.from_unary_single(target.loyalty) or 0
-            c_l = utils.from_unary_single(candidate.loyalty) or 0
-            if c_l < t_l:
-                return False
-
-        # 4. Mechanics and Actions: candidate must be a superset
-        if not target.mechanics.issubset(candidate.mechanics):
-            return False
-        if not target.actions.issubset(candidate.actions):
-            return False
-
-        # 5. Strictly better check: must be better in at least one metric
-        is_strictly_better = False
-        if (c_cmc < t_cmc) or (len(c_reqs) < len(t_reqs)) or strict_mana:
-            is_strictly_better = True
-        if target.is_creature and candidate.is_creature:
-            if c_p > t_p or c_t > t_t: is_strictly_better = True
-        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
-            if c_l > t_l: is_strictly_better = True
-        if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
-        if len(candidate.actions) > len(target.actions): is_strictly_better = True
-
-        return is_strictly_better
-
-    superior_cards = [c for c in cards if is_superior(c, target_card)]
+    superior_cards = [c for c in cards if _is_strictly_better(c, target_card)]
 
     if not superior_cards:
         if not args.quiet:
@@ -1207,6 +1229,56 @@ def handle_superior(args):
 
     # Use search display for results
     _execute_search(superior_cards, args)
+
+def handle_inferior(args):
+    # Smart positional argument handling
+    if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
+        temp = args.query
+        args.query = args.infile if args.infile != '-' else None
+        args.infile = temp
+
+    cards = cli_utils.load_and_filter_cards(args)
+    if not cards:
+        if not args.quiet:
+            print("No cards found in the dataset.", file=sys.stderr)
+        return
+
+    query = args.query
+    if not query:
+        if not args.quiet:
+            print("Error: No reference card name provided.", file=sys.stderr)
+        return
+
+    query_sanitized = query.lower().replace('-', utils.dash_marker)
+    target_card = next((c for c in cards if c.name.lower() == query_sanitized), None)
+    if not target_card:
+        # Try finding in the full dataset if not in the filtered pool
+        all_cards = jdecode.mtg_open_file(args.infile, verbose=False)
+        target_card = next((c for c in all_cards if c.name.lower() == query_sanitized), None)
+        if not target_card:
+            # Fuzzy match
+            search_names = {c.name.lower(): c for c in all_cards}
+            close = difflib.get_close_matches(query.lower(), list(search_names.keys()), n=1, cutoff=0.6)
+            if close:
+                target_card = search_names[close[0]]
+                if not args.quiet:
+                    print(f"Notice: Card '{query}' not found. Using best match: {target_card.display_name}", file=sys.stderr)
+
+    if not target_card:
+        if not args.quiet:
+            print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
+        return
+
+    # To find inferior cards, we check if target_card is superior to candidate
+    inferior_cards = [c for c in cards if _is_strictly_better(target_card, c)]
+
+    if not inferior_cards:
+        if not args.quiet:
+            print(f"No cards found that are inferior to {target_card.display_name}.", file=sys.stderr)
+        return
+
+    # Use search display for results
+    _execute_search(inferior_cards, args)
 
 def handle_random(args):
     # Smart Positional Argument Handling
@@ -1724,6 +1796,38 @@ Usage Examples:
     p_superior.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_superior.set_defaults(func=handle_superior)
+
+    # Inferior Subparser
+    p_inferior = subparsers.add_parser(
+        'inferior',
+        help='Find cards that are strictly worse than a reference card.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Finds "strictly worse" cards by comparing mana cost, stats, and abilities.
+A card is considered inferior if it has harder or identical mana cost,
+equal or worse stats (P/T or Loyalty), and its abilities are a subset
+of the reference card.
+
+Usage Examples:
+  # Find cards worse than Grizzly Bears
+  python3 scripts/mtg_query.py inferior "Grizzly Bears"
+
+  # Find worse cards in a specific set
+  python3 scripts/mtg_query.py inferior "Grizzly Bears" --set MOM
+"""
+    )
+    p_inferior.add_argument('query', help='The card name to use as a reference for comparison.')
+    p_inferior.add_argument('infile', nargs='?', default='-',
+                           help='Input card data file. Defaults to data/AllPrintings.json.')
+    cli_utils.add_standard_filters(p_inferior)
+    cli_utils.add_standard_output_args(p_inferior)
+    p_inferior.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
+                           help='Fields to display in the output table.')
+    p_inferior.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
+                           help='Sort the resulting inferior cards.')
+    p_inferior.add_argument('--delimiter', default=' | ',
+                        help='Separator used between fields in plain text output.')
+    p_inferior.set_defaults(func=handle_inferior)
 
     # Shell Subparser
     p_shell = subparsers.add_parser(

--- a/tests/test_mtg_inferior.py
+++ b/tests/test_mtg_inferior.py
@@ -1,0 +1,132 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import json
+import io
+
+# Add scripts and lib to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../scripts')))
+
+import mtg_query
+import cardlib
+import utils
+
+class TestMtgInferior(unittest.TestCase):
+    def setUp(self):
+        # Create a small test dataset
+        self.test_data = {
+            "data": {
+                "INF": {
+                    "name": "Inferiority Test",
+                    "code": "INF",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Superior Bear",
+                            "manaCost": "{1}{G}",
+                            "type": "Creature — Bear",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "text": "Trample",
+                            "power": "3",
+                            "toughness": "3",
+                            "rarity": "rare"
+                        },
+                        {
+                            "name": "Grizzly Bears",
+                            "manaCost": "{1}{G}",
+                            "type": "Creature — Bear",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "text": "",
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Inferior Bear",
+                            "manaCost": "{2}{G}",
+                            "type": "Creature — Bear",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "text": "",
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Flying Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "text": "Flying",
+                            "rarity": "rare"
+                        }
+                    ]
+                }
+            }
+        }
+        self.test_file = "test_inferior.json"
+        with open(self.test_file, 'w') as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self):
+        if os.path.exists(self.test_file):
+            os.remove(self.test_file)
+
+    def test_inferior_basic(self):
+        # Grizzly Bears and Inferior Bear should be inferior to Superior Bear
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'inferior', 'Superior Bear', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Grizzly Bears", output)
+            self.assertIn("Inferior Bear", output)
+            self.assertNotIn("Superior Bear", output)
+
+    def test_inferior_reference_grizzly(self):
+        # Inferior Bear should be inferior to Grizzly Bears
+        # Superior Bear and Flying Bears are NOT inferior to Grizzly Bears
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'inferior', 'Grizzly Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Inferior Bear", output)
+            self.assertNotIn("Superior Bear", output)
+            self.assertNotIn("Flying Bears", output)
+
+    def test_inferior_no_results(self):
+        # Inferior Bear has no cards inferior to it in this set
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            test_args = ['mtg_query.py', 'inferior', 'Inferior Bear', self.test_file]
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_err.getvalue()
+            self.assertIn("No cards found that are inferior to Inferior Bear.", output)
+
+    def test_superior_regression(self):
+        # Verify that superior still works after refactor
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            test_args = ['mtg_query.py', 'superior', 'Grizzly Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Superior Bear", output)
+            self.assertIn("Flying Bears", output)
+            self.assertNotIn("Inferior Bear", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented the `inferior` subcommand in `scripts/mtg_query.py` to complement the existing `superior` command. This allows users to find cards that are strictly worse than a reference card based on mana cost, combat stats, and mechanical abilities. The feature includes CLI support, interactive shell integration with tab-completion, and full documentation.

---
*PR created automatically by Jules for task [6069901887566256019](https://jules.google.com/task/6069901887566256019) started by @RainRat*