### PR TITLE
Fix ANSI escape sequence corruption in power/toughness fields

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -106,14 +106,12 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         res = card.get_pt_display(ansi_color=ansi_color)
         if not res:
             res = card.get_loyalty_display(ansi_color=ansi_color)
-    elif canon == 'power':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+    elif canon == 'power' or canon == 'toughness':
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
-            res = res.split('/')[0]
-    elif canon == 'toughness':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
-        if '/' in res:
-            res = res.split('/')[-1]
+            res = res.split('/')[0] if canon == 'power' else res.split('/')[-1]
+        if ansi_color and res:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'loyalty':
         res = card.get_loyalty_display(ansi_color=ansi_color, include_parens=False)
     elif canon == 'text':


### PR DESCRIPTION
I identified and fixed a logic bug in `scripts/mtg_query.py` where the `power` and `toughness` fields were incorrectly extracting partial ANSI escape sequences when `ansi_color` was enabled. This was caused by splitting an already-colorized P/T string.

The fix involves:
1. Extracting the power or toughness value from an uncolored P/T string (obtained by calling `card.get_pt_display(ansi_color=False)`).
2. Applying ANSI colorization to the extracted value individually using `utils.colorize`.
3. Consolidating the logic for 'power' and 'toughness' into a single `elif` block to reduce code duplication.

I verified the fix using a reproduction script and confirmed that it correctly generates intact ANSI sequences (e.g., `\x1b[91m2\x1b[0m` for both power and toughness). I also ran the full suite of 1186 tests to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [16457952043238750000](https://jules.google.com/task/16457952043238750000) started by @RainRat*