### PR TITLE
Fix ANSI color corruption in power/toughness extraction

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -107,13 +107,17 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if not res:
             res = card.get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'power':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[0]
+        if ansi_color:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'toughness':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[-1]
+        if ansi_color:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'loyalty':
         res = card.get_loyalty_display(ansi_color=ansi_color, include_parens=False)
     elif canon == 'text':


### PR DESCRIPTION
* **What:** Modified `get_field_value` in `scripts/mtg_query.py` to ensure that ANSI color codes are applied to `power` and `toughness` fields *after* splitting the combined P/T string.
* **Why:** Previously, if `ansi_color` was enabled, `get_pt_display` would return a colorized string like `\x1b[91m2/2\x1b[0m`. Splitting this by `/` to extract power resulted in `\x1b[91m2`, which is a corrupted escape sequence that causes "color bleed" in terminal output. The fix retrieves the uncolored string, performs the split, and then applies the color to the extracted component, ensuring the ANSI sequence is correctly terminated with a reset code. This is a non-breaking change that improves terminal output reliability.

---
*PR created automatically by Jules for task [3863317163170162696](https://jules.google.com/task/3863317163170162696) started by @RainRat*