### PR TITLE
Fix multi-faced card combined name search

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -1550,7 +1550,11 @@ class Card:
         """Returns True if the pattern matches the card's name."""
         if pattern.search(self.name):
             return True
+        # For multi-faced cards, also check the combined name
         if self.bside:
+            combined_name = f"{self.name} // {self.bside.name}"
+            if pattern.search(combined_name):
+                return True
             return self.bside.search_name(pattern)
         return False
 


### PR DESCRIPTION
This PR fixes a logic bug in the `Card.search_name` method where multi-faced cards (such as split cards) could only be found by searching for one of their face names individually. 

By constructing a combined name string `\"Front // Back\"` and searching within it, we now support the common use case of looking up these cards by their full title. The fix is non-breaking as it preserves the recursive search on individual faces, ensuring that anchored or face-specific queries still function as expected.

**Changes:**
- Modified `Card.search_name` in `lib/cardlib.py` to check for a combined name string if a b-side exists.

**Verification:**
- Verified with a reproduction script containing a mock split card.
- Ran existing tests in `tests/test_cardlib.py`, `tests/test_mtg_superior.py`, and `tests/test_mtg_query.py`. All relevant tests passed.

---
*PR created automatically by Jules for task [16936829123193298089](https://jules.google.com/task/16936829123193298089) started by @RainRat*