### PR TITLE
[DOCS] Update custom encoding reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Customization options for formatting data:
 *   `-e old`: Legacy encoding format.
 *   `-e norarity`: Standard format but without rarity labels.
 *   `-e vec`: Numerical format for mathematical models.
-*   `-e custom`: Use your own user-defined formatting rules (see `lib/cardlib.py`).
+*   `-e custom`: Use your own user-defined formatting rules (see placeholders in `encode.py` and `decode.py`).
 *   `--nolabel`: Removes field labels (e.g., `|cost|`, `|text|`) from the output.
 *   `--nolinetrans`: Disables the automatic reordering and normalization of card text lines.
 *   `-r`, `--randomize`: Randomizes mana symbol order (e.g., `{U}{W}` vs `{W}{U}`) to help the AI learn better.


### PR DESCRIPTION
**PR Title:** [DOCS] Update custom encoding reference in README.md 
**Description:** 
* **Type:** Documentation 
* **What:** Updated the reference for the `custom` encoding format in `README.md`. 
* **Why:** The previous documentation incorrectly pointed to `lib/cardlib.py` for user-defined formatting rules. The logic is now implemented via placeholders within `encode.py` and `decode.py`. This change ensures users are directed to the correct files for customization.

---
*PR created automatically by Jules for task [10912005982955306927](https://jules.google.com/task/10912005982955306927) started by @RainRat*