### PR TITLE
[UI/UX] Polish mtg_query UI and add inferior command functionality

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -100,27 +100,15 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if ansi_color:
             res = utils.colorize(res, utils.Ansi.GREEN)
     elif canon == 'pt':
-        res = utils.from_unary(card.pt) if card.pt else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_pt_display(ansi_color=ansi_color)
     elif canon == 'stats':
-        res = utils.from_unary(card.pt) if card.pt else ""
-        if not res:
-            res = utils.from_unary(card.loyalty) if card.loyalty else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_pt_display(ansi_color=ansi_color) or card._get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'power':
-        res = utils.from_unary(card.pt_p) if card.pt_p else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_pt_display(ansi_color=ansi_color, include_parens=False).split('/')[0] if card.pt_p else ""
     elif canon == 'toughness':
-        res = utils.from_unary(card.pt_t) if card.pt_t else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_pt_display(ansi_color=ansi_color, include_parens=False).split('/')[-1] if card.pt_t else ""
     elif canon == 'loyalty':
-        res = utils.from_unary(card.loyalty) if card.loyalty else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card._get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'text':
         res = card.get_text(force_unpass=True, ansi_color=ansi_color)
     elif canon == 'rarity':
@@ -207,12 +195,12 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
     elif canon == 'summary':
         return card.summary(ansi_color=ansi_color).replace('\u2014', '-')
     elif canon == 'encoded':
-        res = card.encode()
+        return card.encode()
     else:
         return ""
 
     if card.bside:
-        if canon in ['rarity', 'set', 'pack', 'box', 'id_count', 'identity', 'mechanics', 'summary']:
+        if canon in ['rarity', 'set', 'pack', 'box', 'id_count', 'identity', 'mechanics', 'summary', 'tokens', 'actions']:
             return str(res)
         b_res = get_field_value(card.bside, field, ansi_color, multi_sep=multi_sep)
         if res and b_res:
@@ -724,7 +712,7 @@ def handle_shell(args):
 
         def completer(text, state):
             if text.startswith('/'):
-                commands = ['/search ', '/help', '/exit', '/quit', '/random', '/clear', '/q']
+                commands = ['/search ', '/superior ', '/inferior ', '/help', '/exit', '/quit', '/random', '/clear', '/q']
                 options = [c for c in commands if c.startswith(text)]
             else:
                 options = [n for n in card_names if n.lower().startswith(text.lower())]
@@ -812,10 +800,26 @@ def handle_shell(args):
                 r_args.query = None
                 if not hasattr(r_args, 'limit'): r_args.limit = 0
                 _execute_oracle(sampled, r_args)
+            elif line.startswith('/superior '):
+                query = line[10:].strip()
+                s_args = copy.copy(args)
+                s_args.query = query
+                s_args.fields = getattr(args, 'fields', 'name,cost,type,stats')
+                s_args.table = True
+                handle_superior(s_args)
+            elif line.startswith('/inferior '):
+                query = line[10:].strip()
+                i_args = copy.copy(args)
+                i_args.query = query
+                i_args.fields = getattr(args, 'fields', 'name,cost,type,stats')
+                i_args.table = True
+                handle_inferior(i_args)
             elif line.startswith('/help'):
                 print("Commands:")
                 print("  <card name>     - Show official rules text for a specific card.")
                 print("  /search <q>     - Search for cards matching <q> (displays a table).")
+                print("  /superior <n>   - Find cards strictly better than <n>.")
+                print("  /inferior <n>   - Find cards strictly worse than <n>.")
                 print("  /random         - Show a random card from the dataset.")
                 print("  /clear          - Clear the terminal screen.")
                 print("  /help           - Show this help message.")
@@ -1065,6 +1069,101 @@ def handle_functional(args):
             print(group[0].summary(ansi_color=use_color).replace('\u2014', '-'))
             print()
 
