### PR TITLE
[TEST] Improve ANSI color mapping and test coverage for card symbols and rarities

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -676,6 +676,8 @@ class Ansi:
             return Ansi.BOLD + Ansi.RED
         if r_lower == 'special' or rarity == rarity_special_marker:
             return Ansi.BOLD + Ansi.MAGENTA
+        if r_lower == 'basic land' or rarity == rarity_basic_land_marker:
+            return Ansi.BOLD
         return Ansi.BOLD
 
     @staticmethod
@@ -684,18 +686,18 @@ class Ansi:
         if not color_sym:
             return Ansi.BOLD
         c = color_sym.upper()
-        if c == 'W':
+        if c in ['W', 'WHITE']:
             return Ansi.BOLD + Ansi.WHITE
-        if c == 'U':
+        if c in ['U', 'BLUE']:
             return Ansi.BOLD + Ansi.CYAN
-        if c == 'B':
+        if c in ['B', 'BLACK']:
             return Ansi.BOLD + Ansi.MAGENTA
-        if c == 'R':
+        if c in ['R', 'RED']:
             return Ansi.BOLD + Ansi.RED
-        if c == 'G':
+        if c in ['G', 'GREEN']:
             return Ansi.BOLD + Ansi.GREEN
-        if c == 'A' or 'COLORLESS' in c or 'LAND' in c:
-            return Ansi.BOLD + Ansi.CYAN # Standard for colorless/artifacts in this project
+        if c in ['A', 'C', 'S'] or 'COLORLESS' in c or 'LAND' in c or 'SNOW' in c:
+            return Ansi.BOLD + Ansi.CYAN # Standard for colorless/artifacts/snow in this project
         # Multicolored/Hybrid/Phyrexian: check for 'M' marker or mixed mana characters
         if c == 'M' or (len(c) > 1 and all(char in 'WUBRG2PSXCE/' for char in c) and any(char in 'WUBRG' for char in c)):
             return Ansi.BOLD + Ansi.YELLOW

--- a/tests/test_qa_ansi_colors_gap.py
+++ b/tests/test_qa_ansi_colors_gap.py
@@ -1,0 +1,24 @@
+from lib import utils
+
+def test_ansi_get_color_color_symbols_gap():
+    Ansi = utils.Ansi
+    # 'C' for Colorless and 'S' for Snow should be Cyan
+    assert Ansi.get_color_color('C') == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_color_color('S') == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_color_color('SNOW') == Ansi.BOLD + Ansi.CYAN
+
+def test_ansi_get_color_color_names_gap():
+    Ansi = utils.Ansi
+    # Full color names should be mapped correctly
+    assert Ansi.get_color_color('WHITE') == Ansi.BOLD + Ansi.WHITE
+    assert Ansi.get_color_color('BLUE') == Ansi.BOLD + Ansi.CYAN
+    assert Ansi.get_color_color('BLACK') == Ansi.BOLD + Ansi.MAGENTA
+    assert Ansi.get_color_color('RED') == Ansi.BOLD + Ansi.RED
+    assert Ansi.get_color_color('GREEN') == Ansi.BOLD + Ansi.GREEN
+
+def test_ansi_get_rarity_color_basic_land_gap():
+    Ansi = utils.Ansi
+    # Basic land rarity should be Bold
+    assert Ansi.get_rarity_color('basic land') == Ansi.BOLD
+    assert Ansi.get_rarity_color('Basic Land') == Ansi.BOLD
+    assert Ansi.get_rarity_color(utils.rarity_basic_land_marker) == Ansi.BOLD


### PR DESCRIPTION
* **Type:** New Coverage / Bug Fix
* **What:** Added support for Colorless ('C'), Snow ('S'/'SNOW'), and full color names (WHITE, BLUE, etc.) in `Ansi.get_color_color`. Also explicitly handled 'basic land' rarity in `Ansi.get_rarity_color`. Added a new test suite `tests/test_qa_ansi_colors_gap.py` to verify these mappings.
* **Why:** These symbols and names were previously falling back to a default bold style, which lacked proper semantic colorization in CLI reports and summaries. Explicitly mapping them ensures consistent and accurate visual output.

---
*PR created automatically by Jules for task [14107239568133071398](https://jules.google.com/task/14107239568133071398) started by @RainRat*