### PR TITLE
[DOCS] Simplify CLI terminology and clarify external references

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Customization options for formatting data:
 ### `decode.py` (Viewing Results)
 Options for formatting the output. While primarily used for AI output, this tool also supports other card data formats (**JSON, XML, CSV, etc.**) for easy conversion.
 
-*   `-g`, `--gatherer`: Formats text like the official Gatherer website (Default). This applies modern wording and capitalization.
+*   `-g`, `--gatherer`: Formats text like the official card database (Default). This applies modern wording and capitalization.
 *   `--raw`: Shows raw text without special formatting.
 *   `-t`, `--table`: Creates a formatted table for terminal view.
 *   `-H`, `--html`: Creates a webpage with card images.
@@ -522,7 +522,7 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
-*   `superior`: Find cards that are strictly better or generally superior to a reference card.
+*   `superior`: Find cards that are generally better or superior to a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -607,7 +607,7 @@ python3 scripts/mtg_query.py functional --dedupe unique_cards.json
 ---
 
 #### **Subcommand: `compare`**
-Side-by-side card comparison for identifying design differences. Supports N-way comparison (any number of cards), fuzzy matching, and automatic similarity finding.
+Side-by-side card comparison for identifying design differences. Supports comparing any number of cards, fuzzy matching, and automatic similarity finding.
 
 ```bash
 # Compare two cards by name
@@ -616,7 +616,7 @@ python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre"
 # Compare one card against its most mechanically similar match
 python3 scripts/mtg_query.py compare "Grizzly Bears"
 
-# Compare multiple cards (N-way)
+# Compare multiple cards
 python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre" "Balduvian Bears"
 
 # Compare a pool of cards matching filters
@@ -629,7 +629,7 @@ python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
 ---
 
 #### **Subcommand: `superior`**
-Identifies "strictly better" or generally superior cards by comparing mana cost, stats, and abilities. A card is superior if it has easier or identical mana cost, better or equal stats, and its abilities are a superset of the reference card.
+Identifies generally better or superior cards by comparing mana cost, stats, and abilities. A card is superior if it has easier or identical mana cost, better or equal stats, and its abilities are a superset of the reference card.
 
 ```bash
 # Find cards better than Grizzly Bears

--- a/decode.py
+++ b/decode.py
@@ -806,7 +806,7 @@ Usage Examples:
     # We provide a --raw flag to disable it.
     # We also keep -g for backward compatibility but make it a no-op that ensures True.
     content_group.add_argument('-g', '--gatherer', action='store_true', default=True,
-                        help='Format text like the official Gatherer website (Default). This applies modern wording and capitalization.')
+                        help='Format text like the official card database (Default). This applies modern wording and capitalization.')
     content_group.add_argument('--raw', '--no-gatherer', dest='gatherer', action='store_false',
                         help='Output raw text exactly as it appears in the encoded data.')
 

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1185,18 +1185,18 @@ def handle_superior(args):
         if not target.actions.issubset(candidate.actions):
             return False
 
-        # 5. Strictly better check: must be better in at least one metric
-        is_strictly_better = False
+        # 5. Superiority check: must be better in at least one metric
+        is_superior_match = False
         if (c_cmc < t_cmc) or (len(c_reqs) < len(t_reqs)) or strict_mana:
-            is_strictly_better = True
+            is_superior_match = True
         if target.is_creature and candidate.is_creature:
-            if c_p > t_p or c_t > t_t: is_strictly_better = True
+            if c_p > t_p or c_t > t_t: is_superior_match = True
         if (target.is_planeswalker or target.is_battle) and (candidate.is_planeswalker or candidate.is_battle):
-            if c_l > t_l: is_strictly_better = True
-        if len(candidate.mechanics) > len(target.mechanics): is_strictly_better = True
-        if len(candidate.actions) > len(target.actions): is_strictly_better = True
+            if c_l > t_l: is_superior_match = True
+        if len(candidate.mechanics) > len(target.mechanics): is_superior_match = True
+        if len(candidate.actions) > len(target.actions): is_superior_match = True
 
-        return is_strictly_better
+        return is_superior_match
 
     superior_cards = [c for c in cards if is_superior(c, target_card)]
 
