### PR TITLE
[TEST] Fix choice block parsing and add gap coverage

### DIFF
--- a/lib/transforms.py
+++ b/lib/transforms.py
@@ -630,8 +630,9 @@ def randomize_lines(text):
 # Text unpasses, for decoding. All assume the text inside a Manatext, so don't do anything
 # weird with the mana cost symbol.
 
-choice_unpass_regex = re.compile(re.escape(choice_open_delimiter) + re.escape(unary_marker)
-                                 + r'.*' + re.escape(bullet_marker) + r'.*' + re.escape(choice_close_delimiter))
+choice_unpass_regex = re.compile(re.escape(choice_open_delimiter) + r'[^' + re.escape(choice_close_delimiter) + r']*'
+                                 + re.escape(bullet_marker) + r'[^' + re.escape(choice_close_delimiter) + r']*'
+                                 + re.escape(choice_close_delimiter))
 def text_unpass_1_choice(s, delimit = False):
     choices = re.findall(choice_unpass_regex, s)
     for choice in sorted(choices, key=len, reverse=True):

--- a/tests/test_qa_transforms_choices.py
+++ b/tests/test_qa_transforms_choices.py
@@ -1,0 +1,44 @@
+import re
+from lib import transforms
+from lib import utils
+
+def test_text_unpass_1_choice_normal():
+    # [&^=Option 1] -> choose one ~\= Option 1
+    s = "[&^=Option 1]"
+    expected = "choose one " + utils.dash_marker + utils.newline + utils.bullet_marker + " Option 1"
+    assert transforms.text_unpass_1_choice(s) == expected
+
+def test_text_unpass_1_choice_exception():
+    # [twenty~five=Option A] -> choose twenty~five ~\= Option A
+    # twenty~five is the unary conversion of 25 in config
+    s = "[twenty~five=Option A]"
+    expected = "choose twenty" + utils.dash_marker + "five " + utils.dash_marker + utils.newline + utils.bullet_marker + " Option A"
+    assert transforms.text_unpass_1_choice(s) == expected
+
+def test_text_unpass_1_choice_empty_count():
+    # [=Option B] -> choose one or both ~\= Option B
+    s = "[=Option B]"
+    expected = "choose one or both " + utils.dash_marker + utils.newline + utils.bullet_marker + " Option B"
+    assert transforms.text_unpass_1_choice(s) == expected
+
+def test_text_unpass_1_choice_multiple():
+    # [&^=Opt1] and [&^^=Opt2] -> choose one ~\= Opt1 and choose two ~\= Opt2
+    s = "[&^=Opt1] and [&^^=Opt2]"
+    res = transforms.text_unpass_1_choice(s)
+    assert "choose one" in res
+    assert "choose two" in res
+    assert "and" in res
+    assert res.count(utils.dash_marker) == 2
+
+def test_text_unpass_1_choice_or_more():
+    # [ or more=Opt] -> choose one or more ~\= Opt
+    s = "[ or more=Opt]"
+    expected = "choose one or more " + utils.dash_marker + utils.newline + utils.bullet_marker + " Opt"
+    assert transforms.text_unpass_1_choice(s) == expected
+
+def test_text_unpass_1_choice_multi_options():
+    s = "[&^=Opt 1=Opt 2]"
+    expected = ("choose one " + utils.dash_marker +
+                utils.newline + utils.bullet_marker + " Opt 1" +
+                utils.newline + utils.bullet_marker + " Opt 2")
+    assert transforms.text_unpass_1_choice(s) == expected


### PR DESCRIPTION
**PR Title:** [TEST] Fix choice block parsing and add gap coverage

**Description:**
* **Type:** Bug Fix / New Coverage
* **What:** Updated the `choice_unpass_regex` in `lib/transforms.py` to be non-greedy (using negated character classes) and removed the mandatory `unary_marker` requirement. Added a new test suite `tests/test_qa_transforms_choices.py` to verify these scenarios.
* **Why:** The previous regex was greedy, causing it to incorrectly combine multiple choice blocks on a single line into one match. It also failed to recognize valid choices that used word-based numeric exceptions (e.g., `[twenty~five=...]`) or had empty counts (defaulting to "choose one or both"), leaving significant logic branches in `text_unpass_1_choice` untested and broken in practice.

---
*PR created automatically by Jules for task [9482325847636109566](https://jules.google.com/task/9482325847636109566) started by @RainRat*