### PR TITLE
Inline redundant subset_identity wrapper in mtg_deckgen.py

### DIFF
--- a/scripts/mtg_deckgen.py
+++ b/scripts/mtg_deckgen.py
@@ -21,10 +21,6 @@ def get_color_identity_set(card):
         return set()
     return set(card.color_identity.upper())
 
-def subset_identity(card_id, cmd_id):
-    # Returns True if card_id is a subset of cmd_id
-    return card_id.issubset(cmd_id)
-
 def pick_cards_with_curve(pool, target_count, curve=None):
     if not pool:
         return []
@@ -248,7 +244,7 @@ Usage Examples:
         valid_pool = []
         for c in pool:
             if c.display_name == commander_card.display_name: continue
-            if subset_identity(get_color_identity_set(c), cmd_id):
+            if get_color_identity_set(c).issubset(cmd_id):
                 valid_pool.append(c)
                 
         creatures_pool = [c for c in valid_pool if c.is_creature]

--- a/tests/test_mtg_deckgen.py
+++ b/tests/test_mtg_deckgen.py
@@ -25,11 +25,6 @@ class TestMtgDeckgen(unittest.TestCase):
         card = object() # No color_identity attribute
         self.assertEqual(mtg_deckgen.get_color_identity_set(card), set())
 
-    def test_subset_identity(self):
-        self.assertTrue(mtg_deckgen.subset_identity({'W'}, {'W', 'U'}))
-        self.assertTrue(mtg_deckgen.subset_identity(set(), {'W', 'U'}))
-        self.assertFalse(mtg_deckgen.subset_identity({'R'}, {'W', 'U'}))
-
     def test_pick_cards_with_curve_basic(self):
         pool = [MagicMock() for _ in range(10)]
         picked = mtg_deckgen.pick_cards_with_curve(pool, 5)


### PR DESCRIPTION
This PR removes a redundant wrapper function to improve code clarity and reduce indirection.

- **What:** Removed `subset_identity(card_id, cmd_id)` from `scripts/mtg_deckgen.py` and replaced its single usage with `get_color_identity_set(c).issubset(cmd_id)`.
- **Why:** The function provided no additional logic beyond calling a built-in Python method. Removing it simplifies the script.
- **Verification:** Ran `tests/test_mtg_deckgen.py` and verified all 8 remaining tests pass. Verified that the external behavior of the deck generator remains identical.

---
*PR created automatically by Jules for task [16978763798828738999](https://jules.google.com/task/16978763798828738999) started by @RainRat*