### PR TITLE
Fix corrupted ANSI sequences in power/toughness display

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -107,13 +107,17 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if not res:
             res = card.get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'power':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[0]
+        if ansi_color and res:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'toughness':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[-1]
+        if ansi_color and res:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'loyalty':
         res = card.get_loyalty_display(ansi_color=ansi_color, include_parens=False)
     elif canon == 'text':


### PR DESCRIPTION
This PR fixes a logic bug in `scripts/mtg_query.py` where extracting the `power` or `toughness` fields with ANSI color enabled resulted in corrupted escape sequences. 

The issue occurred because the code was colorizing the full "Power/Toughness" string first and then splitting it by the `/` character. This left the `power` string with an opening escape sequence but no reset, and the `toughness` string with a reset but no opening sequence.

The fix ensures that the P/T string is split while uncolored, and colorization is applied individually to the resulting component.

Verified with a reproduction script and by running the full project test suite (1186 tests passed).

---
*PR created automatically by Jules for task [5111756023277613424](https://jules.google.com/task/5111756023277613424) started by @RainRat*