### PR TITLE
[DOCS] Document missing mtg_query.py subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,8 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
+*   `reprints`: Find functional reprints (identical mechanics) of a reference card.
+*   `substitutes`: Find functional alternatives to a reference card.
 *   `superior`: Find cards that are generally better than a reference card.
 *   `inferior`: Find cards that are generally worse than a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
@@ -641,6 +643,35 @@ python3 scripts/mtg_query.py compare --set MOM --rarity rare
 
 # Compare cards in a specific file
 python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
+```
+
+---
+
+#### **Subcommand: `reprints`**
+Finds cards with identical mana cost, types, stats, and mechanics/text as the reference card, excluding the reference card itself.
+
+```bash
+# Find reprints of Grizzly Bears
+python3 scripts/mtg_query.py reprints "Grizzly Bears"
+
+# Find reprints of Lightning Bolt in a specific set
+python3 scripts/mtg_query.py reprints "Lightning Bolt" --set MOM
+```
+
+---
+
+#### **Subcommand: `substitutes`**
+Finds functional substitutes by identifying cards with shared types, compatible color identities (subset), similar mana costs (+/- 1), and overlapping functional actions (e.g., Removal, Card Advantage).
+
+```bash
+# Find substitutes for Lightning Bolt
+python3 scripts/mtg_query.py substitutes "Lightning Bolt"
+
+# Find budget (common/uncommon) substitutes for a rare card
+python3 scripts/mtg_query.py substitutes "Damnation" --rarity common --rarity uncommon
+
+# Find substitutes within a specific set
+python3 scripts/mtg_query.py substitutes "Counterspell" --set MOM
 ```
 
 ---


### PR DESCRIPTION
* **Type:** Documentation
* **What:** README.md
* **Why:** Documented the `reprints` and `substitutes` subcommands of `mtg_query.py` which were previously missing from the primary project documentation. This change improves feature discoverability by providing clear descriptions and CLI examples for finding functional reprints and alternatives.

---
*PR created automatically by Jules for task [15327450305927662107](https://jules.google.com/task/15327450305927662107) started by @RainRat*