@@ -1531,7 +1531,7 @@ Usage Examples:
     p_oracle.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score', 'rating', 'power_rating'],
                         help="Sort cards by a specific field. Use 'complexity' for design complexity score.")
     p_oracle.add_argument('-s', '--similar', action='store_true', help='Show mechanically similar cards instead of direct matches.')
-    p_oracle.add_argument('-G', '--gatherer', action='store_true', help='Use official card formatting (emulating the Gatherer website).')
+    p_oracle.add_argument('-G', '--gatherer', action='store_true', help='Use official card formatting (emulating the official card database).')
     p_oracle.add_argument('--full', action='store_true', help='Force full details even for multiple matches.')
     p_oracle.add_argument('--no-rulings', action='store_true', help='Suppress display of card rulings.')
     p_oracle.set_defaults(func=handle_oracle)
@@ -1568,7 +1568,7 @@ Usage Examples:
     p_random.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_random.add_argument('-G', '--gatherer', action='store_true',
-                        help='Use official card formatting (emulating the Gatherer website).')
+                        help='Use official card formatting (emulating the official card database).')
     p_random.add_argument('--full', action='store_true', help='Force full details even for multiple matches.')
     p_random.add_argument('--no-rulings', action='store_true', help='Suppress display of card rulings.')
     p_random.set_defaults(func=handle_random)
@@ -1673,7 +1673,7 @@ Usage Examples:
   # Compare one card against its most mechanically similar match
   python3 scripts/mtg_query.py compare "Grizzly Bears"
 
-  # N-way comparison
+  # Comparing any number of cards
   python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre" "Balduvian Bears"
 
   # Pool comparison (compare cards matching filters)
@@ -1683,7 +1683,7 @@ Usage Examples:
   python3 scripts/mtg_query.py compare "Uthros" "Invasion of Tarkir" testdata/
 """
     )
-    p_compare.add_argument('names', nargs='*', help='Card names to compare. Supports N-way comparison. If one name is provided, it is compared against its closest mechanical match. If no names are provided, the filtered result pool is used.')
+    p_compare.add_argument('names', nargs='*', help='Card names to compare. Supports comparing any number of cards. If one name is provided, it is compared against its closest mechanical match. If no names are provided, the filtered result pool is used.')
     p_compare.add_argument('infile', nargs='?', default='-',
                          help='Input card data. Defaults to data/AllPrintings.json if available.')
     cli_utils.add_standard_filters(p_compare)
@@ -1693,10 +1693,10 @@ Usage Examples:
     # Superior Subparser
     p_superior = subparsers.add_parser(
         'superior',
-        help='Find cards that are strictly better or generally superior to a reference card.',
+        help='Find cards that are generally better or superior to a reference card.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Finds "strictly better" cards by comparing mana cost, stats, and abilities.
+Finds generally better cards by comparing mana cost, stats, and abilities.
 A card is considered superior if it has easier or identical mana cost,
 equal or better stats (P/T or Loyalty), and its abilities are a superset
 of the reference card.

--- a/tests/test_mtg_query_compare_enhanced.py
+++ b/tests/test_mtg_query_compare_enhanced.py
@@ -55,7 +55,7 @@ class TestMtgQueryCompareEnhanced(unittest.TestCase):
         self.assertIn('Uthros Research Craft', output)
 
     def test_compare_json(self):
-        """Test JSON output for N-way comparison."""
+        """Test JSON output for comparing any number of cards."""
         output, _ = self.run_compare(['Beast Summoner', 'Black Lotus', 'Double Front', self.testdata_path, '--json'])
         data = json.loads(output)
         self.assertIn('card1', data)


### PR DESCRIPTION
This change simplifies Magic: The Gathering jargon and technical shorthand in public-facing documentation and CLI help strings.

Key changes:
- Replaced "strictly better" with "generally better or superior" in the `superior` command documentation.
- Replaced "N-way comparison" with "comparing any number of cards" in the `compare` command documentation.
- Clarified "Gatherer" as "the official card database" in the `--gatherer` flag documentation.
- Updated internal variable `is_strictly_better` to `is_superior_match` for consistency.
- Updated test docstrings in `tests/test_mtg_query_compare_enhanced.py` to reflect new terminology.

These updates improve accessibility for non-native English speakers and users unfamiliar with MTG-specific competitive terminology.

---
*PR created automatically by Jules for task [13380962322300920371](https://jules.google.com/task/13380962322300920371) started by @RainRat*