### PR TITLE
Deduplicate card resolution logic in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1195,7 +1195,8 @@ def is_superior(candidate, target):
 
     return is_strictly_better
 
-def handle_superior(args):
+def _resolve_target_from_args(args):
+    """Shared logic for resolving a reference card from CLI arguments."""
     # Smart positional argument handling
     if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
         temp = args.query
@@ -1206,13 +1207,13 @@ def handle_superior(args):
     if not cards:
         if not args.quiet:
             print("No cards found in the dataset.", file=sys.stderr)
-        return
+        return None, None
 
     query = args.query
     if not query:
         if not args.quiet:
             print("Error: No reference card name provided.", file=sys.stderr)
-        return
+        return None, None
 
     query_sanitized = query.lower().replace('-', utils.dash_marker)
     target_card = next((c for c in cards if c.name.lower() == query_sanitized), None)
@@ -1232,8 +1233,14 @@ def handle_superior(args):
     if not target_card:
         if not args.quiet:
             print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
-        return
+        return None, None
 
+    return target_card, cards
+
+def handle_superior(args):
+    target_card, cards = _resolve_target_from_args(args)
+    if not target_card:
+        return
 
     superior_cards = [c for c in cards if is_superior(c, target_card)]
 
@@ -1246,42 +1253,8 @@ def handle_superior(args):
     _execute_search(superior_cards, args)
 
 def handle_inferior(args):
-    # Smart positional argument handling
-    if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
-        temp = args.query
-        args.query = args.infile if args.infile != '-' else None
-        args.infile = temp
-
-    cards = cli_utils.load_and_filter_cards(args)
-    if not cards:
-        if not args.quiet:
-            print("No cards found in the dataset.", file=sys.stderr)
-        return
-
-    query = args.query
-    if not query:
-        if not args.quiet:
-            print("Error: No reference card name provided.", file=sys.stderr)
-        return
-
-    query_sanitized = query.lower().replace('-', utils.dash_marker)
-    target_card = next((c for c in cards if c.name.lower() == query_sanitized), None)
+    target_card, cards = _resolve_target_from_args(args)
     if not target_card:
-        # Try finding in the full dataset if not in the filtered pool
-        all_cards = jdecode.mtg_open_file(args.infile, verbose=False)
-        target_card = next((c for c in all_cards if c.name.lower() == query_sanitized), None)
-        if not target_card:
-            # Fuzzy match
-            search_names = {c.name.lower(): c for c in all_cards}
-            close = difflib.get_close_matches(query.lower(), list(search_names.keys()), n=1, cutoff=0.6)
-            if close:
-                target_card = search_names[close[0]]
-                if not args.quiet:
-                    print(f"Notice: Card '{query}' not found. Using best match: {target_card.display_name}", file=sys.stderr)
-
-    if not target_card:
-        if not args.quiet:
-            print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
         return
 
     # A card is inferior if the target card is superior to it


### PR DESCRIPTION
* **What:** Extracted approximately 30 lines of duplicated code from `handle_superior` and `handle_inferior` in `scripts/mtg_query.py` into a single helper function `_resolve_target_from_args(args)`.
* **Why:** To improve code maintainability and reduce duplication. The refactor ensures that both commands benefit from identical card resolution logic (including fuzzy matching and dataset fallbacks) while simplifying the main subcommand handlers. No external behavior was changed, as verified by existing test suites.

---
*PR created automatically by Jules for task [5984261457004274404](https://jules.google.com/task/5984261457004274404) started by @RainRat*