### PR TITLE
[TEST] Improve and expand mana color production detection

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -885,7 +885,7 @@ class Card:
 
         color_map = {'white': 'W', 'blue': 'U', 'black': 'B', 'red': 'R', 'green': 'G', 'colorless': 'C'}
         for color_name, char in color_map.items():
-            if re.search(r'[Aa]dd\s+(?:one|two|three|[Xx])\s+' + color_name, text):
+            if re.search(r'[Aa]dd\s+(?:[Aa]n?|one|two|three|four|five|six|seven|eight|nine|ten|[Xx]|[\d]+)\s+' + color_name, text):
                 produced.add(char)
 
         if "treasure" in text or "gold token" in text:

--- a/tests/test_qa_produced_colors_gap.py
+++ b/tests/test_qa_produced_colors_gap.py
@@ -1,0 +1,59 @@
+import pytest
+from lib.cardlib import Card
+
+def test_produced_colors_numeric():
+    card = Card({
+        "name": "Test Land 1",
+        "types": ["Land"],
+        "text": "Add 1 white mana."
+    })
+    assert "W" in card.produced_colors
+
+def test_produced_colors_multiple_numeric():
+    card = Card({
+        "name": "Test Land 2",
+        "types": ["Land"],
+        "text": "Add 2 red mana."
+    })
+    assert "R" in card.produced_colors
+
+def test_produced_colors_number_words():
+    card = Card({
+        "name": "Test Land 3",
+        "types": ["Land"],
+        "text": "Add four blue mana."
+    })
+    assert "U" in card.produced_colors
+
+def test_produced_colors_x():
+    card = Card({
+        "name": "Test Land 4",
+        "types": ["Land"],
+        "text": "Add X green mana."
+    })
+    assert "G" in card.produced_colors
+
+def test_produced_colors_black():
+    card = Card({
+        "name": "Test Land 5",
+        "types": ["Land"],
+        "text": "Add 1 black mana."
+    })
+    assert "B" in card.produced_colors
+
+def test_produced_colors_colorless_numeric():
+    card = Card({
+        "name": "Test Land 6",
+        "types": ["Land"],
+        "text": "Add 2 colorless mana."
+    })
+    assert "C" in card.produced_colors
+
+def test_produced_colors_mixed_styles():
+    card = Card({
+        "name": "Test Land 7",
+        "types": ["Land"],
+        "text": "T: Add 1 green mana. Add {R}."
+    })
+    assert "G" in card.produced_colors
+    assert "R" in card.produced_colors


### PR DESCRIPTION
Expanded the regular expression in `Card.get_face_produced_colors` to recognize a wider range of mana quantity formats, including numeric digits and number words up to 'ten'. This ensures that cards with rules text like "Add 1 white mana" or "Add four blue mana" are correctly identified as producing those colors.

Added a new test suite `tests/test_qa_produced_colors_gap.py` to verify the fix and prevent future regressions.


---
*PR created automatically by Jules for task [12068677254233862842](https://jules.google.com/task/12068677254233862842) started by @RainRat*