+def _is_strictly_better(candidate, target):
+    """Internal helper to determine if a candidate card is strictly better than a target card."""
+    if candidate.name.lower() == target.name.lower():
+        return False
+
+    # 1. Type compatibility: must share at least one primary type
+    t_types = set(target.types)
+    c_types = set(candidate.types)
+    if not (t_types & c_types):
+        return False
+
+    # If target is creature/planeswalker/battle, candidate must also be one
+    if target.is_creature and not candidate.is_creature:
+        return False
+    if target.is_planeswalker and not candidate.is_planeswalker:
+        return False
+    if target.is_battle and not candidate.is_battle:
+        return False
+
+    # 2. Mana Cost comparison
+    t_cmc = target.cost.cmc
+    c_cmc = candidate.cost.cmc
+    if c_cmc > t_cmc:
+        return False
+
+    # Color requirement check: match each candidate pip requirement to a target requirement
+    def parse_colored_reqs(cost):
+        reqs = []
+        for sym, count in cost.allsymbols.items():
+            if count <= 0:
+                continue
+            colors = set(c for c in sym if c in 'WUBRGC')
+            if colors:
+                for _ in range(count):
+                    reqs.append(colors)
+        return reqs
+
+    c_reqs = parse_colored_reqs(candidate.cost)
+    t_reqs = parse_colored_reqs(target.cost)
+
+    def match_mana(c_idx, used_t_indices, found_strict):
+        if c_idx == len(c_reqs):
+            return True, found_strict
+        c_req = c_reqs[c_idx]
+        for t_idx, t_req in enumerate(t_reqs):
+            if t_idx not in used_t_indices:
+                if t_req.issubset(c_req):
+                    is_strict = len(t_req) < len(c_req)
+                    used_t_indices.add(t_idx)
+                    success, strict = match_mana(c_idx + 1, used_t_indices, found_strict or is_strict)
+                    if success:
+                        return True, strict
+                    used_t_indices.remove(t_idx)
+        return False, False
+
+    success, strict_mana = match_mana(0, set(), False)
+    if not success:
+        return False
+
+    # 3. Stats check
+    # Creatures
+    if target.is_creature and candidate.is_creature:
+        t_p = utils.from_unary_single(target.pt_p) or 0
+        t_t = utils.from_unary_single(target.pt_t) or 0
+        c_p = utils.from_unary_single(candidate.pt_p) or 0
+        c_t = utils.from_unary_single(candidate.pt_t) or 0
+        if c_p < t_p or c_t < t_t:
+            return False
+
+    # Planeswalkers / Battles
+    if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
+        t_l = utils.from_unary_single(target.loyalty) or 0
+        c_l = utils.from_unary_single(candidate.loyalty) or 0
+        if c_l < t_l:
+            return False
+
+    # 4. Mechanics and Actions: candidate must be a superset
+    if not target.mechanics.issubset(candidate.mechanics):
+        return False
+    if not target.actions.issubset(candidate.actions):
+        return False
+
+    # 5. Strictly better check: must be better in at least one metric
+    is_strictly_better = False
+    if (c_cmc < t_cmc) or (len(c_reqs) < len(t_reqs)) or strict_mana:
+        is_strictly_better = True
+    if target.is_creature and candidate.is_creature:
+        if c_p > t_p or c_t > t_t: is_strictly_better = True
+    if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
+        if c_l > t_l: is_strictly_better = True
+    if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
+    if len(candidate.actions) > len(target.actions): is_strictly_better = True
+
+    return is_strictly_better
+
 def handle_superior(args):
     # Smart positional argument handling
     if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
@@ -1104,101 +1203,7 @@ def handle_superior(args):
             print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
         return
 
