### PR TITLE
[TEST] Add Battle card support to MSE export

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -2109,6 +2109,16 @@ class Card:
                 newtext2 = newtext2.replace('\n', '\n\t\t')
                 outstr += '\trule text 2:\n\t\t' + newtext2 + '\n'
 
+        # Apply specific formatting for battle cards.
+        elif self.is_battle:
+            outstr += '\tstylesheet: magic-m15-extra-improved\n'
+
+            if self.__dict__[field_loyalty]:
+                outstr += '\tdefense: ' + utils.from_unary(self.__dict__[field_loyalty]) + '\n'
+
+            newtext = newtext.replace('\n', '\n\t\t')
+            outstr += '\trule text:\n\t\t' + newtext + '\n'
+
         # Apply specific formatting for planeswalker cards.
         elif self.is_planeswalker:
             outstr += '\tstylesheet: m15-planeswalker\n'

--- a/tests/test_battle_mse.py
+++ b/tests/test_battle_mse.py
@@ -1,0 +1,23 @@
+from lib.cardlib import Card
+from lib import utils
+
+def test_battle_to_mse():
+    battle_json = {
+        "name": "Invasion of Zendikar",
+        "manaCost": "{3}{G}",
+        "types": ["Battle"],
+        "subtypes": ["Siege"],
+        "rarity": "Uncommon",
+        "defense": "3",
+        "text": "When Invasion of Zendikar enters the battlefield, search your library for up to two basic land cards..."
+    }
+
+    card = Card(battle_json)
+    mse_out = card.to_mse()
+
+    assert "super type: Battle" in mse_out
+    assert "sub type: Siege" in mse_out
+    assert "stylesheet: magic-m15-extra-improved" in mse_out
+    assert "defense: 3" in mse_out
+    # Unary check
+    assert "&^^^" not in mse_out


### PR DESCRIPTION
This PR fixes a gap in the Magic Set Editor (MSE) export functionality where Battle cards were being exported without their defense values and with incorrect stylesheets.

Changes:
- Updated `Card.to_mse()` in `lib/cardlib.py` to detect Battle cards and output the appropriate `defense:` field and stylesheet.
- Created `tests/test_battle_mse.py` to provide test coverage for this specific scenario.
- Verified the fix with new and existing tests.

---
*PR created automatically by Jules for task [6312790110372381017](https://jules.google.com/task/6312790110372381017) started by @RainRat*