### PR TITLE
[FEAT] Add 'inferior' command for finding strictly worse cards

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -724,7 +724,7 @@ def handle_shell(args):
 
         def completer(text, state):
             if text.startswith('/'):
-                commands = ['/search ', '/help', '/exit', '/quit', '/random', '/clear', '/q']
+                commands = ['/search ', '/help', '/exit', '/quit', '/random', '/clear', '/q', '/superior ', '/inferior ']
                 options = [c for c in commands if c.startswith(text)]
             else:
                 options = [n for n in card_names if n.lower().startswith(text.lower())]
@@ -812,14 +812,30 @@ def handle_shell(args):
                 r_args.query = None
                 if not hasattr(r_args, 'limit'): r_args.limit = 0
                 _execute_oracle(sampled, r_args)
+            elif line.startswith('/superior '):
+                query = line[10:].strip()
+                s_args = copy.copy(args)
+                s_args.query = query
+                s_args.fields = getattr(args, 'fields', 'name,cost,cmc,type,stats,rarity,mechanics')
+                s_args.table = True
+                handle_superior(s_args)
+            elif line.startswith('/inferior '):
+                query = line[10:].strip()
+                i_args = copy.copy(args)
+                i_args.query = query
+                i_args.fields = getattr(args, 'fields', 'name,cost,cmc,type,stats,rarity,mechanics')
+                i_args.table = True
+                handle_inferior(i_args)
             elif line.startswith('/help'):
                 print("Commands:")
-                print("  <card name>     - Show official rules text for a specific card.")
-                print("  /search <q>     - Search for cards matching <q> (displays a table).")
-                print("  /random         - Show a random card from the dataset.")
-                print("  /clear          - Clear the terminal screen.")
-                print("  /help           - Show this help message.")
-                print("  /exit, /quit, q - Exit the interactive shell.")
+                print("  <card name>      - Show official rules text for a specific card.")
+                print("  /search <q>      - Search for cards matching <q> (displays a table).")
+                print("  /random          - Show a random card from the dataset.")
+                print("  /superior <name> - Find cards strictly better than <name>.")
+                print("  /inferior <name> - Find cards strictly worse than <name>.")
+                print("  /clear           - Clear the terminal screen.")
+                print("  /help            - Show this help message.")
+                print("  /exit, /quit, q  - Exit the interactive shell.")
             else:
                 # Oracle lookup
                 o_args = copy.copy(args)
@@ -1065,24 +1081,13 @@ def handle_functional(args):
             print(group[0].summary(ansi_color=use_color).replace('\u2014', '-'))
             print()
 
-def handle_superior(args):
-    # Smart positional argument handling
-    if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
-        temp = args.query
-        args.query = args.infile if args.infile != '-' else None
-        args.infile = temp
-
-    cards = cli_utils.load_and_filter_cards(args)
+def _resolve_reference_card(args, cards):
     if not cards:
-        if not args.quiet:
-            print("No cards found in the dataset.", file=sys.stderr)
-        return
+        return None
 
-    query = args.query
+    query = getattr(args, 'query', None)
     if not query:
-        if not args.quiet:
-            print("Error: No reference card name provided.", file=sys.stderr)
-        return
+        return None
 
     query_sanitized = query.lower().replace('-', utils.dash_marker)
     target_card = next((c for c in cards if c.name.lower() == query_sanitized), None)
@@ -1098,107 +1103,134 @@ def handle_superior(args):
                 target_card = search_names[close[0]]
                 if not args.quiet:
                     print(f"Notice: Card '{query}' not found. Using best match: {target_card.display_name}", file=sys.stderr)
+    return target_card
 