-    def is_superior(candidate, target):
-        if candidate.name.lower() == target.name.lower():
-            return False
-
-        # 1. Type compatibility: must share at least one primary type
-        t_types = set(target.types)
-        c_types = set(candidate.types)
-        if not (t_types & c_types):
-            return False
-
-        # If target is creature/planeswalker/battle, candidate must also be one
-        if target.is_creature and not candidate.is_creature:
-            return False
-        if target.is_planeswalker and not candidate.is_planeswalker:
-            return False
-        if target.is_battle and not candidate.is_battle:
-            return False
-
-        # 2. Mana Cost comparison
-        t_cmc = target.cost.cmc
-        c_cmc = candidate.cost.cmc
-        if c_cmc > t_cmc:
-            return False
-
-        # Color requirement check: match each candidate pip requirement to a target requirement
-        def parse_colored_reqs(cost):
-            reqs = []
-            for sym, count in cost.allsymbols.items():
-                if count <= 0:
-                    continue
-                colors = set(c for c in sym if c in 'WUBRGC')
-                if colors:
-                    for _ in range(count):
-                        reqs.append(colors)
-            return reqs
-
-        c_reqs = parse_colored_reqs(candidate.cost)
-        t_reqs = parse_colored_reqs(target.cost)
-
-        def match_mana(c_idx, used_t_indices, found_strict):
-            if c_idx == len(c_reqs):
-                return True, found_strict
-            c_req = c_reqs[c_idx]
-            for t_idx, t_req in enumerate(t_reqs):
-                if t_idx not in used_t_indices:
-                    if t_req.issubset(c_req):
-                        is_strict = len(t_req) < len(c_req)
-                        used_t_indices.add(t_idx)
-                        success, strict = match_mana(c_idx + 1, used_t_indices, found_strict or is_strict)
-                        if success:
-                            return True, strict
-                        used_t_indices.remove(t_idx)
-            return False, False
-
-        success, strict_mana = match_mana(0, set(), False)
-        if not success:
-            return False
-
-        # 3. Stats check
-        # Creatures
-        if target.is_creature and candidate.is_creature:
-            t_p = utils.from_unary_single(target.pt_p) or 0
-            t_t = utils.from_unary_single(target.pt_t) or 0
-            c_p = utils.from_unary_single(candidate.pt_p) or 0
-            c_t = utils.from_unary_single(candidate.pt_t) or 0
-            if c_p < t_p or c_t < t_t:
-                return False
-
-        # Planeswalkers / Battles
-        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
-            t_l = utils.from_unary_single(target.loyalty) or 0
-            c_l = utils.from_unary_single(candidate.loyalty) or 0
-            if c_l < t_l:
-                return False
-
-        # 4. Mechanics and Actions: candidate must be a superset
-        if not target.mechanics.issubset(candidate.mechanics):
-            return False
-        if not target.actions.issubset(candidate.actions):
-            return False
-
-        # 5. Strictly better check: must be better in at least one metric
-        is_strictly_better = False
-        if (c_cmc < t_cmc) or (len(c_reqs) < len(t_reqs)) or strict_mana:
-            is_strictly_better = True
-        if target.is_creature and candidate.is_creature:
-            if c_p > t_p or c_t > t_t: is_strictly_better = True
-        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
-            if c_l > t_l: is_strictly_better = True
-        if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
-        if len(candidate.actions) > len(target.actions): is_strictly_better = True
-
-        return is_strictly_better
-
-    superior_cards = [c for c in cards if is_superior(c, target_card)]
+    superior_cards = [c for c in cards if _is_strictly_better(c, target_card)]
 
     if not superior_cards:
         if not args.quiet:
@@ -1207,6 +1212,55 @@ def handle_superior(args):
 
     # Use search display for results
     _execute_search(superior_cards, args)
