### PR TITLE
Always unpass dashes in card name for self-references

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1346,10 +1346,7 @@ class Card:
             return ''
 
         mtext = text_obj.text
-        if gatherer or mse:
-            cardname = titlecase(transforms.name_unpass_1_dashes(name_obj))
-        else:
-            cardname = titlecase(name_obj)
+        cardname = titlecase(transforms.name_unpass_1_dashes(name_obj))
 
         # 1. Choice unpass
         delimit_choice = not (gatherer or mse)


### PR DESCRIPTION
* **What:** Modified `Card.get_text()` in `lib/cardlib.py` to always apply `transforms.name_unpass_1_dashes()` to the card name before using it for self-reference replacements, regardless of output format flags.
* **Why:** This ensures that card names containing internal dash markers (e.g., 'Hate-Twisted') are correctly capitalized and formatted in the rules text (returning 'Hate-Twisted' instead of 'Hate~twisted') across all export targets. This is a non-breaking change that improves consistency in rules text rendering.

---
*PR created automatically by Jules for task [1453385362826221844](https://jules.google.com/task/1453385362826221844) started by @RainRat*