### PR TITLE
Fix capitalization of hyphenated card names in rules text

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1346,10 +1346,7 @@ class Card:
             return ''
 
         mtext = text_obj.text
-        if gatherer or mse:
-            cardname = titlecase(transforms.name_unpass_1_dashes(name_obj))
-        else:
-            cardname = titlecase(name_obj)
+        cardname = titlecase(transforms.name_unpass_1_dashes(name_obj))
 
         # 1. Choice unpass
         delimit_choice = not (gatherer or mse)


### PR DESCRIPTION
* **What:** Modified `Card.get_text()` in `lib/cardlib.py` to always convert internal dash markers (`~`) back to hyphens before applying `titlecase` to the card name.
* **Why:** Previously, this conversion only happened for specific output formats (`gatherer` or `mse`). Without it, `titlecase` would fail to correctly capitalize the part of the name following the tilde (e.g., "Hate~twisted"), leading to inconsistent rules text in other formats like the MTGJSON dictionary output. This change ensures correct and consistent capitalization across all output formats without breaking existing functionality.

---
*PR created automatically by Jules for task [10540581666814772169](https://jules.google.com/task/10540581666814772169) started by @RainRat*