### PR TITLE
Fix ANSI corruption in power/toughness field extraction

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -107,13 +107,17 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         if not res:
             res = card.get_loyalty_display(ansi_color=ansi_color)
     elif canon == 'power':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[0]
+        if ansi_color and res:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'toughness':
-        res = card.get_pt_display(ansi_color=ansi_color, include_parens=False)
+        res = card.get_pt_display(ansi_color=False, include_parens=False)
         if '/' in res:
             res = res.split('/')[-1]
+        if ansi_color and res:
+            res = utils.colorize(res, utils.Ansi.RED)
     elif canon == 'loyalty':
         res = card.get_loyalty_display(ansi_color=ansi_color, include_parens=False)
     elif canon == 'text':


### PR DESCRIPTION
* **What:** Refactored `get_field_value` in `scripts/mtg_query.py` to extract power and toughness from an uncolored P/T string before applying ANSI colorization individually.
* **Why:** Previously, if ANSI color was enabled, the code would attempt to split a colorized string (e.g., `\x1b[91m2/3\x1b[0m`), resulting in broken escape sequences like `\x1b[91m2` for power and `3\x1b[0m` for toughness. This fix ensures terminal output remains valid and correctly styled. No breaking changes were introduced as the plain-text behavior remains identical.

---
*PR created automatically by Jules for task [6455430645149368539](https://jules.google.com/task/6455430645149368539) started by @RainRat*