### PR TITLE
[FEAT] Implement Card Printing History and Multi-Set Support

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -677,6 +677,9 @@ class Card:
         # format-independent view of processed input
         self.fields = None # will be reset later
 
+        # printing history
+        self.printings = []
+
         # looks like a json object
         if isinstance(src, dict):
             self.json = src
@@ -684,6 +687,8 @@ class Card:
             self.number = src.get('number')
             self.rulings = src.get('rulings', [])
             self.legalities = src.get('legalities', {})
+            if self.set_code:
+                self.add_printing(self.set_code, src.get('rarity'), self.number, src.get(utils.json_field_set_name))
             if utils.json_field_bside in src:
                 self.bside = Card(src[utils.json_field_bside],
                                   fmt_ordered = fmt_ordered,
@@ -795,6 +800,43 @@ class Card:
     def is_permanent(self):
         """Returns True if the card is a permanent (Artifact, Creature, Enchantment, Land, Planeswalker, or Battle)."""
         return self.is_artifact or self.is_creature or self.is_enchantment or self.is_land or self.is_planeswalker or self.is_battle
+
+    def add_printing(self, set_code, rarity, number, set_name=None):
+        """Adds a printing to the card's history."""
+        if not set_code:
+            return
+
+        # Avoid duplicates
+        for p in self.printings:
+            if p['set_code'].upper() == set_code.upper():
+                return
+
+        self.printings.append({
+            'set_code': set_code.upper(),
+            'rarity': rarity,
+            'number': str(number) if number else None,
+            'set_name': set_name
+        })
+
+    def activate_printing(self, set_code):
+        """Updates the card's primary metadata to match a specific printing."""
+        if not set_code:
+            return False
+
+        target = set_code.upper()
+        for p in self.printings:
+            if p['set_code'] == target:
+                self.set_code = p['set_code']
+                # Try to map rarity back to marker if it's a name
+                r_val = p['rarity']
+                if r_val and hasattr(r_val, 'lower') and r_val.lower() in utils.json_rarity_map:
+                    self.rarity = utils.json_rarity_map[r_val.lower()]
+                else:
+                    self.rarity = r_val
+
+                self.number = p['number']
+                return True
+        return False
 
     @property
     def tokens(self):
@@ -1981,6 +2023,9 @@ class Card:
             d['box_id'] = self.box_id
         if hasattr(self, 'pack_id'):
             d['pack_id'] = self.pack_id
+
+        if self.printings:
+            d['printings'] = self.printings
 
         # B-Side (Recursive)
         if self.bside:

--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -730,6 +730,10 @@ def _process_json_srcs(json_srcs, bad_sets, verbose, linetrans,
                 continue
 
             if card.valid:
+                # Build printing history from all available versions
+                for jcard in jcards:
+                    card.add_printing(jcard.get('setCode'), jcard.get('rarity'), jcard.get('number'), jcard.get(utils.json_field_set_name))
+
                 # Handle multiplication from decklist
                 count = decklist_names[json_cardname] if decklist_names else 1
                 for _ in range(count):
@@ -1273,12 +1277,27 @@ def mtg_open_file(fname, verbose = False,
                 if card.search_loyalty(pattern):
                     return False
 
-            # Set filtering
+            # Set filtering: Check primary set and all printings
             if target_sets:
-                # If the card has no set code (like from an encoded text file),
-                # we don't filter it out by set.
-                if card.set_code and card.set_code.upper() not in target_sets:
-                    return False
+                matched_set = None
+                if card.set_code and card.set_code.upper() in target_sets:
+                    matched_set = card.set_code.upper()
+                else:
+                    # Check reprints
+                    for p in card.printings:
+                        if p['set_code'] in target_sets:
+                            matched_set = p['set_code']
+                            break
+
+                if matched_set:
+                    # Automatically activate the printing that matched the user's filter
+                    # This ensures correct display/simulation context.
+                    card.activate_printing(matched_set)
+                else:
+                    # If the card has no set code (like from an encoded text file),
+                    # we don't filter it out by set.
+                    if card.set_code:
+                        return False
 
             # Rarity filtering
             if target_rarities:

--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -64,6 +64,8 @@ FIELD_MAP = {
     'legalities': {'header': 'Legalities', 'align': 'l', 'aliases': ['formats', 'legal']},
     'legendary': {'header': 'Legendary', 'align': 'l', 'aliases': []},
     'permanent': {'header': 'Permanent', 'align': 'l', 'aliases': []},
+    'printings': {'header': 'Printings', 'align': 'l', 'aliases': ['history', 'sets_all']},
+    'all_sets': {'header': 'Sets', 'align': 'l', 'aliases': ['other_sets']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
 
@@ -196,6 +198,24 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         res = "Yes" if card.is_permanent else "No"
         if ansi_color:
             res = utils.colorize(res, utils.Ansi.BOLD + (utils.Ansi.CYAN if card.is_permanent else utils.Ansi.WHITE))
+        return res
+    elif canon == 'all_sets':
+        sets = sorted([p['set_code'] for p in card.printings])
+        res = ", ".join(sets)
+        if ansi_color:
+            res = utils.colorize(res, utils.Ansi.CYAN)
+        return res
+    elif canon == 'printings':
+        parts = []
+        for p in sorted(card.printings, key=lambda x: x['set_code']):
+            info = p['set_code']
+            if p['rarity']:
+                r_mark = cardlib.RARITY_MAP.get(p['rarity'].lower() if hasattr(p['rarity'], 'lower') else p['rarity'], p['rarity'][0].upper() if p['rarity'] else '?')
+                info += f" ({r_mark})"
+            parts.append(info)
+        res = ", ".join(parts)
+        if ansi_color:
+            res = utils.colorize(res, utils.Ansi.CYAN)
         return res
     elif canon == 'produced':
         produced = card.produced_colors
@@ -714,6 +734,22 @@ def _execute_oracle(cards, args):
                 analytics_parts.append(f"{fmt_label('COLOR PIE:')} {cp_val}")
 
             footer_lines.append(" \u2022 ".join(analytics_parts))
+
+            # Printings History
+            if c.printings and len(c.printings) > 1:
+                parts = []
+                for p in sorted(c.printings, key=lambda x: x['set_code']):
+                    info = p['set_code']
+                    if p['rarity']:
+                        r_mark = cardlib.RARITY_MAP.get(p['rarity'].lower() if hasattr(p['rarity'], 'lower') else p['rarity'], p['rarity'][0].upper() if p['rarity'] else '?')
+                        if use_color:
+                            r_color = utils.Ansi.get_rarity_color(p['rarity'])
+                            info += " (" + utils.colorize(r_mark, r_color) + ")"
+                        else:
+                            info += f" ({r_mark})"
+                    parts.append(info)
+                history_val = ", ".join(parts)
+                footer_lines.append(f"{fmt_label('PRINTINGS:')} {history_val}")
 
             # Legality
             if c.legalities:


### PR DESCRIPTION
This PR adds a "Printing History" feature that allows the toolkit to recognize and display all sets a card has appeared in. 

Key changes:
1. **Model Expansion**: The `Card` class now has a `printings` list.
2. **Aggregated Loading**: Data ingestion now combines multiple entries for the same card name into a single history.
3. **Smart Filtering**: Searching by set (`--set`) now finds cards reprinted in that set even if another version is the primary one, and automatically switches the card's metadata to match the filtered context.
4. **Enhanced UI**: The `oracle` subcommand now displays a card's full history in the footer, and new fields (`all_sets`, `printings`) are available for custom searches.

This improves the utility of the toolkit as a comprehensive MTG database and ensures that simulations (like opening boosters) use set-appropriate data.

---
*PR created automatically by Jules for task [14229202196458716792](https://jules.google.com/task/14229202196458716792) started by @RainRat*