### PR TITLE
[DOCS] Standardize report headers to 'Distribution'

### DIFF
--- a/lib/datalib.py
+++ b/lib/datalib.py
@@ -246,12 +246,12 @@ def _print_mechanical_profile(mechanical_stats, total, use_color, vsize=None):
     if not mechanical_stats:
         return
     print()
-    print('  ' + color_line('Mechanical Profile (Frequency & Budget):', use_color))
+    print('  ' + color_line('Mechanical Profile (Distribution & Budget):', use_color))
 
     header = _colorize_header(['Mechanic', 'Count', 'Percent', 'Distribution', 'CMC', 'P/T'], use_color)
 
     rows = [header]
-    # Sort by frequency
+    # Sort by distribution
     sorted_mechanics = sorted(mechanical_stats.keys(), key=lambda m: mechanical_stats[m]['count'], reverse=True)
     if vsize:
         sorted_mechanics = sorted_mechanics[:vsize]
@@ -293,12 +293,12 @@ def _print_color_pie(pie_groups, pie_mechanics, all_mechanics, use_color, vsize=
     if not all_mechanics:
         return
     print()
-    print('  ' + color_line('Mechanical Color Pie (Frequency %):', use_color))
+    print('  ' + color_line('Mechanical Color Pie (Distribution %):', use_color))
 
     header = _colorize_header(['Mechanic', 'W', 'U', 'B', 'R', 'G', 'A', 'M'], use_color)
 
     rows = [header]
-    # Sort mechanics by total frequency
+    # Sort mechanics by total distribution
     sorted_mechanics = sorted(all_mechanics.keys(), key=lambda m: len(all_mechanics[m]), reverse=True)
     if vsize:
         sorted_mechanics = sorted_mechanics[:vsize]
@@ -343,7 +343,7 @@ def _print_lexical_analysis(word_counts, total_words, unique_words, ttr, avg_wor
     if not word_counts:
         return
     print()
-    print('  ' + color_line('Vocabulary & Lexicon (Word Frequency):', use_color))
+    print('  ' + color_line('Vocabulary & Lexicon (Word Distribution):', use_color))
 
     metrics = [
         ('Total Words', str(total_words)),
@@ -359,7 +359,7 @@ def _print_lexical_analysis(word_counts, total_words, unique_words, ttr, avg_wor
         print(f"    {label}: {val}")
     print()
 
-    header = _colorize_header(['Word', 'Count', 'Percent', 'Frequency'], use_color)
+    header = _colorize_header(['Word', 'Count', 'Percent', 'Distribution'], use_color)
     rows = [header]
 
     top_words = word_counts.most_common(vsize)
@@ -686,7 +686,7 @@ class Datamine:
                    + str(max(self.by_textlen)) + ' characters in length', use_color))
             print('  ' + color_line('Card text ranges from ' + str(min(self.by_textlines)) + ' to '
                    + str(max(self.by_textlines)) + ' lines', use_color))
-        _print_breakdown('Line counts by frequency:', self.by_textlines, len(self.allcards), use_color,
+        _print_breakdown('Line counts by distribution:', self.by_textlines, len(self.allcards), use_color,
                          vsize=vsize, sort_key=lambda x: len(self.by_textlines[x]))
         print()
 

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -689,7 +689,7 @@ def handle_pips(args):
                 print("INCLUDES RULES TEXT", file=target)
             print("  MANA PIP DISTRIBUTION", file=target)
             print("  ===============================", file=target)
-            print("  Symbol  Count  Percent  Frequency", file=target)
+            print("  Symbol  Count  Percent  Distribution", file=target)
             print("  ------  -----  -------  ------------", file=target)
             for r in res:
                 print(f"  {r['sym']:<6}  {r['cnt']:>5}  {r['pct']:>6.1f}%  [██████████]", file=target)
@@ -697,7 +697,7 @@ def handle_pips(args):
             if args.include_text:
                 print("  INCLUDES RULES TEXT")
             utils.print_header("MANA PIP DISTRIBUTION", count=len(cards), use_color=use_color)
-            rows = [[utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) if use_color else h for h in ["Symbol", "Count", "Percent", "Frequency"]]]
+            rows = [[utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) if use_color else h for h in ["Symbol", "Count", "Percent", "Distribution"]]]
             for r in res:
                 es = utils.mana_symall_encode.get(r['sym'], r['sym'])
                 rows.append([utils.from_mana("{"+es+"}", ansi_color=use_color), datalib.color_count(r['cnt'], use_color), f"{r['pct']:5.1f}%", datalib.get_bar_chart(r['pct'], use_color, color=utils.Ansi.get_color_color(r['sym']))])
@@ -759,7 +759,7 @@ def handle_mechanics(args):
     res = [{'name': m, 'c1': c1[m], 'p1': c1[m]/t1*100, 'c2': c2[m] if c2 else 0, 'p2': c2[m]/t2*100 if t2>0 else 0, 'delta': (c2[m]/t2*100 if t2>0 else 0) - c1[m]/t1*100 if c2 else 0} for m in ordered]
     res.sort(key=lambda x: x['name'].lower() if args.sort=='name' else x['c1'], reverse=args.reverse if args.sort=='name' else not args.reverse)
     if args.top > 0: res = res[:args.top]
-    utils.print_header("MECHANICAL COMPARISON" if c2 else "MECHANICAL FREQUENCY", count=len(cards1), use_color=use_color)
+    utils.print_header("MECHANICAL COMPARISON" if c2 else "MECHANICAL DISTRIBUTION", count=len(cards1), use_color=use_color)
     print(f"  Total Cards: {len(cards1)}")
     if c2:
         h = ["Mechanic", "% P1", "% P2", "Delta", "Ind"]
@@ -768,7 +768,7 @@ def handle_mechanics(args):
             d = r['delta']; ind = "▲" if d>0.1 else ("▼" if d<-0.1 else "•")
             rows.append([utils.colorize(r['name'], utils.Ansi.CYAN) if use_color else r['name'], f"{r['p1']:5.1f}%", f"{r['p2']:5.1f}%", utils.colorize(f"{d:+6.1f}%", utils.Ansi.GREEN if d>0.1 else utils.Ansi.RED) if use_color and abs(d)>0.1 else f"{d:+6.1f}%", utils.colorize(ind, utils.Ansi.GREEN if d>0.1 else utils.Ansi.RED) if use_color and abs(d)>0.1 else ind])
     else:
-        h = ["Mechanic", "Count", "Percent", "Frequency"]
+        h = ["Mechanic", "Count", "Percent", "Distribution"]
         rows = [[utils.colorize(x, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else x for x in h]]
         for r in res: rows.append([utils.colorize(r['name'], utils.Ansi.CYAN) if use_color else r['name'], str(r['c1']), f"{r['p1']:5.1f}%", datalib.get_bar_chart(r['p1'], use_color, color=utils.Ansi.CYAN)])
     datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','r','r','c'] if c2 else ['l','r','r','l']), indent=2)
@@ -818,12 +818,12 @@ def handle_actions(args):
     if args.json: print(json.dumps({'total': len(cards), 'total_cards': len(cards), 'summary': dict(act_c), 'color': {c: dict(v) for c, v in col_act.items()}}, indent=2))
     else:
         utils.print_header("CARD ACTION ANALYSIS", count=len(cards), use_color=use_color)
-        rows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ["Action", "Count", "Percent", "Frequency"]]]
+        rows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ["Action", "Count", "Percent", "Distribution"]]]
         for a, cnt in act_c.most_common():
             p = cnt/len(cards)*100
             rows.append([utils.colorize(a, utils.Ansi.CYAN) if use_color else a, datalib.color_count(cnt, use_color), f"{p:5.1f}%", datalib.get_bar_chart(p, use_color, color=utils.Ansi.BOLD+utils.Ansi.CYAN)])
         datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','r','l']), indent=4)
