### PR TITLE
[DOCS] Document missing mtg_query subcommands and analysis fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,8 +538,10 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
+*   `reprints`: Find functional reprints (identical mechanics and cost) of a reference card.
 *   `superior`: Find cards that are generally better than a reference card.
 *   `inferior`: Find cards that are generally worse than a reference card.
+*   `substitutes`: Find functional alternatives to a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -558,7 +560,7 @@ python3 scripts/mtg_query.py search data/AllPrintings.json --grep "Goblin" --fie
 # Find all mythic rares with CMC > 7 and save to a JSON file
 python3 scripts/mtg_query.py search data/AllPrintings.json --rarity mythic --cmc ">7" mythics.json
 ```
-*   **Fields:** `name`, `cost`, `cmc`, `type`, `stats`, `rarity`, `text`, `mechanics`, `set`, `complexity`, etc.
+*   **Fields:** `name`, `cost`, `cmc`, `type`, `stats`, `rarity`, `text`, `mechanics`, `identity`, `rating`, `fair_mv`, `set`, `complexity`, etc.
 *   **Formats:** `--table`, `--md-table`, `--json`, `--jsonl`, `--csv`, `--summary`.
 
 ---
@@ -645,6 +647,19 @@ python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
 
 ---
 
+#### **Subcommand: `reprints`**
+Finds cards with identical mana cost, types, stats, and mechanics as the reference card.
+
+```bash
+# Find reprints of Grizzly Bears
+python3 scripts/mtg_query.py reprints "Grizzly Bears"
+
+# Find reprints of Lightning Bolt in a specific set
+python3 scripts/mtg_query.py reprints "Lightning Bolt" --set MOM
+```
+
+---
+
 #### **Subcommand: `superior`**
 Identifies cards that are generally better than a reference card by comparing mana cost, stats, and abilities. A card is considered superior if it has easier or identical mana cost, better or equal stats, and its abilities include all of the reference card's mechanics and actions.
 
@@ -670,6 +685,22 @@ python3 scripts/mtg_query.py inferior "Black Vise"
 
 # Find worse cards in a specific set
 python3 scripts/mtg_query.py inferior "Lightning Bolt" --set MOM
+```
+
+---
+
+#### **Subcommand: `substitutes`**
+Finds functional substitutes by identifying cards with shared types, compatible color identities, similar mana costs (+/- 1), and overlapping functional actions (e.g., Removal, Card Advantage).
+
+```bash
+# Find substitutes for Lightning Bolt
+python3 scripts/mtg_query.py substitutes "Lightning Bolt"
+
+# Find budget (common/uncommon) substitutes for a rare card
+python3 scripts/mtg_query.py substitutes "Damnation" --rarity common --rarity uncommon
+
+# Find substitutes within a specific set
+python3 scripts/mtg_query.py substitutes "Counterspell" --set MOM
 ```
 
 ---
@@ -796,7 +827,7 @@ python3 scripts/mtg_analyze.py asfan data/AllPrintings.json --compare generated.
     *   `--csv`: Output results in CSV format.
     *   Supports standard **Advanced Filtering** flags and 'Smart Positional Argument Handling'.
 
-### `mtg_analyze.py interaction`
+### `mtg_analyze.py interaction` (alias: `synergy`)
 Analyzes how different mechanics (like Flying, Kicker, or Flashback) appear together on the same cards. It identifies frequent pairings and calculates a 'Lift Score' to measure if these mechanics appear together more often than expected by chance.
 ```bash
 # Analyze co-occurrence for a specific set


### PR DESCRIPTION
This PR improves the project documentation by adding missing CLI features to `README.md`. 

**Changes:**
1.  **New Subcommands:** Added detailed documentation and usage examples for `reprints` and `substitutes` in the `mtg_query.py` section.
2.  **Field Extraction:** Updated the `search` subcommand examples to include analysis and design fields like `identity`, `rating`, and `fair_mv`.
3.  **Command Aliases:** Noted that `synergy` is a valid alias for `mtg_analyze.py interaction`.

These updates help users discover and use all available features of the MTG Card Encoder toolkit.

---
*PR created automatically by Jules for task [6811419307079879063](https://jules.google.com/task/6811419307079879063) started by @RainRat*