### PR TITLE
[DOCS] Document missing interactive shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,11 @@ python3 scripts/mtg_query.py shell my_cards.json --fields "name,cost,type,pt,rar
 *   **In-Shell Commands:**
     *   `<card name>`: Type any card name to see its official rules text.
     *   `/search <query>`: Perform a bulk search and display results in a table.
+    *   `/compare <n1> <n2>...`: Compare multiple cards side-by-side.
+    *   `/superior <name>`: Find cards that are generally better than the reference card.
+    *   `/inferior <name>`: Find cards that are generally worse than the reference card.
+    *   `/random [n]`: Show one or more random cards from the dataset.
+    *   `/clear`: Clear the terminal screen.
     *   `/help`: Show available commands.
     *   `exit` or `quit`: Leave the shell.
 


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the `README.md` file to include all available slash-commands for the interactive shell.
* **Why:** The previous documentation only listed three commands (`<card name>`, `/search`, `/help`). I added the five missing commands (`/compare`, `/superior`, `/inferior`, `/random`, and `/clear`) to ensure the documentation matches the actual script behavior and helps users discover the full utility of the interactive mode.

---
*PR created automatically by Jules for task [12262492302871059394](https://jules.google.com/task/12262492302871059394) started by @RainRat*