### PR TITLE
[DOCS] Update custom encoding instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Customization options for formatting data:
 *   `-e old`: Legacy encoding format.
 *   `-e norarity`: Standard format but without rarity labels.
 *   `-e vec`: Numerical format for mathematical models.
-*   `-e custom`: Use your own user-defined formatting rules (see `lib/cardlib.py`).
+*   `-e custom`: Use your own user-defined formatting rules (see the placeholders in `encode.py` and `decode.py`).
 *   `--nolabel`: Removes field labels (e.g., `|cost|`, `|text|`) from the output.
 *   `--nolinetrans`: Disables the automatic reordering and normalization of card text lines.
 *   `-r`, `--randomize`: Randomizes mana symbol order (e.g., `{U}{W}` vs `{W}{U}`) to help the AI learn better.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the `README.md` file's description of the `-e custom` flag.
* **Why:** The previous instruction incorrectly pointed to `lib/cardlib.py` for defining custom formatting rules. The actual customization logic is handled via placeholders within `encode.py` and `decode.py`. This change ensures users are directed to the correct files when they want to implement their own encoding formats.

---
*PR created automatically by Jules for task [11464614338372058133](https://jules.google.com/task/11464614338372058133) started by @RainRat*