### PR TITLE
[DOCS] Simplify documentation and help strings using Plain English

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ python3 sortcards.py encoded_output.txt sorted_sample.txt --sample 50 --grep "El
 *   `--color` / `--no-color`: Enable or disable ANSI color output.
 
 ### `mtg_analyze.py profile`
-Identifies the "Mechanical Identity" (signature features) of a card subset by comparing it against a global baseline. This highlights what makes a specific group of cards unique.
+Identifies the unique features of a card subset by comparing it against a global baseline. This highlights what makes a specific group of cards unique.
 ```bash
 # Profile Green Rare cards to see their defining mechanics
 python3 scripts/mtg_analyze.py profile data/AllPrintings.json --colors G --rarity rare
@@ -495,7 +495,7 @@ python3 scripts/mtg_eval.py --checkpoint checkpoint.pt --temp 1.0
     *   `-j`, `--json`: Output results in structured JSON format.
 
 ### `mtg_llm_validate.py`
-Validates the mechanical integrity of cards using a Large Language Model (LLM). This tool asks the AI to judge if a card's text follows Magic's rules logic and provides a reason for its decision. It supports both local models and remote APIs.
+Checks how well cards follow rules using an AI model. This tool asks the AI to judge if a card's text follows Magic's rules logic and provides a reason for its decision. It supports both local models and remote APIs.
 
 ```bash
 # Validate cards using the default local model (TinyLlama)
@@ -825,7 +825,7 @@ python3 scripts/mtg_analyze.py types data/AllPrintings.json --compare generated.
     *   Supports all **Advanced Filtering** flags and 'Smart Positional Argument Handling'.
 
 ### `mtg_analyze.py audit`
