### PR TITLE
[UI/UX] Standardize card statistic formatting in CLI output

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -952,9 +952,9 @@ class Card:
             typeline = utils.colorize(typeline, utils.Ansi.GREEN)
 
         # Stats (P/T or Loyalty/Defense)
-        stats = self._get_pt_display(ansi_color=ansi_color, include_parens=False)
+        stats = self.get_pt_display(ansi_color=ansi_color, include_parens=False)
         if not stats:
-            stats = self._get_loyalty_display(ansi_color=ansi_color, include_parens=False)
+            stats = self.get_loyalty_display(ansi_color=ansi_color, include_parens=False)
 
         # Text
         text = ""
@@ -1154,7 +1154,7 @@ class Card:
             return utils.json_rarity_unmap[self.rarity]
         return self.rarity
 
-    def _get_pt_display(self, ansi_color=False, include_parens=True, unary=False):
+    def get_pt_display(self, ansi_color=False, include_parens=True, unary=False):
         """Helper to format Power/Toughness for display."""
         if not self.pt:
             return ""
@@ -1164,7 +1164,7 @@ class Card:
             res = utils.colorize(res, utils.Ansi.RED)
         return res
 
-    def _get_loyalty_display(self, ansi_color=False, double_paren=False, include_parens=True, unary=False):
+    def get_loyalty_display(self, ansi_color=False, double_paren=False, include_parens=True, unary=False):
         """Helper to format Loyalty or Defense for display."""
         if not self.loyalty:
             return ""
@@ -1581,9 +1581,9 @@ class Card:
             typeline = utils.colorize(typeline, utils.Ansi.GREEN)
 
         # P/T or Loyalty
-        stats = self._get_pt_display(ansi_color=ansi_color)
+        stats = self.get_pt_display(ansi_color=ansi_color)
         if not stats:
-            stats = self._get_loyalty_display(ansi_color=ansi_color)
+            stats = self.get_loyalty_display(ansi_color=ansi_color)
 
         # Construct final header string with consistent bullet separators
         res = f'{status}{rarity_indicator}{cardname}{coststr} \u2022 {typeline}'
@@ -1740,11 +1740,11 @@ class Card:
             outstr += ' (' + rarity_display.lower() + ')'
 
         if gatherer:
-            stats = self._get_pt_display(ansi_color=ansi_color)
+            stats = self.get_pt_display(ansi_color=ansi_color)
             if stats:
                 outstr += ' ' + stats
 
-            stats = self._get_loyalty_display(ansi_color=ansi_color, double_paren=True)
+            stats = self.get_loyalty_display(ansi_color=ansi_color, double_paren=True)
             if stats:
                 outstr += ' ' + stats
 
@@ -1756,11 +1756,11 @@ class Card:
             outstr += linebreak + formatted_mtext
 
         if not gatherer:
-            stats = self._get_pt_display(ansi_color=ansi_color)
+            stats = self.get_pt_display(ansi_color=ansi_color)
             if stats:
                 outstr += linebreak + stats
 
-            stats = self._get_loyalty_display(ansi_color=ansi_color, double_paren=True)
+            stats = self.get_loyalty_display(ansi_color=ansi_color, double_paren=True)
             if stats:
                 outstr += linebreak + stats
 
@@ -1812,9 +1812,9 @@ class Card:
     def _get_face_csv_data(self):
         """Returns the 7 canonical CSV fields for this card face."""
         # P/T or Loyalty/Defense
-        pt_val = self._get_pt_display(include_parens=False)
+        pt_val = self.get_pt_display(include_parens=False)
         if not pt_val:
-            pt_val = self._get_loyalty_display(include_parens=False)
+            pt_val = self.get_loyalty_display(include_parens=False)
 
         # Rarity shorthand
         rarity_short = RARITY_MAP.get(self.rarity, self.rarity)
@@ -1868,7 +1868,7 @@ class Card:
             d['subtypes'] = self.display_subtypes
 
         # Power / Toughness
-        pt_str = self._get_pt_display(include_parens=False)
+        pt_str = self.get_pt_display(include_parens=False)
         if pt_str:
             if '/' in pt_str:
                 p, t = pt_str.split('/', 1)
@@ -1878,7 +1878,7 @@ class Card:
                 d['pt'] = pt_str
 
         # Loyalty / Defense
-        loyalty_val = self._get_loyalty_display(include_parens=False)
+        loyalty_val = self.get_loyalty_display(include_parens=False)
         if loyalty_val:
             if self.is_battle:
                 d['defense'] = loyalty_val
@@ -2103,7 +2103,7 @@ class Card:
             outstr += ' '
 
         if self.loyalty:
-            outstr += self._get_loyalty_display(double_paren=True, unary=True) + ' '
+            outstr += self.get_loyalty_display(double_paren=True, unary=True) + ' '
             
         outstr += self.__dict__[field_text].vectorize()
 

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -981,7 +981,7 @@ def handle_power(args):
                 fair_mv = utils.colorize(fair_mv, utils.Ansi.BOLD + color)
 
             rar = c.rarity_name
