### PR TITLE
[DOCS] Update decode.py help text for automatic format detection

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -756,7 +756,7 @@ Usage Examples:
     io_group.add_argument('infile', nargs='?', default='-',
                         help='Input card data (MTGJSON or Scryfall JSON, JSONL, CSV, MSE, XML, ZIP, or MTG Decklist), an encoded file, or a directory. Defaults to stdin (-).')
     io_group.add_argument('outfile', nargs='?', default=None,
-                        help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .jsonl, .csv, .md, .sum, .summary, .deck, .dek, .mse-set).')
+                        help='Path to save the decoded output. If not provided, output prints to the console. The format is automatically detected from the file extension (.html, .json, .jsonl, .csv, .md, .mdt, .sum, .summary, .tbl, .table, .deck, .dek, .xml, .mse-set).')
 
     # Group: Output Format (Mutually Exclusive)
     # We use a mutually exclusive group to enforce one output format.


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Updated the help string for the `outfile` argument in `decode.py`.
* **Why:** The previous help text was missing several supported file extensions (.mdt, .tbl, .table, .xml) for automatic format detection. Adding them makes the CLI more transparent and easier to use.

---
*PR created automatically by Jules for task [13186215411076666319](https://jules.google.com/task/13186215411076666319) started by @RainRat*