### PR TITLE
[UI/UX] Implement subcommand aliases for CLI efficiency

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1544,8 +1544,10 @@ def handle_compare_cards(args):
 def main():
     # UI/UX Improvement: Intelligent Subcommand Defaults
     # If no subcommand is provided, we intelligently default to 'shell', 'oracle', or 'search'.
-    valid_subcommands = ['search', 'oracle', 'random', 'extract', 'sets', 'functional',
-                         'compare', 'superior', 'inferior', 'shell', 'interactive', 'repl']
+    valid_subcommands = ['search', 's', 'oracle', 'o', 'random', 'r', 'extract', 'e',
+                         'sets', 'st', 'functional', 'f', 'compare', 'c',
+                         'superior', 'sup', 'inferior', 'inf',
+                         'shell', 'sh', 'interactive', 'repl']
 
     has_subcommand = any(arg in valid_subcommands for arg in sys.argv[1:])
 
@@ -1572,6 +1574,7 @@ def main():
     # Search Subparser
     p_search = subparsers.add_parser(
         'search',
+        aliases=['s'],
         help='Search card data and extract specific fields.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1617,6 +1620,7 @@ Note: If no input file is provided, data/AllPrintings.json is used if available.
     # Oracle Subparser
     p_oracle = subparsers.add_parser(
         'oracle',
+        aliases=['o'],
         help='Search for a card by name and display its full official rules text.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1649,6 +1653,7 @@ Usage Examples:
     # Random Subparser
     p_random = subparsers.add_parser(
         'random',
+        aliases=['r'],
         help='Display one or more random cards matching the filters.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1686,6 +1691,7 @@ Usage Examples:
     # Extract Subparser
     p_extract = subparsers.add_parser(
         'extract',
+        aliases=['e'],
         help='Extract a single card object from a large JSON database.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1704,6 +1710,7 @@ Usage Examples:
     # Sets Subparser
     p_sets = subparsers.add_parser(
         'sets',
+        aliases=['st'],
         help='List and filter card sets from a data file.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1737,6 +1744,7 @@ Usage Examples:
     # Functional Subparser
     p_functional = subparsers.add_parser(
         'functional',
+        aliases=['f'],
         help='Identify and group cards with the same mechanics but different names.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1773,6 +1781,7 @@ Usage Examples:
     # Compare Subparser
     p_compare = subparsers.add_parser(
         'compare',
+        aliases=['c'],
         help='Compare multiple cards side-by-side.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1803,6 +1812,7 @@ Usage Examples:
     # Superior Subparser
     p_superior = subparsers.add_parser(
         'superior',
+        aliases=['sup'],
         help='Find cards that are generally better than a reference card.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1838,6 +1848,7 @@ Usage Examples:
     # Inferior Subparser
     p_inferior = subparsers.add_parser(
         'inferior',
+        aliases=['inf'],
         help='Find cards that are generally inferior to a reference card.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -1870,7 +1881,7 @@ Usage Examples:
     # Shell Subparser
     p_shell = subparsers.add_parser(
         'shell',
-        aliases=['interactive', 'repl'],
+        aliases=['sh', 'interactive', 'repl'],
         help='Launch an interactive shell for quick card lookups and searches.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""


### PR DESCRIPTION
This PR improves the usability and efficiency of the `mtg_query.py` CLI tool by introducing shorthand aliases for all its subcommands.

### Context: CLI
### Problem:
The `mtg_query.py` script consolidates multiple features under several subcommands. Many of these subcommand names are long (e.g., `functional`, `superior`, `interactive`), which increases typing friction for common card lookup and search tasks.

### Solution:
Implemented standardized shorthand aliases for every subcommand:
*   `s` for `search`
*   `o` for `oracle`
*   `r` for `random`
*   `e` for `extract`
*   `st` for `sets`
*   `f` for `functional`
*   `c` for `compare`
*   `sup` for `superior`
*   `inf` for `inferior`
*   `sh` for `shell`

The intelligent subcommand detection logic in the script's entry point was also updated to support these aliases. This ensures that the script correctly identifies the intended command when an alias is used, preventing it from incorrectly defaulting to `oracle` or `search` based on positional arguments.

These changes allow power users to perform common tasks with significantly fewer keystrokes while maintaining the discoverability and clarity of the original long-form commands.


---
*PR created automatically by Jules for task [9576068091925511692](https://jules.google.com/task/9576068091925511692) started by @RainRat*