### PR TITLE
Deduplicate card resolution logic in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1346,42 +1346,8 @@ def handle_inferior(args):
     _execute_search(inferior_cards, args)
 
 def handle_reprints(args):
-    # Smart positional argument handling
-    if args.query and os.path.exists(args.query) and (args.infile == '-' or not os.path.exists(args.infile)):
-        temp = args.query
-        args.query = args.infile if args.infile != '-' else None
-        args.infile = temp
-
-    cards = cli_utils.load_and_filter_cards(args)
-    if not cards:
-        if not args.quiet:
-            print("No cards found in the dataset.", file=sys.stderr)
-        return
-
-    query = args.query
-    if not query:
-        if not args.quiet:
-            print("Error: No reference card name provided.", file=sys.stderr)
-        return
-
-    query_sanitized = query.lower().replace('-', utils.dash_marker)
-    target_card = next((c for c in cards if c.name.lower() == query_sanitized), None)
+    target_card, cards = _resolve_target_from_args(args)
     if not target_card:
-        # Try finding in the full dataset if not in the filtered pool
-        all_cards = jdecode.mtg_open_file(args.infile, verbose=False)
-        target_card = next((c for c in all_cards if c.name.lower() == query_sanitized), None)
-        if not target_card:
-            # Fuzzy match
-            search_names = {c.name.lower(): c for c in all_cards}
-            close = difflib.get_close_matches(query.lower(), list(search_names.keys()), n=1, cutoff=0.6)
-            if close:
-                target_card = search_names[close[0]]
-                if not args.quiet:
-                    print(f"Notice: Card '{query}' not found. Using best match: {target_card.display_name}", file=sys.stderr)
-
-    if not target_card:
-        if not args.quiet:
-            print(f"Error: Could not find reference card '{query}'", file=sys.stderr)
         return
 
     target_key = get_functional_key(target_card)


### PR DESCRIPTION
The `handle_reprints` function in `scripts/mtg_query.py` contained a large block of logic for resolving a target card from CLI arguments that was identical to logic already extracted into the `_resolve_target_from_args` helper function. This helper is used by the `superior` and `inferior` subcommands.

This change replaces the redundant implementation in `handle_reprints` with a call to the helper, reducing code duplication and improving maintainability.

Verified that behavior remains identical, including:
- Smart positional argument disambiguation (file vs. query).
- Dataset loading and filtering.
- Fuzzy matching with user-facing notices.
- Error reporting for missing cards or datasets.

Tests passed:
- `tests/test_mtg_query.py`
- `tests/test_mtg_superior.py`
- `tests/test_mtg_inferior.py`
- Manual verification of `reprints` subcommand with fuzzy matching.

---
*PR created automatically by Jules for task [17861267244518829299](https://jules.google.com/task/17861267244518829299) started by @RainRat*