### PR TITLE
Remove redundant subset_identity wrapper in mtg_deckgen.py

### DIFF
--- a/scripts/mtg_deckgen.py
+++ b/scripts/mtg_deckgen.py
@@ -21,10 +21,6 @@ def get_color_identity_set(card):
         return set()
     return set(card.color_identity.upper())
 
-def subset_identity(card_id, cmd_id):
-    # Returns True if card_id is a subset of cmd_id
-    return card_id.issubset(cmd_id)
-
 def pick_cards_with_curve(pool, target_count, curve=None):
     if not pool:
         return []
@@ -248,7 +244,7 @@ Usage Examples:
         valid_pool = []
         for c in pool:
             if c.display_name == commander_card.display_name: continue
-            if subset_identity(get_color_identity_set(c), cmd_id):
+            if get_color_identity_set(c).issubset(cmd_id):
                 valid_pool.append(c)
                 
         creatures_pool = [c for c in valid_pool if c.is_creature]

--- a/tests/test_mtg_deckgen.py
+++ b/tests/test_mtg_deckgen.py
@@ -25,11 +25,6 @@ class TestMtgDeckgen(unittest.TestCase):
         card = object() # No color_identity attribute
         self.assertEqual(mtg_deckgen.get_color_identity_set(card), set())
 
-    def test_subset_identity(self):
-        self.assertTrue(mtg_deckgen.subset_identity({'W'}, {'W', 'U'}))
-        self.assertTrue(mtg_deckgen.subset_identity(set(), {'W', 'U'}))
-        self.assertFalse(mtg_deckgen.subset_identity({'R'}, {'W', 'U'}))
-
     def test_pick_cards_with_curve_basic(self):
         pool = [MagicMock() for _ in range(10)]
         picked = mtg_deckgen.pick_cards_with_curve(pool, 5)


### PR DESCRIPTION
This change removes a redundant wrapper function `subset_identity` in `scripts/mtg_deckgen.py` and inlines its logic using the native `set.issubset` method. The corresponding test in `tests/test_mtg_deckgen.py` has also been removed. This is a non-breaking atomic improvement to code quality by reducing unnecessary abstraction.

---
*PR created automatically by Jules for task [6308731012456519194](https://jules.google.com/task/6308731012456519194) started by @RainRat*