-    if not target_card:
+def is_superior_card(candidate, target):
+    if candidate.name.lower() == target.name.lower():
+        return False
+
+    # 1. Type compatibility: must share at least one primary type
+    t_types = set(target.types)
+    c_types = set(candidate.types)
+    if not (t_types & c_types):
+        return False
+
+    # If target is creature/planeswalker/battle, candidate must also be one
+    if target.is_creature and not candidate.is_creature:
+        return False
+    if target.is_planeswalker and not candidate.is_planeswalker:
+        return False
+    if target.is_battle and not candidate.is_battle:
+        return False
+
+    # 2. Mana Cost comparison
+    t_cmc = target.cost.cmc
+    c_cmc = candidate.cost.cmc
+    if c_cmc > t_cmc:
+        return False
+
+    # Color requirement check: match each candidate pip requirement to a target requirement
+    def parse_colored_reqs(cost):
+        reqs = []
+        for sym, count in cost.allsymbols.items():
+            if count <= 0:
+                continue
+            colors = set(c for c in sym if c in 'WUBRGC')
+            if colors:
+                for _ in range(count):
+                    reqs.append(colors)
+        return reqs
+
+    c_reqs = parse_colored_reqs(candidate.cost)
+    t_reqs = parse_colored_reqs(target.cost)
+
+    def match_mana(c_idx, used_t_indices, found_strict):
+        if c_idx == len(c_reqs):
+            return True, found_strict
+        c_req = c_reqs[c_idx]
+        for t_idx, t_req in enumerate(t_reqs):
+            if t_idx not in used_t_indices:
+                if t_req.issubset(c_req):
+                    is_strict = len(t_req) < len(c_req)
+                    used_t_indices.add(t_idx)
+                    success, strict = match_mana(c_idx + 1, used_t_indices, found_strict or is_strict)
+                    if success:
+                        return True, strict
+                    used_t_indices.remove(t_idx)
+        return False, False
+
+    success, strict_mana = match_mana(0, set(), False)
+    if not success:
+        return False
+
+    # 3. Stats check
+    # Creatures
+    if target.is_creature and candidate.is_creature:
+        t_p = utils.from_unary_single(target.pt_p) or 0
+        t_t = utils.from_unary_single(target.pt_t) or 0
+        c_p = utils.from_unary_single(candidate.pt_p) or 0
+        c_t = utils.from_unary_single(candidate.pt_t) or 0
+        if c_p < t_p or c_t < t_t:
+            return False
+
+    # Planeswalkers
+    if target.is_planeswalker and candidate.is_planeswalker:
+        t_l = utils.from_unary_single(target.loyalty) or 0
+        c_l = utils.from_unary_single(candidate.loyalty) or 0
+        if c_l < t_l:
+            return False
+
+    # Battles (Defense): lower defense is better for the caster (usually Sieges)
+    if target.is_battle and candidate.is_battle:
+        t_d = utils.from_unary_single(target.loyalty) or 0
+        c_d = utils.from_unary_single(candidate.loyalty) or 0
+        if c_d > t_d:
+            return False
+
+    # 4. Mechanics and Actions: candidate must be a superset
+    if not target.mechanics.issubset(candidate.mechanics):
+        return False
+    if not target.actions.issubset(candidate.actions):
+        return False
+
+    # 5. Strictly better check: must be better in at least one metric
+    is_strictly_better = False
+    if (c_cmc < t_cmc) or (len(c_reqs) < len(t_reqs)) or strict_mana:
+        is_strictly_better = True
+    if target.is_creature and candidate.is_creature:
+        if c_p > t_p or c_t > t_t: is_strictly_better = True
+    if target.is_planeswalker and candidate.is_planeswalker:
+        if c_l > t_l: is_strictly_better = True
+    if target.is_battle and candidate.is_battle:
+        if c_d < t_d: is_strictly_better = True
+    if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
+    if len(candidate.actions) > len(target.actions): is_strictly_better = True
+
+    return is_strictly_better
+
+def handle_superior(args):
+    # Smart positional argument handling
+    if hasattr(args, 'query') and args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
+        temp = args.query
+        args.query = args.infile if args.infile != '-' else None
+        args.infile = temp
+
+    cards = cli_utils.load_and_filter_cards(args)
+    if not cards:
         if not args.quiet:
-            print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
+            print("No cards found matching the criteria.", file=sys.stderr)
         return
 
