### PR TITLE
[UI/UX] Standardize report headers and dataset labels in mtg_analyze.py

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -180,6 +180,17 @@ def get_cost_metrics(card):
 def get_numeric_stats(card):
     return utils.from_unary_single(card.pt_p), utils.from_unary_single(card.pt_t), utils.from_unary_single(card.loyalty)
 
+def _get_dataset_label(path, fallback=None):
+    """Generates a clean, short label for a dataset from its file path."""
+    if not path or path == '-':
+        return fallback or "Primary"
+    bn = os.path.basename(path)
+    for ext in ['.json', '.csv', '.txt', '.mse-set', '.xml', '.jsonl']:
+        if bn.lower().endswith(ext):
+            bn = bn[:-len(ext)]
+            break
+    return bn[:15]
+
 def check_cards(cards, args):
     if not cards:
         if not getattr(args, 'quiet', False):
@@ -622,7 +633,9 @@ def handle_mana(args):
     else:
         utils.print_header("MANA PRODUCTION ANALYSIS" + (" (COMPARISON)" if s2 else ""), count=s1['total'], use_color=use_color)
         print(f"  {datalib.color_line('General Metrics:', use_color)}")
-        h = ["Metric", "Primary"] + (["Comparison", "Delta"] if s2 else [])
+        label1 = _get_dataset_label(args.infile)
+        label2 = _get_dataset_label(args.compare, fallback="Comparison")
+        h = ["Metric", label1] + ([label2, "Delta"] if s2 else [])
         rows = [[utils.colorize(x, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) if use_color else x for x in h]]
         ms = [("Total Producers", s1['producers'], s2['producers'] if s2 else None), ("Fixing Cards", s1['fixing'], s2['fixing'] if s2 else None), ("Fixing Density", f"{s1['fixing']/s1['total']*100:.1f}%", f"{s2['fixing']/s2['total']*100:.1f}%" if s2 else None)]
         for lbl, v1, v2 in ms:
@@ -689,7 +702,7 @@ def handle_pips(args):
                 print("INCLUDES RULES TEXT", file=target)
             print("  MANA PIP DISTRIBUTION", file=target)
             print("  ===============================", file=target)
-            print("  Symbol  Count  Percent  Frequency", file=target)
+            print("  Symbol  Count  Percent  Distribution", file=target)
             print("  ------  -----  -------  ------------", file=target)
             for r in res:
                 print(f"  {r['sym']:<6}  {r['cnt']:>5}  {r['pct']:>6.1f}%  [██████████]", file=target)
@@ -697,7 +710,7 @@ def handle_pips(args):
             if args.include_text:
                 print("  INCLUDES RULES TEXT")
             utils.print_header("MANA PIP DISTRIBUTION", count=len(cards), use_color=use_color)
-            rows = [[utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) if use_color else h for h in ["Symbol", "Count", "Percent", "Frequency"]]]
+            rows = [[utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) if use_color else h for h in ["Symbol", "Count", "Percent", "Distribution"]]]
             for r in res:
                 es = utils.mana_symall_encode.get(r['sym'], r['sym'])
                 rows.append([utils.from_mana("{"+es+"}", ansi_color=use_color), datalib.color_count(r['cnt'], use_color), f"{r['pct']:5.1f}%", datalib.get_bar_chart(r['pct'], use_color, color=utils.Ansi.get_color_color(r['sym']))])
@@ -762,13 +775,15 @@ def handle_mechanics(args):
     utils.print_header("MECHANICAL COMPARISON" if c2 else "MECHANICAL FREQUENCY", count=len(cards1), use_color=use_color)
     print(f"  Total Cards: {len(cards1)}")
     if c2:
