### PR TITLE
[TEST] Increase coverage for card validity logic in cardlib.py

### DIFF
--- a/tests/test_card_validity_gaps.py
+++ b/tests/test_card_validity_gaps.py
@@ -1,0 +1,34 @@
+import pytest
+from lib.cardlib import Card
+
+def test_missing_types():
+    card = Card({"name": "No Type Card"})
+    assert card.valid is False
+
+def test_battle_validity():
+    card_no_loyalty = Card({"name": "Battle Card", "types": ["Battle"], "rarity": "rare"})
+    assert card_no_loyalty.valid is False
+
+    card_with_loyalty = Card({"name": "Battle Card", "types": ["Battle"], "loyalty": "5", "rarity": "rare"})
+    assert card_with_loyalty.valid is True
+
+def test_vehicle_is_creature():
+    card_no_pt = Card({"name": "Skysovereign", "types": ["Artifact"], "subtypes": ["Vehicle"], "rarity": "rare"})
+    assert card_no_pt.valid is False
+
+    card_with_pt = Card({"name": "Skysovereign", "types": ["Artifact"], "subtypes": ["Vehicle"], "pt": "6/5", "rarity": "rare"})
+    assert card_with_pt.valid is True
+
+def test_station_pt_exception():
+    card_pt_no_station = Card({"name": "Regular Artifact", "types": ["Artifact"], "pt": "1/1", "rarity": "common"})
+    assert card_pt_no_station.valid is False
+
+    card_pt_station = Card({"name": "Salvaging", "types": ["Artifact"], "text": "This station is cool", "pt": "1/1", "rarity": "rare"})
+    assert card_pt_station.valid is True
+
+    card_no_pt_station = Card({"name": "Salvaging", "types": ["Artifact"], "text": "This station is cool", "rarity": "rare"})
+    assert card_no_pt_station.valid is True
+
+def test_non_creature_with_pt():
+    card = Card({"name": "Enchantment with PT", "types": ["Enchantment"], "pt": "1/1", "rarity": "rare"})
+    assert card.valid is False


### PR DESCRIPTION
I have improved the test coverage of the `lib/cardlib.py` module by identifying and filling gaps in the `fields_check_valid` function. This function is responsible for ensuring that card objects meet the minimum requirements for their types (e.g., creatures having P/T, planeswalkers having loyalty).

Specifically, I added tests for:
- **Missing Types:** Ensuring cards without a type line are flagged as invalid.
- **Battle Cards:** Verifying that the `Battle` type is correctly identified and requires a `loyalty` (defense) value.
- **Vehicles:** Ensuring that `Vehicle` subtypes are treated as creatures for validation purposes, requiring P/T.
- **Station Artifacts:** Testing the specific exception that allows artifacts with the word "station" in their rules text to have P/T even if they aren't creatures.
- **General P/T Validation:** Confirming that other non-creature types (like Enchantments) cannot have P/T.

All 1160 tests in the suite, including these 5 new test cases, are passing.

---
*PR created automatically by Jules for task [3078851043302668534](https://jules.google.com/task/3078851043302668534) started by @RainRat*