-    def is_superior(candidate, target):
-        if candidate.name.lower() == target.name.lower():
-            return False
+    target_card = _resolve_reference_card(args, cards)
+    if not target_card:
+        if not args.quiet:
+            if not getattr(args, 'query', None):
+                print("Error: No reference card name provided.", file=sys.stderr)
+            else:
+                print(f"Error: Could not find reference card '{args.query}'", file=sys.stderr)
+        return
 
-        # 1. Type compatibility: must share at least one primary type
-        t_types = set(target.types)
-        c_types = set(candidate.types)
-        if not (t_types & c_types):
-            return False
-
-        # If target is creature/planeswalker/battle, candidate must also be one
-        if target.is_creature and not candidate.is_creature:
-            return False
-        if target.is_planeswalker and not candidate.is_planeswalker:
-            return False
-        if target.is_battle and not candidate.is_battle:
-            return False
-
-        # 2. Mana Cost comparison
-        t_cmc = target.cost.cmc
-        c_cmc = candidate.cost.cmc
-        if c_cmc > t_cmc:
-            return False
-
-        # Color requirement check: match each candidate pip requirement to a target requirement
-        def parse_colored_reqs(cost):
-            reqs = []
-            for sym, count in cost.allsymbols.items():
-                if count <= 0:
-                    continue
-                colors = set(c for c in sym if c in 'WUBRGC')
-                if colors:
-                    for _ in range(count):
-                        reqs.append(colors)
-            return reqs
-
-        c_reqs = parse_colored_reqs(candidate.cost)
-        t_reqs = parse_colored_reqs(target.cost)
-
-        def match_mana(c_idx, used_t_indices, found_strict):
-            if c_idx == len(c_reqs):
-                return True, found_strict
-            c_req = c_reqs[c_idx]
-            for t_idx, t_req in enumerate(t_reqs):
-                if t_idx not in used_t_indices:
-                    if t_req.issubset(c_req):
-                        is_strict = len(t_req) < len(c_req)
-                        used_t_indices.add(t_idx)
-                        success, strict = match_mana(c_idx + 1, used_t_indices, found_strict or is_strict)
-                        if success:
-                            return True, strict
-                        used_t_indices.remove(t_idx)
-            return False, False
-
-        success, strict_mana = match_mana(0, set(), False)
-        if not success:
-            return False
-
-        # 3. Stats check
-        # Creatures
-        if target.is_creature and candidate.is_creature:
-            t_p = utils.from_unary_single(target.pt_p) or 0
-            t_t = utils.from_unary_single(target.pt_t) or 0
-            c_p = utils.from_unary_single(candidate.pt_p) or 0
-            c_t = utils.from_unary_single(candidate.pt_t) or 0
-            if c_p < t_p or c_t < t_t:
-                return False
-
-        # Planeswalkers / Battles
-        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
-            t_l = utils.from_unary_single(target.loyalty) or 0
-            c_l = utils.from_unary_single(candidate.loyalty) or 0
-            if c_l < t_l:
-                return False
-
-        # 4. Mechanics and Actions: candidate must be a superset
-        if not target.mechanics.issubset(candidate.mechanics):
-            return False
-        if not target.actions.issubset(candidate.actions):
-            return False
-
-        # 5. Strictly better check: must be better in at least one metric
-        is_strictly_better = False
-        if (c_cmc < t_cmc) or (len(c_reqs) < len(t_reqs)) or strict_mana:
-            is_strictly_better = True
-        if target.is_creature and candidate.is_creature:
-            if c_p > t_p or c_t > t_t: is_strictly_better = True
-        if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
-            if c_l > t_l: is_strictly_better = True
-        if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
-        if len(candidate.actions) > len(target.actions): is_strictly_better = True
-
-        return is_strictly_better
-
-    superior_cards = [c for c in cards if is_superior(c, target_card)]
+    superior_cards = [c for c in cards if is_superior_card(c, target_card)]
 
     if not superior_cards:
         if not args.quiet:
@@ -1207,6 +1239,38 @@ def handle_superior(args):
 
     # Use search display for results
     _execute_search(superior_cards, args)