-            rows.append([utils.colorize(c.display_name, c._get_ansi_color()) if use_color else c.display_name, rt, c.cost.format(ansi_color=use_color), fair_mv, c._get_pt_display(ansi_color=use_color, include_parens=False), utils.colorize(rar, utils.Ansi.get_rarity_color(rar)) if use_color else rar])
+            rows.append([utils.colorize(c.display_name, c._get_ansi_color()) if use_color else c.display_name, rt, c.cost.format(ansi_color=use_color), fair_mv, c.get_pt_display(ansi_color=use_color, include_parens=False), utils.colorize(rar, utils.Ansi.get_rarity_color(rar)) if use_color else rar])
         datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','l','r','r','l']), indent=4)
 
 def handle_archetypes(args):

--- a/scripts/mtg_diff.py
+++ b/scripts/mtg_diff.py
@@ -41,14 +41,14 @@ def compare_cards(c1, c2):
         diffs.append(('Type', c1.get_type_line(), c2.get_type_line()))
 
     # 3. Stats (P/T)
-    s1 = c1._get_pt_display(include_parens=False)
-    s2 = c2._get_pt_display(include_parens=False)
+    s1 = c1.get_pt_display(include_parens=False)
+    s2 = c2.get_pt_display(include_parens=False)
     if s1 != s2:
         diffs.append(('P/T', s1, s2))
 
     # 4. Loyalty / Defense
-    l1 = c1._get_loyalty_display(include_parens=False)
-    l2 = c2._get_loyalty_display(include_parens=False)
+    l1 = c1.get_loyalty_display(include_parens=False)
+    l2 = c2.get_loyalty_display(include_parens=False)
     if l1 != l2:
         diffs.append(('Loyalty/Defense', l1, l2))
 

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -100,27 +100,21 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if ansi_color:
             res = utils.colorize(res, utils.Ansi.GREEN)
     elif canon == 'pt':
-        res = utils.from_unary(card.pt) if card.pt else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
     elif canon == 'stats':
-        res = utils.from_unary(card.pt) if card.pt else ""
+        res = card.get_pt_display(ansi_color=ansi_color)
         if not res:
-            res = utils.from_unary(card.loyalty) if card.loyalty else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+            res = card.get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'power':
-        res = utils.from_unary(card.pt_p) if card.pt_p else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        if '/' in res:
+            res = res.split('/')[0]
     elif canon == 'toughness':
-        res = utils.from_unary(card.pt_t) if card.pt_t else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        if '/' in res:
+            res = res.split('/')[-1]
     elif canon == 'loyalty':
-        res = utils.from_unary(card.loyalty) if card.loyalty else ""
-        if res and ansi_color:
-            res = utils.colorize(res, utils.Ansi.RED)
+        res = card.get_loyalty_display(ansi_color=ansi_color, include_parens=False)
     elif canon == 'text':
         res = card.get_text(force_unpass=True, ansi_color=ansi_color)
     elif canon == 'rarity':
@@ -558,7 +552,7 @@ def _execute_oracle(cards, args):
                         face_name = utils.colorize(face_name, face._get_ansi_color())
 
                     face_info = face.get_type_line(separator='-')
-                    stats = face._get_pt_display(ansi_color=use_color) or face._get_loyalty_display(ansi_color=use_color)
+                    stats = face.get_pt_display(ansi_color=use_color) or face.get_loyalty_display(ansi_color=use_color)
                     if stats:
                         face_info += f" • {stats}"
                     if use_color:

--- a/tests/test_mtg_query_compare.py
+++ b/tests/test_mtg_query_compare.py
@@ -44,5 +44,5 @@ def test_query_compare_multi_face():
     assert "Double Back" in result.stdout
     # Check that they are identified as different in the table
     # Since Double Front matches the whole card (both faces) and Double Back matches only one face
-    assert "1/1 // 2/2" in result.stdout
-    assert "2/2" in result.stdout
+    assert "(1/1) // (2/2)" in result.stdout
+    assert "(2/2)" in result.stdout

--- a/tests/test_mtg_query_random.py
+++ b/tests/test_mtg_query_random.py
@@ -47,8 +47,8 @@ class TestMtgQueryRandom(unittest.TestCase):
         card.rulings = []
         card.bside = None
         card.get_type_line.return_value = "Creature - Bear"
-        card._get_pt_display.return_value = "2/2"
-        card._get_loyalty_display.return_value = ""
+        card.get_pt_display.return_value = "2/2"
+        card.get_loyalty_display.return_value = ""
         card.get_face_tokens.return_value = []
         card.pt = "&&/&&"
         card.pt_p = "&&"

--- a/tests/test_mtg_search_gaps.py
+++ b/tests/test_mtg_search_gaps.py
@@ -97,7 +97,7 @@ class TestMtgSearchGaps(unittest.TestCase):
         from lib.cardlib import Card
         card = Card({"name": "Test", "loyalty": "5", "types": ["Planeswalker"]})
         self.assertEqual(get_field_value(card, "loyalty"), "5")
-        self.assertEqual(get_field_value(card, "stats"), "5")
+        self.assertEqual(get_field_value(card, "stats"), "(5)")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Context: CLI
* Problem: The `stats` field in `mtg_query.py search` output lacked visual context, displaying bare numbers that were inconsistent with other views (like `summary` or `oracle`) and harder to distinguish across different card types.
* Solution: Refactored the `get_field_value` logic to use standardized display methods from `Card`. Statistics now include appropriate delimiters (e.g., `(2/2)`, `[[5]]`) and integrated ANSI coloring, making table outputs more readable and professional.

---
*PR created automatically by Jules for task [14220251487054257499](https://jules.google.com/task/14220251487054257499) started by @RainRat*