### PR TITLE
Expand functional action analysis to support X values and mass bounce

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -38,23 +38,23 @@ RECOGNIZED_MECHANICS = [
 ACTION_CATEGORIES = {
     'Removal': [
         r'\bdestroy\b', r'\bexile (target|each|all|any)\b', r'sacrifice (a|target|an)\b',
-        r'deals? [\d&^]+ damage to (target|each|any|any target) (creature|planeswalker|permanent|target|any)',
-        r'return (target|each) [^:]* to (its|their) owner\'s hand',
-        r'gets? \-&[\^]+/\-&[\^]+'
+        r'deals? [\d&^x]+ damage to (target|each|any|any target) (creature|planeswalker|permanent|target|any)',
+        r'return (target|each|all) [^:]* to (its|their) owner\'s hand',
+        r'gets? \-[\d&^x]+/\-[\d&^x]+'
     ],
     'Protection': [
         r'\bhexproof\b', r'\bindestructible\b', r'\bward\b', r'\bprotection from\b', r'\bshroud\b', r'\bregenerate\b'
     ],
     'Buffs': [
-        r'gets? \+&[\^]*/\+&[\^]*', r'put (a|&[\^]+) \+&[\^]*/\+&[\^]* counter',
+        r'gets? \+[\d&^x]*/\+[\d&^x]*', r'put (a|[\d&^x]+) \+[\d&^x]*/\+[\d&^x]* counter',
         r'target creature gets \+', r'creatures you control get \+'
     ],
     'Card Advantage': [
-        r'\bdraw(s|ing)? (a|&[\^]+) cards?\b', r'\bsearch your library\b', r'\breturn (target|a) card from your graveyard\b',
+        r'\bdraw(s|ing)? (a|[\d&^x]+) cards?\b', r'\bsearch your library\b', r'\breturn (target|a) card from your graveyard\b',
         r'\bexile .* you may (play|cast) .*\b'
     ],
     'Disruption': [
-        r'\bdiscard(s|ing)? (a|&[\^]+)?\b', r'\buncast target\b', r'\btap (target|all|each)\b',
+        r'\bdiscard(s|ing)? (a|[\d&^x]+)?\b', r'\buncast target\b', r'\btap (target|all|each)\b',
         r'can\'t (attack|block)', r'don\'t untap during (its|their) [^.]* untap step'
     ]
 }

--- a/tests/test_mtg_actions_expanded.py
+++ b/tests/test_mtg_actions_expanded.py
@@ -1,0 +1,82 @@
+import pytest
+from lib.cardlib import Card
+
+def test_x_damage_removal():
+    card = Card({
+        "name": "Fireball",
+        "manaCost": "{X}{R}",
+        "types": ["Sorcery"],
+        "text": "@ deals X damage to any target.",
+        "rarity": "uncommon"
+    })
+    assert "Removal" in card.actions
+
+def test_mass_bounce_removal():
+    card = Card({
+        "name": "River's Rebuke",
+        "manaCost": "{4}{U}{U}",
+        "types": ["Sorcery"],
+        "text": "Return all nonland permanents target player controls to their owner's hand.",
+        "rarity": "rare"
+    })
+    assert "Removal" in card.actions
+
+def test_x_pt_reduction_removal():
+    card = Card({
+        "name": "Death Wind",
+        "manaCost": "{X}{B}",
+        "types": ["Instant"],
+        "text": "Target creature gets -X/-X until end of turn.",
+        "rarity": "common"
+    })
+    assert "Removal" in card.actions
+
+def test_x_draw_card_advantage():
+    card = Card({
+        "name": "Blue Sun's Zenith",
+        "manaCost": "{X}{U}{U}{U}",
+        "types": ["Instant"],
+        "text": "Target player draws X cards. Shuffle @ into its owner's library.",
+        "rarity": "rare"
+    })
+    assert "Card Advantage" in card.actions
+
+def test_x_discard_disruption():
+    card = Card({
+        "name": "Mind Twist",
+        "manaCost": "{X}{B}",
+        "types": ["Sorcery"],
+        "text": "Target player discards X cards at random.",
+        "rarity": "rare"
+    })
+    assert "Disruption" in card.actions
+
+def test_x_buff():
+    card = Card({
+        "name": "Strength of the Tajuru",
+        "manaCost": "{X}{G}{G}",
+        "types": ["Instant"],
+        "text": "Multikicker {1}. Choose target creature, then choose another target creature for each time @ was kicked. Put X +1/+1 counters on each of them.",
+        "rarity": "rare"
+    })
+    assert "Buffs" in card.actions
+
+def test_x_static_buff():
+    card = Card({
+        "name": "Enlarge",
+        "manaCost": "{3}{G}{G}",
+        "types": ["Sorcery"],
+        "text": "Target creature gets +7/+7 and gains trample until end of turn.",
+        "rarity": "uncommon"
+    })
+    assert "Buffs" in card.actions
+
+def test_pt_reduction_literal_removal():
+    card = Card({
+        "name": "Dead Weight",
+        "manaCost": "{B}",
+        "types": ["Enchantment"],
+        "text": "Enchanted creature gets -2/-2.",
+        "rarity": "common"
+    })
+    assert "Removal" in card.actions


### PR DESCRIPTION
Identified and fixed several gaps in the mechanical action categorization logic. Specifically, the system previously missed variable 'X' values and literal numeric digits in damage, drawing, discarding, and stat-buffing effects. Additionally, mass bounce effects ("return all...") were not correctly identified as Removal.

Changes:
1.  **lib/cardlib.py:** Refined regex patterns in `ACTION_CATEGORIES` to use the `[\d&^x]+` character class, supporting raw numbers, encoded unary markers, and the 'X' variable.
2.  **lib/cardlib.py:** Updated the bounce regex to include the `all` keyword.
3.  **tests/test_mtg_actions_expanded.py:** New test file covering these previously unhandled edge cases with real-world card examples.

All tests passed, including the new suite and existing action tests.

---
*PR created automatically by Jules for task [2335631505002986537](https://jules.google.com/task/2335631505002986537) started by @RainRat*