-        h = ["Mechanic", "% P1", "% P2", "Delta", "Ind"]
+        label1 = _get_dataset_label(args.infile)
+        label2 = _get_dataset_label(args.compare, fallback="Comp")
+        h = ["Mechanic", f"% {label1}", f"% {label2}", "Delta", "Ind"]
         rows = [[utils.colorize(x, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else x for x in h]]
         for r in res:
             d = r['delta']; ind = "▲" if d>0.1 else ("▼" if d<-0.1 else "•")
             rows.append([utils.colorize(r['name'], utils.Ansi.CYAN) if use_color else r['name'], f"{r['p1']:5.1f}%", f"{r['p2']:5.1f}%", utils.colorize(f"{d:+6.1f}%", utils.Ansi.GREEN if d>0.1 else utils.Ansi.RED) if use_color and abs(d)>0.1 else f"{d:+6.1f}%", utils.colorize(ind, utils.Ansi.GREEN if d>0.1 else utils.Ansi.RED) if use_color and abs(d)>0.1 else ind])
     else:
-        h = ["Mechanic", "Count", "Percent", "Frequency"]
+        h = ["Mechanic", "Count", "Percent", "Distribution"]
         rows = [[utils.colorize(x, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else x for x in h]]
         for r in res: rows.append([utils.colorize(r['name'], utils.Ansi.CYAN) if use_color else r['name'], str(r['c1']), f"{r['p1']:5.1f}%", datalib.get_bar_chart(r['p1'], use_color, color=utils.Ansi.CYAN)])
     datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','r','r','c'] if c2 else ['l','r','r','l']), indent=2)
@@ -818,7 +833,7 @@ def handle_actions(args):
     if args.json: print(json.dumps({'total': len(cards), 'total_cards': len(cards), 'summary': dict(act_c), 'color': {c: dict(v) for c, v in col_act.items()}}, indent=2))
     else:
         utils.print_header("CARD ACTION ANALYSIS", count=len(cards), use_color=use_color)
-        rows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ["Action", "Count", "Percent", "Frequency"]]]
+        rows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ["Action", "Count", "Percent", "Distribution"]]]
         for a, cnt in act_c.most_common():
             p = cnt/len(cards)*100
             rows.append([utils.colorize(a, utils.Ansi.CYAN) if use_color else a, datalib.color_count(cnt, use_color), f"{p:5.1f}%", datalib.get_bar_chart(p, use_color, color=utils.Ansi.BOLD+utils.Ansi.CYAN)])
@@ -1074,7 +1089,9 @@ def handle_asfan(args):
     utils.print_header("AS-FAN ANALYSIS" + (" (COMPARISON)" if a2 else ""), use_color=use_color)
     def pt(title, d1, d2, ks=None):
         print(f"  {datalib.color_line(title, use_color)}")
-        h = ["Metric", "P1"] + (["P2", "Delta"] if d2 else ["Freq"])
+        label1 = _get_dataset_label(args.infile, fallback="As-Fan")
+        label2 = _get_dataset_label(args.compare, fallback="Comp")
+        h = ["Metric", label1] + ([label2, "Delta"] if d2 else ["Distribution"])
         rows = [[utils.colorize(x, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else x for x in h]]
         ks = ks or sorted(d1.keys())
         for k in ks:
@@ -1412,14 +1429,8 @@ def handle_compare(args):
         mines.append(get_stats_for_file(f, args))
     if not mines: return
     base_mine = mines[0]; base_data = base_mine.to_dict()
-    def clean_fname(path):
-        bn = os.path.basename(path)
-        for ext in ['.json', '.csv', '.txt', '.mse-set', '.xml', '.jsonl']:
-            if bn.lower().endswith(ext):
-                bn = bn[:-len(ext)]
-                break
-        return bn[:15]
-    fnames = [clean_fname(f) for f in args.infiles]
+
+    fnames = [_get_dataset_label(f) for f in args.infiles]
     header = ["Metric", fnames[0]]
     for i in range(1, len(fnames)): header.extend([fnames[i], "Delta"])
     if use_color: header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]


### PR DESCRIPTION
### Context
CLI

### Problem
The `mtg_analyze.py` tool used generic and technical column headers like `P1`, `P2`, and `Freq` in its analysis reports. This required users to manually map labels back to their input files during comparisons and used ambiguous abbreviations for statistical distributions.

### Solution
I implemented a dynamic labeling system that extracts clean dataset names from input filenames and standardized the terminology across all subcommands. Specifically:
- Added `_get_dataset_label` to generate meaningful column headers.
- Updated `asfan`, `mechanics`, `pips`, `actions`, and `mana` to use these dynamic labels in comparison views.
- Standardized the bar chart column header to "Distribution" throughout the script.
- Ensured consistency between single-dataset and comparison reports.

This improves feedback clarity and provides a more intuitive experience for power users comparing multiple datasets.

---
*PR created automatically by Jules for task [928581082135296864](https://jules.google.com/task/928581082135296864) started by @RainRat*