### PR TITLE
Fix capitalization of card names with dashes in rules text

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1346,10 +1346,7 @@ class Card:
             return ''
 
         mtext = text_obj.text
-        if gatherer or mse:
-            cardname = titlecase(transforms.name_unpass_1_dashes(name_obj))
-        else:
-            cardname = titlecase(name_obj)
+        cardname = titlecase(transforms.name_unpass_1_dashes(name_obj))
 
         # 1. Choice unpass
         delimit_choice = not (gatherer or mse)

--- a/tests/test_card_name_dashes_logic.py
+++ b/tests/test_card_name_dashes_logic.py
@@ -1,0 +1,44 @@
+import sys
+import os
+libdir = os.path.join(os.getcwd(), 'lib')
+sys.path.append(libdir)
+import cardlib
+import utils
+import transforms
+
+def test_card_name_dashes_logic():
+    # Card with a dash in its name
+    # Internal representation uses '~' for dash
+    card_json = {
+        "name": "Hate-Twisted",
+        "manaCost": "{1}{B}",
+        "types": ["Enchantment"],
+        "text": "Whenever Hate-Twisted enters, it deals 2 damage.",
+        "rarity": "Rare"
+    }
+    card = cardlib.Card(card_json)
+
+    # Internal name should be lowercase with dash marker
+    assert card.name == "hate~twisted"
+
+    # Rules text should have Hate-Twisted correctly capitalized
+    # Test with force_unpass=True
+    text = card.get_text(force_unpass=True)
+    assert "Hate-Twisted" in text
+    assert "Hate~twisted" not in text
+    assert "hate~twisted" not in text
+
+    # Test with gatherer=True
+    text_gatherer = card.get_text(gatherer=True)
+    assert "Hate-Twisted" in text_gatherer
+    assert "Hate~twisted" not in text_gatherer
+
+    # Test with mse=True
+    text_mse = card.get_text(mse=True)
+    assert "Hate-Twisted" in text_mse
+    assert "Hate~twisted" not in text_mse
+
+    print("Tests passed: Hate-Twisted correctly capitalized in rules text.")
+
+if __name__ == "__main__":
+    test_card_name_dashes_logic()


### PR DESCRIPTION
* **What:** Updated `Card.get_text` in `lib/cardlib.py` to consistently apply `transforms.name_unpass_1_dashes()` before `titlecase()` when processing the card name for rules text replacements.
* **Why:** Previously, card names containing internal dash markers ('~') were only correctly formatted if the `gatherer` or `mse` flags were active. This caused incorrect capitalization (e.g., 'Hate~twisted' instead of 'Hate-Twisted') in the default output format. Standardizing this logic improves rules text readability and consistency across all display modes. No breaking changes were introduced, and all existing tests passed.

---
*PR created automatically by Jules for task [624400294157247574](https://jules.google.com/task/624400294157247574) started by @RainRat*