+
+def handle_inferior(args):
+    # Smart positional argument handling
+    if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
+        temp = args.query
+        args.query = args.infile if args.infile != '-' else None
+        args.infile = temp
+
+    cards = cli_utils.load_and_filter_cards(args)
+    if not cards:
+        if not args.quiet:
+            print("No cards found in the dataset.", file=sys.stderr)
+        return
+
+    query = args.query
+    if not query:
+        if not args.quiet:
+            print("Error: No reference card name provided.", file=sys.stderr)
+        return
+
+    query_sanitized = query.lower().replace('-', utils.dash_marker)
+    target_card = next((c for c in cards if c.name.lower() == query_sanitized), None)
+    if not target_card:
+        # Try finding in the full dataset if not in the filtered pool
+        all_cards = jdecode.mtg_open_file(args.infile, verbose=False)
+        target_card = next((c for c in all_cards if c.name.lower() == query_sanitized), None)
+        if not target_card:
+            # Fuzzy match
+            search_names = {c.name.lower(): c for c in all_cards}
+            close = difflib.get_close_matches(query.lower(), list(search_names.keys()), n=1, cutoff=0.6)
+            if close:
+                target_card = search_names[close[0]]
+                if not args.quiet:
+                    print(f"Notice: Card '{query}' not found. Using best match: {target_card.display_name}", file=sys.stderr)
+
+    if not target_card:
+        if not args.quiet:
+            print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
+        return
+
+    inferior_cards = [c for c in cards if _is_strictly_better(target_card, c)]
+
+    if not inferior_cards:
+        if not args.quiet:
+            print(f"No cards found that are inferior to {target_card.display_name}.", file=sys.stderr)
+        return
+
+    # Use search display for results
+    _execute_search(inferior_cards, args)
 
 def handle_random(args):
     # Smart Positional Argument Handling
@@ -1724,6 +1778,38 @@ Usage Examples:
     p_superior.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_superior.set_defaults(func=handle_superior)
