### PR TITLE
[TEST] Fix missing mechanics and multicolored data in asfan output

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1088,6 +1088,8 @@ def handle_asfan(args):
         datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','r','r']), indent=4)
     pt("Color Distribution:", a1['colors'], a2['colors'] if a2 else None, ks='WUBRGC')
     pt("Type Distribution:", a1['types'], a2['types'] if a2 else None)
+    pt("Mechanical Distribution:", a1['mechs'], a2['mechs'] if a2 else None)
+    print(f"\n  Multicolored As-Fan: {a1['multi']:.2f}" + (f" ({a2['multi']-a1['multi']:+.2f})" if a2 else ""))
 
 def handle_tokens(args):
     cards = cli_utils.load_and_filter_cards(args)

--- a/tests/test_mtg_asfan_enhanced.py
+++ b/tests/test_mtg_asfan_enhanced.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch
+import io
+import sys
+import os
+
+# Add lib and scripts directory to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import scripts.mtg_analyze as mtg_analyze
+import cardlib
+
+class TestMtgAsfanEnhanced(unittest.TestCase):
+
+    def setUp(self):
+        # Create a sample dataset with mechanics and multicolored cards
+        self.cards = [
+            cardlib.Card({
+                'name': 'Gold Flyer',
+                'rarity': 'common',
+                'manaCost': '{W}{U}',
+                'types': ['Creature'],
+                'text': 'Flying'
+            }),
+            cardlib.Card({
+                'name': 'Monocolor',
+                'rarity': 'common',
+                'manaCost': '{G}',
+                'types': ['Creature'],
+                'text': 'Trample'
+            })
+        ]
+
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_main_enhanced_output(self, mock_stdout, mock_open):
+        mock_open.return_value = self.cards
+
+        with patch('sys.argv', ['mtg_analyze.py', 'asfan', 'dummy.json', '--no-color']):
+            mtg_analyze.main()
+
+        output = mock_stdout.getvalue()
+        self.assertIn("AS-FAN ANALYSIS", output)
+        self.assertIn("Color Distribution", output)
+        self.assertIn("Type Distribution", output)
+
+        # These are the missing sections we want to add
+        self.assertIn("Mechanical Distribution", output)
+        self.assertIn("Multicolored As-Fan", output)
+
+        # Verify content within those sections
+        self.assertIn("Flying", output)
+        self.assertIn("Trample", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Type: Bug Fix / New Coverage

### What:
Updated `scripts/mtg_analyze.py` to correctly display "Mechanical Distribution" and "Multicolored As-Fan" statistics in the `asfan` subcommand. Previously, these metrics were calculated by `calculate_asfan()` but omitted from the output. Added `tests/test_mtg_asfan_enhanced.py` to verify the fix.

### Why:
As-Fan statistics are a critical part of set design analysis. While the underlying logic for mechanics and multicolored cards existed, the user could not see them in the tool's output. This change ensures all calculated As-Fan data is visible to the user and covered by tests.

---
*PR created automatically by Jules for task [6607191746067868231](https://jules.google.com/task/6607191746067868231) started by @RainRat*