### PR TITLE
[DOCS] Standardize terminology and remove technical jargon

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Customization options for formatting data:
 ### `decode.py` (Viewing Results)
 Options for formatting the output. While primarily used for AI output, this tool also supports other card data formats (**JSON, XML, CSV, etc.**) for easy conversion.
 
-*   `-g`, `--gatherer`: Formats text like the official Gatherer website (Default). This applies modern wording and capitalization.
+*   `-g`, `--gatherer`: Formats text like the official card database (Default). This applies modern wording and capitalization.
 *   `--raw`: Shows raw text without special formatting.
 *   `-t`, `--table`: Creates a formatted table for terminal view.
 *   `-H`, `--html`: Creates a webpage with card images.
@@ -522,7 +522,7 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
-*   `superior`: Find cards that are strictly better or generally superior to a reference card.
+*   `superior`: Find cards that are generally better than a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -607,7 +607,7 @@ python3 scripts/mtg_query.py functional --dedupe unique_cards.json
 ---
 
 #### **Subcommand: `compare`**
-Side-by-side card comparison for identifying design differences. Supports N-way comparison (any number of cards), fuzzy matching, and automatic similarity finding.
+Side-by-side card comparison for identifying design differences. Supports comparing any number of cards, fuzzy matching, and automatic similarity finding.
 
 ```bash
 # Compare two cards by name
@@ -629,7 +629,7 @@ python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
 ---
 
 #### **Subcommand: `superior`**
-Identifies "strictly better" or generally superior cards by comparing mana cost, stats, and abilities. A card is superior if it has easier or identical mana cost, better or equal stats, and its abilities are a superset of the reference card.
+Identifies cards that are generally better than a reference card by comparing mana cost, stats, and abilities. A card is considered superior if it has easier or identical mana cost, better or equal stats, and its abilities include all of the reference card's mechanics and actions.
 
 ```bash
 # Find cards better than Grizzly Bears

--- a/decode.py
+++ b/decode.py
@@ -806,7 +806,7 @@ Usage Examples:
     # We provide a --raw flag to disable it.
     # We also keep -g for backward compatibility but make it a no-op that ensures True.
     content_group.add_argument('-g', '--gatherer', action='store_true', default=True,
-                        help='Format text like the official Gatherer website (Default). This applies modern wording and capitalization.')
+                        help='Format text like the official card database (Default). This applies modern wording and capitalization.')
     content_group.add_argument('--raw', '--no-gatherer', dest='gatherer', action='store_false',
                         help='Output raw text exactly as it appears in the encoded data.')
 

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1495,7 +1495,7 @@ def main():
               # Calculate As-Fan statistics (average cards per pack)
               python3 scripts/mtg_analyze.py asfan generated.txt
 
-              # Analyze mechanical interaction (synergy) in a card pool
+              # Analyze mechanical interactions in a card pool
               python3 scripts/mtg_analyze.py interaction my_cards.json --min-freq 5
 
               # Compare the color lexicon of two datasets

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1179,7 +1179,7 @@ def handle_superior(args):
             if c_l < t_l:
                 return False
 
-        # 4. Mechanics and Actions: candidate must be a superset
+        # 4. Mechanics and Actions: candidate must include all of the reference card's mechanics and actions
         if not target.mechanics.issubset(candidate.mechanics):
             return False
         if not target.actions.issubset(candidate.actions):
@@ -1531,7 +1531,7 @@ Usage Examples:
     p_oracle.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score', 'rating', 'power_rating'],
                         help="Sort cards by a specific field. Use 'complexity' for design complexity score.")
     p_oracle.add_argument('-s', '--similar', action='store_true', help='Show mechanically similar cards instead of direct matches.')
-    p_oracle.add_argument('-G', '--gatherer', action='store_true', help='Use official card formatting (emulating the Gatherer website).')
+    p_oracle.add_argument('-G', '--gatherer', action='store_true', help='Use official card formatting (as seen in the official card database).')
     p_oracle.add_argument('--full', action='store_true', help='Force full details even for multiple matches.')
     p_oracle.add_argument('--no-rulings', action='store_true', help='Suppress display of card rulings.')
     p_oracle.set_defaults(func=handle_oracle)
@@ -1568,7 +1568,7 @@ Usage Examples:
     p_random.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_random.add_argument('-G', '--gatherer', action='store_true',
-                        help='Use official card formatting (emulating the Gatherer website).')
+                        help='Use official card formatting (as seen in the official card database).')
     p_random.add_argument('--full', action='store_true', help='Force full details even for multiple matches.')
     p_random.add_argument('--no-rulings', action='store_true', help='Suppress display of card rulings.')
     p_random.set_defaults(func=handle_random)
@@ -1673,7 +1673,7 @@ Usage Examples:
   # Compare one card against its most mechanically similar match
   python3 scripts/mtg_query.py compare "Grizzly Bears"
 
-  # N-way comparison
+  # Comparing any number of cards
   python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre" "Balduvian Bears"
 
   # Pool comparison (compare cards matching filters)
@@ -1683,7 +1683,7 @@ Usage Examples:
   python3 scripts/mtg_query.py compare "Uthros" "Invasion of Tarkir" testdata/
 """
     )
-    p_compare.add_argument('names', nargs='*', help='Card names to compare. Supports N-way comparison. If one name is provided, it is compared against its closest mechanical match. If no names are provided, the filtered result pool is used.')
+    p_compare.add_argument('names', nargs='*', help='Card names to compare. Supports comparing any number of cards. If one name is provided, it is compared against its closest mechanical match. If no names are provided, the filtered result pool is used.')
     p_compare.add_argument('infile', nargs='?', default='-',
                          help='Input card data. Defaults to data/AllPrintings.json if available.')
     cli_utils.add_standard_filters(p_compare)
@@ -1693,13 +1693,13 @@ Usage Examples:
     # Superior Subparser
     p_superior = subparsers.add_parser(
         'superior',
-        help='Find cards that are strictly better or generally superior to a reference card.',
+        help='Find cards that are generally better than a reference card.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Finds "strictly better" cards by comparing mana cost, stats, and abilities.
+Finds generally better cards by comparing mana cost, stats, and abilities.
 A card is considered superior if it has easier or identical mana cost,
-equal or better stats (P/T or Loyalty), and its abilities are a superset
-of the reference card.
+equal or better stats (P/T or Loyalty), and its abilities include all
+of the reference card's mechanics and actions.
 
 Usage Examples:
   # Find cards better than Grizzly Bears


### PR DESCRIPTION
This change standardizes terminology across the repository's documentation and command-line interface to make it more accessible and easier to use for a global audience. 

Specific improvements include:
*   **Plain English:** Replaced technical MTG jargon like "strictly better" and "superset" with clearer descriptions like "generally better" and "includes all mechanics and actions."
*   **Accessibility:** Replaced "Gatherer" (a specific brand name) with "official card database" to help users who may not be familiar with official terminology.
*   **Simplicity:** Simplified technical terms like "N-way comparison" to "comparing any number of cards."
*   **Consistency:** Ensured that `README.md`, CLI help strings (`--help`), and internal comments use the same standardized terminology.
*   **Backward Compatibility:** Maintained the functional `synergy` alias in `mtg_analyze.py` while updating the visible documentation to use "interaction."

All changes have been verified through CLI help inspection and the full project test suite (1155 tests passed).

---
*PR created automatically by Jules for task [13904415088425845320](https://jules.google.com/task/13904415088425845320) started by @RainRat*