### PR TITLE
[DOCS] Simplify documentation and CLI help by removing technical jargon

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre"
 # Compare one card against its most mechanically similar match
 python3 scripts/mtg_query.py compare "Grizzly Bears"
 
-# Compare multiple cards (N-way)
+# Compare any number of cards
 python3 scripts/mtg_query.py compare "Grizzly Bears" "Gray Ogre" "Balduvian Bears"
 
 # Compare a pool of cards matching filters
@@ -659,7 +659,7 @@ python3 scripts/mtg_query.py superior "Grizzly Bears" --set MOM
 ---
 
 #### **Subcommand: `inferior`**
-Identifies "strictly worse" or generally inferior cards by comparing mana cost, stats, and abilities. A card is inferior if the reference card has easier or identical mana cost, equal or better stats, and its abilities are a superset of the candidate card's abilities.
+Identifies generally inferior cards by comparing mana cost, stats, and abilities. A card is inferior if the reference card has easier or identical mana cost, equal or better stats, and its abilities include all of the candidate card's mechanics and actions.
 
 ```bash
 # Find cards worse than Black Vise

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1805,13 +1805,13 @@ Usage Examples:
     # Inferior Subparser
     p_inferior = subparsers.add_parser(
         'inferior',
-        help='Find cards that are strictly worse or generally inferior to a reference card.',
+        help='Find cards that are generally inferior to a reference card.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Finds "strictly worse" cards by comparing mana cost, stats, and abilities.
+Finds generally inferior cards by comparing mana cost, stats, and abilities.
 A card is considered inferior if the reference card has easier or identical mana cost,
-equal or better stats (P/T or Loyalty), and its abilities are a superset
-of the candidate card's abilities.
+equal or better stats (P/T or Loyalty), and its abilities include all
+of the candidate card's mechanics and actions.
 
 Usage Examples:
   # Find cards worse than Black Vise


### PR DESCRIPTION
This PR improves the codebase's accessibility by replacing technical and MTG-specific jargon with plain English in the documentation and CLI help strings. Specifically, it simplifies the description of the `inferior` subcommand (removing "strictly worse" and "superset") and clarifies multi-card comparison terminology. All changes were verified through CLI output inspection and automated tests.

---
*PR created automatically by Jules for task [6349652422742250316](https://jules.google.com/task/6349652422742250316) started by @RainRat*