+
+    # Inferior Subparser
+    p_inferior = subparsers.add_parser(
+        'inferior',
+        help='Find cards that are strictly worse than a reference card.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Finds "strictly worse" cards by comparing mana cost, stats, and abilities.
+A card is considered inferior if it has more expensive or identical mana cost,
+equal or worse stats (P/T or Loyalty), and its abilities are a subset
+of the reference card.
+
+Usage Examples:
+  # Find cards worse than Kalonian Tusker
+  python3 scripts/mtg_query.py inferior "Kalonian Tusker"
+
+  # Find worse cards in a specific set
+  python3 scripts/mtg_query.py inferior "Grizzly Bears" --set TEST
+"""
+    )
+    p_inferior.add_argument('query', help='The card name to use as a reference for comparison.')
+    p_inferior.add_argument('infile', nargs='?', default='-',
+                           help='Input card data file. Defaults to data/AllPrintings.json.')
+    cli_utils.add_standard_filters(p_inferior)
+    cli_utils.add_standard_output_args(p_inferior)
+    p_inferior.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
+                           help='Fields to display in the output table.')
+    p_inferior.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
+                           help='Sort the resulting inferior cards.')
+    p_inferior.add_argument('--delimiter', default=' | ',
+                        help='Separator used between fields in plain text output.')
+    p_inferior.set_defaults(func=handle_inferior)
 
     # Shell Subparser
     p_shell = subparsers.add_parser(

--- a/tests/test_mtg_inferior.py
+++ b/tests/test_mtg_inferior.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import json
+import io
+
+# Add scripts and lib to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../scripts')))
+
+import mtg_query
+import cardlib
+import utils
+
+class TestMtgInferior(unittest.TestCase):
+    def setUp(self):
+        # Create a small test dataset
+        self.test_data = {
+            "data": {
+                "TEST": {
+                    "name": "Test Set",
+                    "code": "TEST",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Grizzly Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Better Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "3",
+                            "toughness": "3",
+                            "rarity": "uncommon"
+                        },
+                        {
+                            "name": "Expensive Bears",
+                            "manaCost": "{2}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Plain Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "1",
+                            "toughness": "1",
+                            "rarity": "common"
+                        }
+                    ]
+                }
+            }
+        }
+        self.test_file = "test_inferior_command.json"
+        with open(self.test_file, 'w') as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self):
+        if os.path.exists(self.test_file):
+            os.remove(self.test_file)
+
+    def test_inferior_basic(self):
+        # Grizzly Bears and Expensive Bears and Plain Bears should be inferior to Better Bears
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'inferior', 'Better Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Grizzly Bears", output)
+            self.assertIn("Expensive Bears", output)
+            self.assertIn("Plain Bears", output)
+            self.assertNotIn("Better Bears", output) # Should not include itself
+
+    def test_formatting_consistency(self):
+        # Verify that stat formatting uses parentheses now
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'search', 'Grizzly Bears', self.test_file, '--fields', 'stats', '--table']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            # It should use (2/2) now, not just 2/2
+            self.assertIn("(2/2)", output)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mtg_query_compare.py
+++ b/tests/test_mtg_query_compare.py
@@ -44,5 +44,5 @@ def test_query_compare_multi_face():
     assert "Double Back" in result.stdout
     # Check that they are identified as different in the table
     # Since Double Front matches the whole card (both faces) and Double Back matches only one face
-    assert "1/1 // 2/2" in result.stdout
-    assert "2/2" in result.stdout
+    assert "(1/1) // (2/2)" in result.stdout
+    assert "(2/2)" in result.stdout

--- a/tests/test_mtg_search_gaps.py
+++ b/tests/test_mtg_search_gaps.py
@@ -90,14 +90,14 @@ class TestMtgSearchGaps(unittest.TestCase):
         card = Card({"name": "Test", "power": "2", "toughness": "3", "types": ["Creature"]})
         self.assertEqual(get_field_value(card, "power"), "2")
         self.assertEqual(get_field_value(card, "toughness"), "3")
-        self.assertEqual(get_field_value(card, "pt"), "2/3")
+        self.assertEqual(get_field_value(card, "pt"), "(2/3)")
 
     def test_get_field_value_loyalty(self):
         from scripts.mtg_query import get_field_value
         from lib.cardlib import Card
         card = Card({"name": "Test", "loyalty": "5", "types": ["Planeswalker"]})
-        self.assertEqual(get_field_value(card, "loyalty"), "5")
-        self.assertEqual(get_field_value(card, "stats"), "5")
+        self.assertEqual(get_field_value(card, "loyalty"), "(5)")
+        self.assertEqual(get_field_value(card, "stats"), "(5)")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR improves the consistency and power-user efficiency of the `mtg_query.py` toolkit. 

### Improvements:
1.  **Visual Consistency:** The `pt`, `stats`, `power`, `toughness`, and `loyalty` fields now use the standardized formatting provided by the `Card` class (e.g., parentheses for P/T, double brackets for Battle defense). This ensures a polished "stock" look across search tables, side-by-side comparisons, and the interactive shell.
2.  **Functional Symmetry:** Added the `inferior` command, completing the pair with the existing `superior` command. This allows users to find "strictly worse" versions of a card (e.g., finding all cards strictly worse than *Better Bears*).
3.  **Shell Efficiency:** Integrated `/superior` and `/inferior` into the interactive shell, including tab-completion for command names. This reduces the keystrokes required for iterative card design analysis.
4.  **Bug Fixes:**
    - Prevented redundant data concatenation for multi-faced cards when using the `encoded` field.
    - Updated the b-side skip list to include `tokens` and `actions` to avoid double-processing recursive class properties.

### Verification:
- Added `tests/test_mtg_inferior.py` covering the new command and stat formatting.
- Updated `tests/test_mtg_search_gaps.py` and `tests/test_mtg_query_compare.py` to reflect the new standardized formatting.
- Ran the full test suite (`PYTHONPATH=.:./lib:./scripts python3 -m pytest tests/`) and verified that all 1157 tests passed.
- Manually verified shell command integration and formatting.

---
*PR created automatically by Jules for task [8301649840202674981](https://jules.google.com/task/8301649840202674981) started by @RainRat*