### PR TITLE
[FEAT] Calculated design metric filtering (Complexity, Rating, Fair MV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,9 @@ Filter cards using search patterns, set codes, rarities, or decklist files. Thes
         *   `--pow VALUE`: Filter by Power.
         *   `--tou VALUE`: Filter by Toughness.
         *   `--loy VALUE`: Filter by Loyalty or Defense.
+        *   `--complexity VALUE`: Filter by design complexity score.
+        *   `--rating VALUE`: Filter by power rating (efficiency relative to cost).
+        *   `--fair-mv VALUE`: Filter by recommended Fair Mana Value.
     *   `--mechanic NAME`: Include cards with specific keyword abilities or features (e.g., `Flying`, `Activated`, `ETB Effect`).
     *   `--action NAME`: Include cards with specific functional actions (e.g., `Removal`, `Protection`, `Buffs`, `Card Advantage`, `Disruption`, or `Mana`).
     *   `--deck-filter FILE`: Filter cards using a standard MTG decklist file. This also multiplies cards in the output based on their counts in the decklist.

--- a/lib/cli_utils.py
+++ b/lib/cli_utils.py
@@ -69,6 +69,12 @@ def add_standard_filters(parser):
     filter_group.add_argument('--loy', '--loyalty', '--defense', action='append', dest='loy',
                         help='Only include cards with specific Loyalty or Defense values. Supports exact values, '
                              'inequalities, ranges, and multiple values (OR logic).')
+    filter_group.add_argument('--complexity', '--score', action='append',
+                        help='Only include cards with specific design complexity scores. Supports inequalities and ranges.')
+    filter_group.add_argument('--rating', '--power-rating', action='append', dest='rating',
+                        help='Only include cards with specific power ratings (efficiency vs CMC). Supports inequalities and ranges.')
+    filter_group.add_argument('--fair-mv', '--fcmc', '--recommended-cmc', action='append', dest='fair_mv',
+                        help='Only include cards with specific recommended Fair Mana Values. Supports inequalities and ranges.')
     filter_group.add_argument('--mechanic', action='append',
                         help='Only include cards with specific mechanical features or keyword abilities (e.g., Flying, Activated, ETB Effect). '
                              'Supports multiple values (OR logic).')
@@ -195,6 +201,9 @@ def load_and_filter_cards(args):
                                   color_pie_break=getattr(args, 'color_pie_break', False),
                                   identities=getattr(args, 'identity', None), 
                                   id_counts=getattr(args, 'id_count', None),
+                                  complexities=getattr(args, 'complexity', None),
+                                  ratings=getattr(args, 'rating', None),
+                                  fair_mvs=getattr(args, 'fair_mv', None),
                                   decklist_file=getattr(args, 'deck', None),
                                   booster=getattr(args, 'booster', 0), 
                                   box=getattr(args, 'box', 0),

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -851,7 +851,8 @@ def mtg_open_file(fname, verbose = False,
                   identities=None, id_counts=None,
                   shuffle=False, seed=None,
                   decklist_file=None,
-                  stats=None, booster=0, box=0):
+                  stats=None, booster=0, box=0,
+                  complexities=None, ratings=None, fair_mvs=None):
     """
     High-level entry point for loading card data from various formats.
     Supported formats: JSON, JSONL, CSV, Magic Set Editor (.mse-set),
@@ -1169,7 +1170,7 @@ def mtg_open_file(fname, verbose = False,
                  print((str(valid) + ' valid, ' + str(skipped) + ' skipped, '
                         + str(invalid) + ' invalid, ' + str(unparsed) + ' failed to parse.'), file=sys.stderr)
 
-    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics or actions or produces or color_pie_break or identities or id_counts:
+    if grep or vgrep or sets or rarities or grep_name or vgrep_name or grep_types or vgrep_types or grep_text or vgrep_text or grep_cost or vgrep_cost or grep_pt or vgrep_pt or grep_loyalty or vgrep_loyalty or colors or cmcs or pows or tous or loys or mechanics or actions or produces or color_pie_break or identities or id_counts or complexities or ratings or fair_mvs:
         # Sanitize queries to match internal representations (hyphens are dash_marker)
         greps = _compile_patterns(grep, sanitize=True)
         vgreps = _compile_patterns(vgrep, sanitize=True)
@@ -1209,6 +1210,9 @@ def mtg_open_file(fname, verbose = False,
         pow_filters = [utils.NumericFilter(f) for f in pows] if pows else []
         tou_filters = [utils.NumericFilter(f) for f in tous] if tous else []
         loy_filters = [utils.NumericFilter(f) for f in loys] if loys else []
+        comp_filters = [utils.NumericFilter(f) for f in complexities] if complexities else []
+        rate_filters = [utils.NumericFilter(f) for f in ratings] if ratings else []
+        fmv_filters = [utils.NumericFilter(f) for f in fair_mvs] if fair_mvs else []
 
         def match_card(card):
             # Generic filtering (AND logic for greps, OR logic for vgreps)
@@ -1394,6 +1398,36 @@ def mtg_open_file(fname, verbose = False,
                         match_id_count = True
                         break
                 if not match_id_count:
+                    return False
+
+            # Complexity filtering
+            if comp_filters:
+                match_comp = False
+                for f in comp_filters:
+                    if f.evaluate(card.complexity_score):
+                        match_comp = True
+                        break
+                if not match_comp:
+                    return False
+
+            # Rating filtering
+            if rate_filters:
+                match_rate = False
+                for f in rate_filters:
+                    if f.evaluate(card.power_rating):
+                        match_rate = True
+                        break
+                if not match_rate:
+                    return False
+
+            # Fair MV filtering
+            if fmv_filters:
+                match_fmv = False
+                for f in fmv_filters:
+                    if f.evaluate(card.recommended_cmc):
+                        match_fmv = True
+                        break
+                if not match_fmv:
                     return False
 
             return True

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -132,7 +132,8 @@ def test_load_and_filter_cards_all_args(mock_exists, mock_open):
         mechanics=['M'], actions=['A'], produces=None, color_pie_break=False,
         identities=['I'], id_counts=['1'],
         decklist_file='deck.txt', booster=1, box=1,
-        shuffle=True, seed=42
+        shuffle=True, seed=42,
+        complexities=None, ratings=None, fair_mvs=None
     )
 
 @patch('lib.cli_utils.jdecode.mtg_open_file')

--- a/tests/test_mtg_mana_gaps.py
+++ b/tests/test_mtg_mana_gaps.py
@@ -121,8 +121,10 @@ class TestMtgManaGaps(unittest.TestCase):
                                     actions=None,
                                     produces=None,
                                     color_pie_break=False,
-                                    identities=None, id_counts=None, decklist_file=None, booster=0, box=0,
-                                    shuffle=False, seed=None)
+                                    identities=None, id_counts=None,
+                                    decklist_file=None, booster=0, box=0,
+                                    shuffle=False, seed=None,
+                                    complexities=None, ratings=None, fair_mvs=None)
 
     @patch('mtg_analyze.jdecode.mtg_open_file')
     @patch('sys.stdout', new_callable=io.StringIO)


### PR DESCRIPTION
This pull request implements **Calculated Metric Filtering**, allowing users to filter card datasets based on heuristic design metrics.

### Technical Description
- Added three new numerical filtering flags:
  - `--complexity` (alias `--score`): Filters by heuristic design complexity.
  - `--rating` (alias `--power-rating`): Filters by combat efficiency relative to cost.
  - `--fair-mv` (aliases `--fcmc`, `--recommended-cmc`): Filters by the recommended "Fair Mana Value".
- Integrated these filters into the core `mtg_open_file` loader in `lib/jdecode.py` using the existing `NumericFilter` infrastructure (supporting exact values, inequalities, and ranges).
- Updated `lib/cli_utils.py` to expose these filters to all CLI tools in the repository.
- Refactored the `mtg_open_file` signature by appending new parameters at the end, ensuring backward compatibility for library consumers using positional arguments.
- Updated unit test mocks in `tests/test_cli_utils.py` and `tests/test_mtg_mana_gaps.py`.
- Updated `README.md` documentation.

### Logical Deduction
The toolkit already calculates and displays these valuable design metrics (Complexity, Rating, etc.) and allows sorting by them. However, it lacked the ability to *filter* by them. By adding this "missing piece," designers and AI designers can now easily slice datasets to find outliers (e.g., `--complexity ">100"`) or identify pushed/pushed cards (e.g., `--rating ">1.2"`). This completes the symmetry between calculation, display, and search functionality.

---
*PR created automatically by Jules for task [5175784112871299862](https://jules.google.com/task/5175784112871299862) started by @RainRat*