-        print(f"\n  {datalib.color_line('Actions by Color (Frequency %):', use_color)}")
+        print(f"\n  {datalib.color_line('Actions by Color (Distribution %):', use_color)}")
         ch = ["Action"] + list("WUBRGC")
         crows = [[utils.colorize(h, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else h for h in ch]]
         for a in sorted(ACTION_CATEGORIES.keys()):
@@ -1074,7 +1074,7 @@ def handle_asfan(args):
     utils.print_header("AS-FAN ANALYSIS" + (" (COMPARISON)" if a2 else ""), use_color=use_color)
     def pt(title, d1, d2, ks=None):
         print(f"  {datalib.color_line(title, use_color)}")
-        h = ["Metric", "P1"] + (["P2", "Delta"] if d2 else ["Freq"])
+        h = ["Metric", "P1"] + (["P2", "Delta"] if d2 else ["Dist"])
         rows = [[utils.colorize(x, utils.Ansi.BOLD+utils.Ansi.UNDERLINE) if use_color else x for x in h]]
         ks = ks or sorted(d1.keys())
         for k in ks:
@@ -1579,7 +1579,7 @@ def main():
     add_std(p_pi)
     p_pi.add_argument('outfile', nargs='?', default=None, help='Save pip distribution to a file.')
     p_pi.add_argument('--include-text', action='store_true', help='Include mana symbols found in rules text (e.g., activation costs).')
-    p_pi.add_argument('--sort', choices=['name','count'], default='count', help='Sort results by symbol name or frequency.')
+    p_pi.add_argument('--sort', choices=['name','count'], default='count', help='Sort results by symbol name or distribution.')
     p_pi.add_argument('--reverse', action='store_true', help='Reverse the sort order.')
     p_pi.set_defaults(func=handle_pips)
 
@@ -1590,9 +1590,9 @@ def main():
     p_co.set_defaults(func=handle_costs)
 
     # mechanics
-    p_me = subparsers.add_parser('mechanics', help='List recognized mechanics and calculate their frequency.')
+    p_me = subparsers.add_parser('mechanics', help='List recognized mechanics and calculate their distribution.')
     add_std(p_me)
-    p_me.add_argument('--compare', '-c', help='Compare frequencies with a second dataset.')
+    p_me.add_argument('--compare', '-c', help='Compare distributions with a second dataset.')
     p_me.add_argument('--sort', choices=['name','count'], default='name', help='Sort mechanics by name or count.')
     p_me.add_argument('--reverse', action='store_true', help='Reverse the sort order.')
     p_me.add_argument('--top', type=int, default=0, help='Limit the number of mechanics shown.')

--- a/tests/test_mtg_mechanics.py
+++ b/tests/test_mtg_mechanics.py
@@ -28,7 +28,7 @@ class TestMtgMechanics(unittest.TestCase):
             with patch('sys.argv', ['mtg_analyze.py', 'mechanics', 'testdata/uthros.json', '--no-color']):
                 mechanics_main()
                 output = fake_out.getvalue()
-                self.assertIn("MECHANICAL FREQUENCY", output)
+                self.assertIn("MECHANICAL DISTRIBUTION", output)
                 self.assertIn("Total Cards: 1", output)
                 # Uthros has Flying and Station
                 self.assertIn("Flying", output)
@@ -54,7 +54,7 @@ class TestMtgMechanics(unittest.TestCase):
             with patch('sys.argv', ['mtg_analyze.py', 'mechanics', 'testdata/uthros.json', '--sort', 'count', '--limit', '1', '--no-color']):
                 mechanics_main()
                 output = fake_out.getvalue()
-                self.assertIn("MECHANICAL FREQUENCY", output)
+                self.assertIn("MECHANICAL DISTRIBUTION", output)
                 # Header + separator + 1 row = 3 rows in data area usually,
                 # but let's just ensure it doesn't crash and contains at least one mechanic.
 
@@ -94,7 +94,7 @@ class TestMtgMechanics(unittest.TestCase):
             with patch('sys.argv', ['mtg_analyze.py', 'mechanics', 'testdata/uthros.json', '--quiet', '--no-color']):
                 mechanics_main()
                 output = fake_out.getvalue()
-                self.assertIn("MECHANICAL FREQUENCY", output)
+                self.assertIn("MECHANICAL DISTRIBUTION", output)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Standardized user-facing report headers and help text to use "Distribution" (or "Dist") instead of "Frequency" (or "Freq") for bar charts and percentage-based data. This improves clarity by distinguishing relative spreads from absolute counts, following the project's 'No Jargon' and clarity guidelines.

**Changes:**
*   **scripts/mtg_analyze.py**: Updated headers in `handle_pips`, `handle_mechanics`, `handle_actions`, and `handle_asfan`. Updated help text for `mechanics` and `pips` commands.
*   **lib/datalib.py**: Updated descriptive report titles and column headers in `_print_mechanical_profile`, `_print_color_pie`, `_print_lexical_analysis`, and `Datamine.summarize`.
*   **tests/test_mtg_mechanics.py**: Updated assertions to match the new "MECHANICAL DISTRIBUTION" header.

---
*PR created automatically by Jules for task [12348482421292827113](https://jules.google.com/task/12348482421292827113) started by @RainRat*