### PR TITLE
[DOCS] Document missing mtg_query subcommands reprints and substitutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,9 +537,11 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `random`: Display one or more random cards matching the filters.
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
+*   `reprints`: Find functional reprints (identical mechanics) of a reference card.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
 *   `superior`: Find cards that are generally better than a reference card.
 *   `inferior`: Find cards that are generally worse than a reference card.
+*   `substitutes`: Find functional alternatives to a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -623,6 +625,19 @@ python3 scripts/mtg_query.py functional --dedupe unique_cards.json
 
 ---
 
+#### **Subcommand: `reprints`**
+Identifies functional reprints (cards with identical mana cost, types, stats, and mechanics) of a reference card.
+
+```bash
+# Find reprints of Grizzly Bears
+python3 scripts/mtg_query.py reprints "Grizzly Bears"
+
+# Find reprints of Lightning Bolt in a specific set
+python3 scripts/mtg_query.py reprints "Lightning Bolt" --set MOM
+```
+
+---
+
 #### **Subcommand: `compare`**
 Side-by-side card comparison for identifying design differences. Supports comparing any number of cards, fuzzy matching, and automatic similarity finding.
 
@@ -670,6 +685,22 @@ python3 scripts/mtg_query.py inferior "Black Vise"
 
 # Find worse cards in a specific set
 python3 scripts/mtg_query.py inferior "Lightning Bolt" --set MOM
+```
+
+---
+
+#### **Subcommand: `substitutes`**
+Finds functional alternatives to a reference card. It identifies cards with shared types, compatible color identities (subset), similar mana costs (+/- 1), and overlapping functional actions (e.g., Removal, Card Advantage).
+
+```bash
+# Find substitutes for Lightning Bolt
+python3 scripts/mtg_query.py substitutes "Lightning Bolt"
+
+# Find budget (common/uncommon) substitutes for a rare card
+python3 scripts/mtg_query.py substitutes "Damnation" --rarity common --rarity uncommon
+
+# Find substitutes within a specific set
+python3 scripts/mtg_query.py substitutes "Counterspell" --set MOM
 ```
 
 ---


### PR DESCRIPTION
This PR improves the project documentation by adding the missing `reprints` and `substitutes` subcommands of `mtg_query.py` to the `README.md` file.

**Changes:**
*   Added `reprints` and `substitutes` to the master list of `mtg_query.py` commands.
*   Added a detailed **Subcommand: `reprints`** section with a description and usage examples.
*   Added a detailed **Subcommand: `substitutes`** section with a description and usage examples.
*   Reordered the command list to match the section sequence for better navigation.

**Why:**
These subcommands are powerful features for finding identical cards or functional alternatives, but users were previously only able to discover them by exploring the CLI help. This update makes the tool more accessible and easier to use for everyone.

---
*PR created automatically by Jules for task [13340863808469299153](https://jules.google.com/task/13340863808469299153) started by @RainRat*