### PR TITLE
Simplify card type and subtype membership checks

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -704,13 +704,11 @@ class Card:
 
     def _has_type(self, type_name):
         """Returns True if the card has the specified type (case-insensitive)."""
-        tn = type_name.lower()
-        return tn in self.types or any(t.lower() == tn for t in self.types)
+        return type_name.lower() in self.types
 
     def _has_subtype(self, subtype_name):
         """Returns True if the card has the specified subtype (case-insensitive)."""
-        sn = subtype_name.lower()
-        return sn in self.subtypes or any(s.lower() == sn for s in self.subtypes)
+        return subtype_name.lower() in self.subtypes
 
     @property
     def is_artifact(self):


### PR DESCRIPTION
Simplified `_has_type` and `_has_subtype` in `lib/cardlib.py` by removing redundant loops and case normalization, as the underlying collections are already normalized to lowercase during initialization.

---
*PR created automatically by Jules for task [10680892160527094353](https://jules.google.com/task/10680892160527094353) started by @RainRat*