### PR TITLE
Fix KeyError in mtg_analyze.py lexicon analysis

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -839,12 +839,12 @@ def handle_lexicon(args):
     cards1 = cli_utils.load_and_filter_cards(args)
     if not check_cards(cards1, args): return
     stats1 = analyze_lexicon(cards1, top=args.top, min_len=args.min_len)
-    if not stats1 or stats1['total'] == 0:
+    if not stats1 or stats1.get('total', 0) == 0:
         if not getattr(args, 'quiet', False):
             print("Insufficient card text.", file=sys.stderr)
         return
     stats2 = analyze_lexicon(cli_utils.load_and_filter_cards(argparse.Namespace(**{**vars(args), 'infile': args.compare})), top=args.top, min_len=args.min_len) if getattr(args, 'compare', None) else None
-    if stats2 is not None and stats2['total'] == 0:
+    if stats2 is not None and stats2.get('total', 0) == 0:
         if not getattr(args, 'quiet', False):
             print(f"Insufficient card text in {args.compare} for comparison.", file=sys.stderr)
     use_color = args.color if args.color is not None else (not (args.json or args.csv) and sys.stdout.isatty())


### PR DESCRIPTION
* **What:** Updated the `handle_lexicon` function in `scripts/mtg_analyze.py` to use `.get('total', 0)` when checking the results from `analyze_lexicon`.
* **Why:** The previous implementation directly accessed the `'total'` key, which caused a `KeyError` crash when analyzing empty datasets or datasets with insufficient card text (as `analyze_lexicon` returns an empty dictionary in those cases). This change ensures the tool robustly handles empty inputs by providing a user-friendly warning instead of crashing. It improves both the primary and comparison dataset checks for consistency.

---
*PR created automatically by Jules for task [8943416939977498467](https://jules.google.com/task/8943416939977498467) started by @RainRat*