-Performs a comprehensive design 'Health Check' for card datasets. It reports on core metrics (creature density, average CMC, complexity), functional coverage (removal, card advantage, mana fixing), identifies complexity outliers, and flags mechanical color pie violations.
+Performs a check of how well a card set is designed. It reports on core metrics (creature density, average CMC, complexity), functional coverage (removal, card advantage, mana fixing), identifies complexity outliers, and flags mechanical color pie violations.
 ```bash
 # Perform a health audit for a generated set
 python3 scripts/mtg_analyze.py audit generated.txt

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1501,10 +1501,10 @@ def main():
               # Compare the color lexicon of two datasets
               python3 scripts/mtg_analyze.py lexicon data/AllPrintings.json --compare generated.txt
 
-              # Perform a design health check on a card set
+              # Perform a check of how well a card set is designed
               python3 scripts/mtg_analyze.py audit data/AllPrintings.json --set MOM
 
-              # Identify the signature features of Green Rare cards
+              # Identify the unique features of Green Rare cards
               python3 scripts/mtg_analyze.py profile data/AllPrintings.json --colors G --rarity rare
 
               # Find the most combat-efficient creatures in a set
@@ -1565,7 +1565,7 @@ def main():
     p_ty.set_defaults(func=handle_types)
 
     # skeleton
-    p_sk = subparsers.add_parser('skeleton', help='Generate a "Design Skeleton" bucketing cards by type and CMC.')
+    p_sk = subparsers.add_parser('skeleton', help='Generate a "Design Skeleton" (grouping cards by type and mana cost).')
     add_std(p_sk)
     p_sk.add_argument('outfile', nargs='?', default=None, help='Save the skeleton to a file.')
     p_sk.set_defaults(func=handle_skeleton)
@@ -1604,9 +1604,9 @@ def main():
     p_sy = subparsers.add_parser(
         'interaction',
         aliases=['synergy'],
-        help='Analyze how often different mechanics appear together.',
+        help='Analyze how different mechanics appear together.',
         description=textwrap.dedent("""
-            Analyzes how different mechanics (like Flying and Trample) appear together
+            Analyzes how different mechanics appear together
             on the same cards. It identifies frequent pairings and calculates a
             'Lift Score' to measure how often they appear together compared to
             what would happen by random chance.
@@ -1665,9 +1665,9 @@ def main():
     # power
     p_po = subparsers.add_parser(
         'power',
-        help='Analyze creature combat efficiency relative to mana cost.',
+        help='Analyze how strong creatures are for their mana cost.',
         description=textwrap.dedent("""
-            Analyzes the creature power balance in a dataset. It calculates a
+            Analyzes how strong creatures are for their mana cost. It calculates a
             'Power Rating' relative to mana cost to identify cards that are
             significantly above or below the expected combat strength for their cost.
 
@@ -1724,9 +1724,9 @@ def main():
     # asfan
     p_as = subparsers.add_parser(
         'asfan',
-        help='Calculate "As-Fan" (average cards per pack) statistics.',
+        help='Calculate "As-Fan" (average cards per booster pack) statistics.',
         description=textwrap.dedent("""
-            Calculates "As-Fan" (As-fanned) statistics for a card dataset.
+            Calculates "As-Fan" (average cards per booster pack) statistics.
             As-Fan represents the average number of cards with a certain
             characteristic (like a specific color, type, or mechanic) a player
             can expect to see in a single 15-card booster pack.
@@ -1753,7 +1753,7 @@ def main():
     # profile
     p_prof = subparsers.add_parser(
         'profile',
-        help='Identify the "Mechanical Identity" (signature features) of a card subset.',
+        help='Identify the unique features of a card subset.',
         description=textwrap.dedent("""
             Identifies the defining characteristics of a card subset by comparing
             it against a global baseline. It highlights "signature features"
@@ -1769,9 +1769,9 @@ def main():
     # audit
     p_audit = subparsers.add_parser(
         'audit',
-        help='Perform a comprehensive design health check of a card dataset.',
+        help='Perform a check of how well a card set is designed.',
         description=textwrap.dedent("""
-            Performs a comprehensive design health check of a card dataset.
+            Performs a check of how well a card set is designed.
             This tool calculates several core metrics and functional coverage
             statistics, comparing them against standard design targets:
 

--- a/scripts/mtg_complexity.py
+++ b/scripts/mtg_complexity.py
@@ -17,7 +17,7 @@ import cardlib
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Analyze the design complexity of cards in a dataset. This tool calculates a 'Complexity Score' to help identify 'wordy' or mechanically dense cards.",
+        description="Analyze how complex cards are in a dataset. This tool calculates a 'Complexity Score' to help identify 'wordy' cards.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 The Complexity Score is a heuristic that measures how difficult a card is to read and understand. Higher scores indicate "wordier" cards or those with many mechanical features.

--- a/scripts/mtg_eval.py
+++ b/scripts/mtg_eval.py
@@ -19,12 +19,12 @@ from train import CharRNN, generate_text
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Check the quality of an AI model by generating and validating cards.",
+        description="Check how well an AI model works by creating and checking cards.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-This tool evaluates AI model checkpoints. It generates a batch of cards,
+This tool checks AI model files. It creates a batch of cards,
 checks if they follow the rules using scripts/mtg_validate.py, and calculates
-an 'Accuracy Score'.
+how many cards followed the rules.
 
 Usage Examples:
   # Evaluate a checkpoint by generating 100 cards

--- a/scripts/mtg_llm_validate.py
+++ b/scripts/mtg_llm_validate.py
@@ -203,7 +203,7 @@ def validate_cards_llm(cards, model_name, device, batch_size=1, quiet=False, ver
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Validate card mechanical integrity using a Large Language Model.",
+        description="Check how well cards follow rules using an AI model.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Usage Examples:


### PR DESCRIPTION
This PR improves the project's documentation and internal help strings by applying strict "Plain English" principles. It removes technical jargon and business buzzwords, replacing them with simple, descriptive alternatives to make the toolkit more accessible to a global audience.

**Key Improvements:**
- **README.md:** Simplified the descriptions for `mtg_llm_validate.py`, `mtg_analyze.py profile`, and `mtg_analyze.py audit`.
- **CLI Help Strings:** Updated `scripts/mtg_llm_validate.py`, `scripts/mtg_analyze.py`, `scripts/mtg_eval.py`, and `scripts/mtg_complexity.py` to use consistent, non-technical language.
- **Consistency:** Ensured that jargon like "mechanical integrity" and "Large Language Model" are replaced with "how well cards follow rules" and "AI model" across all user-facing text.

All changes were verified by running the scripts with the `--help` flag and ensuring that the full test suite (1186 tests) passes.

---
*PR created automatically by Jules for task [16311788122048827638](https://jules.google.com/task/16311788122048827638) started by @RainRat*