### PR TITLE
[TEST] Expand card action and mana production detection

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -30,9 +30,8 @@ RECOGNIZED_MECHANICS = [
 # Functional categories for card effects
 ACTION_CATEGORIES = {
     'Removal': [
-        r'\bdestroy\b', r'\bexile target\b', r'sacrifice (a|target|an)\b',
-        r'deals? \d+ damage to (target|each) (creature|planeswalker|permanent)',
-        r'deals? &[\^]+ damage to (target|each) (creature|planeswalker|permanent)',
+        r'\bdestroy\b', r'\bexile (target|each|all|any)\b', r'sacrifice (a|target|an)\b',
+        r'deals? [\d&^]+ damage to (target|each|any|any target) (creature|planeswalker|permanent|target|any)',
         r'return (target|each) [^:]* to (its|their) owner\'s hand',
         r'gets? \-&[\^]+/\-&[\^]+'
     ],
@@ -44,10 +43,12 @@ ACTION_CATEGORIES = {
         r'target creature gets \+', r'creatures you control get \+'
     ],
     'Card Advantage': [
-        r'\bdraw(s|ing)? (a|&[\^]+) cards?\b', r'\bsearch your library\b', r'\breturn (target|a) card from your graveyard\b'
+        r'\bdraw(s|ing)? (a|&[\^]+) cards?\b', r'\bsearch your library\b', r'\breturn (target|a) card from your graveyard\b',
+        r'\bexile .* you may (play|cast) .*\b'
     ],
     'Disruption': [
-        r'\bdiscard(s|ing)? (a|&[\^]+)?\b', r'\buncast target\b', r'\btap target\b', r'can\'t attack or block'
+        r'\bdiscard(s|ing)? (a|&[\^]+)?\b', r'\buncast target\b', r'\btap (target|all|each)\b',
+        r'can\'t (attack|block)', r'don\'t untap during (its|their) [^.]* untap step'
     ]
 }
 
@@ -88,7 +89,7 @@ ACTION_COLORS = {
     'Buffs': 'WGRBC',
     'Card Advantage': 'UBGRWC',
     'Disruption': 'BURWC',
-    'Mana': 'GRRC' # Acceleration/Fixing (R for rituals)
+    'Mana': 'WGRC' # Acceleration/Fixing (W for treasures/taxing, R for rituals)
 }
 
 # Heuristic weights for calculating power rating
@@ -788,7 +789,7 @@ class Card:
         text = self.get_text(force_unpass=True).lower()
         any_patterns = ["any color", "any chosen color", "one mana of any color", "any combination of colors", "any one color"]
         if any(p in text for p in any_patterns):
-            return {"Any"}
+            produced.add("Any")
 
         for match in re.finditer(r'[Aa]dd\s+([^.]+)', text):
             symbols = re.findall(r'\{([^}]+)\}', match.group(1))
@@ -801,6 +802,9 @@ class Card:
         for color_name, char in color_map.items():
             if re.search(r'[Aa]dd\s+(?:one|two|three|[Xx])\s+' + color_name, text):
                 produced.add(char)
+
+        if "treasure" in text or "gold token" in text:
+            produced.add("Any")
 
         return produced
 

--- a/tests/test_mtg_actions_gaps.py
+++ b/tests/test_mtg_actions_gaps.py
@@ -1,0 +1,84 @@
+import pytest
+from lib.cardlib import Card
+
+def test_exile_all_removal():
+    card = Card({
+        "name": "Final Farewell",
+        "manaCost": "{4}{W}{W}",
+        "types": ["Sorcery"],
+        "text": "Exile all creatures."
+    })
+    assert "Removal" in card.actions
+
+def test_any_target_removal():
+    card = Card({
+        "name": "Lightning Bolt",
+        "manaCost": "{R}",
+        "types": ["Instant"],
+        "text": "@ deals &^^^ damage to any target."
+    })
+    assert "Removal" in card.actions
+
+def test_impulsive_draw_card_advantage():
+    card = Card({
+        "name": "Light Up the Stage",
+        "manaCost": "{2}{R}",
+        "types": ["Sorcery"],
+        "text": "Exile the top two cards of your library. Until the end of your next turn, you may play those cards."
+    })
+    assert "Card Advantage" in card.actions
+
+def test_cant_attack_block_disruption():
+    card_attack = Card({
+        "name": "Pacifism",
+        "manaCost": "{1}{W}",
+        "types": ["Enchantment", "Aura"],
+        "text": "Enchanted creature can't attack."
+    })
+    assert "Disruption" in card_attack.actions
+
+    card_block = Card({
+        "name": "Falter",
+        "manaCost": "{1}{R}",
+        "types": ["Sorcery"],
+        "text": "Creatures without flying can't block this turn."
+    })
+    assert "Disruption" in card_block.actions
+
+def test_freeze_disruption():
+    card = Card({
+        "name": "Sleep",
+        "manaCost": "{2}{U}{U}",
+        "types": ["Sorcery"],
+        "text": "Tap all creatures target player controls. Those creatures don't untap during their controller's next untap step."
+    })
+    assert "Disruption" in card.actions
+
+def test_treasure_mana():
+    card = Card({
+        "name": "Strike It Rich",
+        "manaCost": "{R}",
+        "types": ["Sorcery"],
+        "text": "Create a Treasure token."
+    })
+    assert "Mana" in card.actions
+
+def test_mass_tap_disruption():
+    card2 = Card({
+        "name": "Ensnare",
+        "manaCost": "{2}{U}{U}",
+        "types": ["Sorcery"],
+        "text": "Tap all creatures."
+    })
+    assert "Disruption" in card2.actions
+
+def test_treasure_and_specific_mana():
+    card = Card({
+        "name": "Wealthy Druid",
+        "manaCost": "{1}{G}",
+        "types": ["Creature"],
+        "text": "T: Add {G}. Create a Treasure token."
+    })
+    produced = card.produced_colors
+    assert "G" in produced
+    assert "Any" in produced


### PR DESCRIPTION
This PR improves the accuracy of card analysis by expanding the detection of functional card actions and mana production.

Key changes:
1.  **Action Detection:** Updated regex patterns in `ACTION_CATEGORIES` (`lib/cardlib.py`) to recognize more common Magic: The Gathering phrasing:
    *   **Removal:** Now detects "exile all/each" (board wipes) and damage to "any target".
    *   **Card Advantage:** Now detects impulsive draw patterns ("exile the top card... you may play it").
    *   **Disruption:** Now detects "freeze" effects ("don't untap during... next untap step"), mass tap effects, and individual "can't attack" or "can't block" restrictions.
2.  **Mana Production:** Updated `get_face_produced_colors` in `lib/cardlib.py` to recognize Treasure and Gold tokens as mana sources. The logic was improved to ensure that cards producing both specific colors and universal tokens (like a creature adding {G} and a Treasure) have both correctly identified.
3.  **Color Pie Validation:** Fixed a typo in `ACTION_COLORS` and added White (W) to the valid colors for the 'Mana' action to account for treasures and taxing effects.
4.  **Testing:** Added a new test suite `tests/test_mtg_actions_gaps.py` that verifies all the new detection patterns and ensures that mana production sets are correctly aggregated.

All changes were verified against the existing test suite and new gap tests.

---
*PR created automatically by Jules for task [14623188797809938760](https://jules.google.com/task/14623188797809938760) started by @RainRat*