### PR TITLE
[DOCS] Centralize and enhance field extraction help in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -68,6 +68,12 @@ FIELD_MAP = {
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
 
+FIELDS_HELP = """Comma-separated list of fields to extract. Available fields:
+  - Basic:    name, cost, cmc, type, stats, text, rarity
+  - Analysis: mechanics, actions, tokens, identity, produced, color_pie, signature
+  - Design:   complexity, rating, fair_mv
+  - Metadata: set, number, pack, box, legalities"""
+
 _CANONICAL_MAP = {k: k for k in FIELD_MAP}
 for k, v in FIELD_MAP.items():
     for alias in v.get('aliases', []):
@@ -1866,10 +1872,7 @@ Note: If no input file is provided, data/AllPrintings.json is used if available.
     p_search.add_argument('outfile', nargs='?', default=None,
                         help='Path to save the search results. If not provided, results print to the console.')
     p_search.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                        help='Comma-separated list of fields to extract. Available fields:\n'
-                             '  - Basic: name, cost, cmc, type, stats, text, rarity\n'
-                             '  - Analysis: mechanics, actions, tokens, identity, complexity, rating, fair_mv, color_pie\n'
-                             '  - Metadata: set, number, pack, box')
+                        help=FIELDS_HELP)
     p_search.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     cli_utils.add_standard_filters(p_search)
@@ -1906,7 +1909,7 @@ Usage Examples:
     p_oracle.add_argument('infile', nargs='?', default='-',
                         help='Input card data file. Defaults to the official dataset (data/AllPrintings.json).')
     p_oracle.add_argument('-f', '--fields', default='name,cost,type,stats,rarity,text',
-                        help='Fields to extract when using structured output formats.')
+                        help=FIELDS_HELP)
     cli_utils.add_standard_filters(p_oracle)
     cli_utils.add_standard_output_args(p_oracle)
     p_oracle.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score', 'rating', 'power_rating'],
@@ -1946,7 +1949,7 @@ Usage Examples:
     p_random.add_argument('--jsonl', action='store_true', help='Output results in JSON Lines format.')
     p_random.add_argument('-S', '--summary', action='store_true', help='Output a compact one-line summary for each card.')
     p_random.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                        help='Comma-separated list of fields to extract (when using table/csv/json).')
+                        help=FIELDS_HELP)
     p_random.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_random.add_argument('-G', '--gatherer', action='store_true',
@@ -2028,7 +2031,7 @@ Usage Examples:
     p_functional.add_argument('--dedupe', nargs='?', const='-',
                             help='Create a deduplicated dataset (one card per functional group) and save to the specified file.')
     p_functional.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                            help='Comma-separated list of fields to extract when using --dedupe.')
+                            help=FIELDS_HELP)
     p_functional.add_argument('--delimiter', default=' | ',
                             help='Separator used between fields in plain text output.')
     p_functional.add_argument('--text', action='store_true', help='Force plain text output.')
@@ -2102,7 +2105,7 @@ Usage Examples:
     cli_utils.add_standard_filters(p_superior)
     cli_utils.add_standard_output_args(p_superior)
     p_superior.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                           help='Fields to display in the output table.')
+                           help=FIELDS_HELP)
     p_superior.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
                            help='Sort the resulting superior cards.')
     p_superior.add_argument('--delimiter', default=' | ',
@@ -2133,7 +2136,7 @@ Usage Examples:
     cli_utils.add_standard_filters(p_reprints)
     cli_utils.add_standard_output_args(p_reprints)
     p_reprints.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                           help='Fields to display in the output table.')
+                           help=FIELDS_HELP)
     p_reprints.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
                            help='Sort the resulting reprint cards.')
     p_reprints.add_argument('--delimiter', default=' | ',
@@ -2166,7 +2169,7 @@ Usage Examples:
     cli_utils.add_standard_filters(p_inferior)
     cli_utils.add_standard_output_args(p_inferior)
     p_inferior.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                           help='Fields to display in the output table.')
+                           help=FIELDS_HELP)
     p_inferior.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
                            help='Sort the resulting inferior cards.')
     p_inferior.add_argument('--delimiter', default=' | ',
@@ -2201,7 +2204,7 @@ Usage Examples:
     cli_utils.add_standard_filters(p_substitutes)
     cli_utils.add_standard_output_args(p_substitutes)
     p_substitutes.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
-                           help='Fields to display in the output table.')
+                           help=FIELDS_HELP)
     p_substitutes.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_substitutes.set_defaults(func=handle_substitutes)
@@ -2224,7 +2227,7 @@ Usage Examples:
     p_shell.add_argument('infile', nargs='?', default='-',
                         help='Input card data. Defaults to data/AllPrintings.json if available.')
     p_shell.add_argument('-f', '--fields', default='name,cost,type,stats,rarity',
-                        help='Default fields to show during /search commands.')
+                        help=FIELDS_HELP)
     cli_utils.add_standard_output_args(p_shell)
     p_shell.set_defaults(func=handle_shell)
 


### PR DESCRIPTION
This change improves the internal documentation of the `mtg_query.py` CLI tool. It introduces a `FIELDS_HELP` constant that contains a categorized list of all valid field names for extraction. This constant is then applied to the `-f/--fields` argument in the following subcommands: `search`, `oracle`, `random`, `functional`, `reprints`, `superior`, `inferior`, `substitutes`, and `shell`.

Key improvements:
- **Consistency:** All subcommands now show the same comprehensive list of fields.
- **Organization:** Fields are grouped into logical categories (Basic, Analysis, Design, Metadata).
- **Accuracy:** Included missing fields like `produced`, `signature`, and `legalities` that are supported by the underlying field mapping logic.
- **Maintainability:** Future changes to available fields only need to be updated in one location.

---
*PR created automatically by Jules for task [772033063801104752](https://jules.google.com/task/772033063801104752) started by @RainRat*