### PR TITLE
Fix ANSI corruption in power/toughness extraction in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -107,13 +107,17 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if not res:
             res = card.get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'power':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[0]
+        if ansi_color:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'toughness':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[-1]
+        if ansi_color:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'loyalty':
         res = card.get_loyalty_display(ansi_color=ansi_color, include_parens=False)
     elif canon == 'text':


### PR DESCRIPTION
Updated `get_field_value` in `scripts/mtg_query.py` to extract `power` and `toughness` values from an uncolored P/T string before applying ANSI colorization. Previously, splitting a colored string like `\x1b[91m2/2\x1b[0m` by `/` would leave the first part without a reset code and the second part without a start code. The fix ensures individual components are correctly colorized.

---
*PR created automatically by Jules for task [498164033418302061](https://jules.google.com/task/498164033418302061) started by @RainRat*