+
+def handle_inferior(args):
+    # Smart positional argument handling
+    if hasattr(args, 'query') and args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
+        temp = args.query
+        args.query = args.infile if args.infile != '-' else None
+        args.infile = temp
+
+    cards = cli_utils.load_and_filter_cards(args)
+    if not cards:
+        if not args.quiet:
+            print("No cards found matching the criteria.", file=sys.stderr)
+        return
+
+    target_card = _resolve_reference_card(args, cards)
+    if not target_card:
+        if not args.quiet:
+            if not getattr(args, 'query', None):
+                print("Error: No reference card name provided.", file=sys.stderr)
+            else:
+                print(f"Error: Could not find reference card '{args.query}'", file=sys.stderr)
+        return
+
+    inferior_cards = [c for c in cards if is_superior_card(target_card, c)]
+
+    if not inferior_cards:
+        if not args.quiet:
+            print(f"No cards found that are inferior to {target_card.display_name}.", file=sys.stderr)
+        return
+
+    # Use search display for results
+    _execute_search(inferior_cards, args)
 
 def handle_random(args):
     # Smart Positional Argument Handling
@@ -1724,6 +1788,38 @@ Usage Examples:
     p_superior.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_superior.set_defaults(func=handle_superior)
+
+    # Inferior Subparser
+    p_inferior = subparsers.add_parser(
+        'inferior',
+        help='Find cards that are strictly worse or generally inferior to a reference card.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Finds "strictly worse" cards by comparing mana cost, stats, and abilities.
+A card is considered inferior if it has harder or identical mana cost,
+equal or worse stats (P/T or Loyalty), and its abilities are a subset
+of the reference card.
+
+Usage Examples:
+  # Find cards worse than Grizzly Bears
+  python3 scripts/mtg_query.py inferior "Grizzly Bears"
+
+  # Find worse cards that are also Goblins
+  python3 scripts/mtg_query.py inferior "Grizzly Bears" --grep "Goblin"
+"""
+    )
+    p_inferior.add_argument('query', help='The card name to use as a reference for comparison.')
+    p_inferior.add_argument('infile', nargs='?', default='-',
+                           help='Input card data file. Defaults to data/AllPrintings.json.')
+    cli_utils.add_standard_filters(p_inferior)
+    cli_utils.add_standard_output_args(p_inferior)
+    p_inferior.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
+                           help='Fields to display in the output table.')
+    p_inferior.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
+                           help='Sort the resulting inferior cards.')
+    p_inferior.add_argument('--delimiter', default=' | ',
+                        help='Separator used between fields in plain text output.')
+    p_inferior.set_defaults(func=handle_inferior)
 
     # Shell Subparser
     p_shell = subparsers.add_parser(

--- a/tests/test_mtg_inferior.py
+++ b/tests/test_mtg_inferior.py
@@ -1,0 +1,201 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import json
+import io
+
+# Add scripts and lib to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../scripts')))
+
+import mtg_query
+import cardlib
+import utils
+
+class TestMtgInferior(unittest.TestCase):
+    def setUp(self):
+        # Create a small test dataset
+        self.test_data = {
+            "data": {
+                "TEST": {
+                    "name": "Test Set",
+                    "code": "TEST",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Grizzly Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Kalonian Tusker",
+                            "manaCost": "{G}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Boar"],
+                            "power": "3",
+                            "toughness": "3",
+                            "rarity": "uncommon"
+                        },
+                        {
+                            "name": "Better Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "3",
+                            "toughness": "2",
+                            "rarity": "uncommon"
+                        },
+                        {
+                            "name": "Cheaper Bears",
+                            "manaCost": "{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "rare"
+                        },
+                        {
+                            "name": "Flying Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "subtypes": ["Bear"],
+                            "power": "2",
+                            "toughness": "2",
+                            "text": "Flying",
+                            "rarity": "rare"
+                        },
+                        {
+                            "name": "Hill Giant",
+                            "manaCost": "{3}{R}",
+                            "types": ["Creature"],
+                            "subtypes": ["Giant"],
+                            "power": "3",
+                            "toughness": "3",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Gray Ogre",
+                            "manaCost": "{2}{R}",
+                            "types": ["Creature"],
+                            "subtypes": ["Ogre"],
+                            "power": "2",
+                            "toughness": "2",
+                            "rarity": "common"
+                        },
+                        {
+                            "name": "Invasion of Alara",
+                            "manaCost": "{W}{U}{B}{R}{G}",
+                            "types": ["Battle"],
+                            "subtypes": ["Siege"],
+                            "loyalty": "7",
+                            "rarity": "rare"
+                        },
+                        {
+                            "name": "Better Battle",
+                            "manaCost": "{W}{U}{B}{R}{G}",
+                            "types": ["Battle"],
+                            "subtypes": ["Siege"],
+                            "loyalty": "5",
+                            "rarity": "rare"
+                        }
+                    ]
+                }
+            }
+        }
+        self.test_file = "test_inferior.json"
+        with open(self.test_file, 'w') as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self):
+        if os.path.exists(self.test_file):
+            os.remove(self.test_file)
+
+    def test_inferior_basic(self):
+        # Grizzly Bears should be inferior to Better Bears, Cheaper Bears, and Flying Bears
+        # We test by asking for cards inferior to Better Bears
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'inferior', 'Better Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Grizzly Bears", output)
+            self.assertNotIn("Better Bears", output)
+            self.assertNotIn("Cheaper Bears", output)
+
+    def test_inferior_pips(self):
+        # Grizzly Bears ({1}{G}) should be inferior to Cheaper Bears ({G})
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'inferior', 'Cheaper Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Grizzly Bears", output)
+
+    def test_inferior_mechanics(self):
+        # Grizzly Bears (no abilities) should be inferior to Flying Bears (with Flying)
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'inferior', 'Flying Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Grizzly Bears", output)
+
+    def test_inferior_no_results(self):
+        # Grizzly Bears has no inferior cards in this set
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            test_args = ['mtg_query.py', 'inferior', 'Grizzly Bears', self.test_file]
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_err.getvalue()
+            self.assertIn("No cards found that are inferior to Grizzly Bears.", output)
+
+    def test_inferior_not_found(self):
+        # Reference card does not exist
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            test_args = ['mtg_query.py', 'inferior', 'Nonexistent Card', self.test_file]
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_err.getvalue()
+            self.assertIn("Error: Could not find reference card 'Nonexistent Card'", output)
+
+    def test_inferior_battles(self):
+        # For battles, lower defense is better.
+        # So Invasion of Alara (Defense 7) should be inferior to Better Battle (Defense 5).
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'inferior', 'Better Battle', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Invasion of Alara", output)
+
+    def test_superior_integration(self):
+        # Verify that superior still works after refactoring
+        with patch('sys.stdout', new=io.StringIO()) as fake_out, \
+             patch('sys.stderr', new=io.StringIO()):
+            test_args = ['mtg_query.py', 'superior', 'Grizzly Bears', self.test_file, '--fields', 'name']
+            with patch('sys.argv', test_args):
+                mtg_query.main()
+
+            output = fake_out.getvalue()
+            self.assertIn("Better Bears", output)
+            self.assertIn("Cheaper Bears", output)
+            self.assertIn("Flying Bears", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a new `inferior` subcommand and `/inferior` shell command to `scripts/mtg_query.py`. This feature identifies cards that are strictly worse than a reference card by comparing mana cost, power/toughness, loyalty, and mechanical abilities.

Key improvements:
- Symmetry with the existing `superior` command.
- Robust comparison logic that handles hybrid/phyrexian mana and multi-face cards.
- Specialized logic for Battle cards (lower defense is considered superior for the caster).
- Enhanced interactive shell with tab-completion for the new commands.
- High-coverage test suite verifying various edge cases.

---
*PR created automatically by Jules for task [11606397664163581009](https://jules.google.com/task/11606397664163581009) started by @RainRat*