### PR TITLE
[FEAT] Index-based navigation and selection for mtg_query shell

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -65,6 +65,7 @@ FIELD_MAP = {
     'legendary': {'header': 'Legendary', 'align': 'l', 'aliases': []},
     'permanent': {'header': 'Permanent', 'align': 'l', 'aliases': []},
     'signature': {'header': 'Signature', 'align': 'l', 'aliases': ['unique', 'diff', 'diffs']},
+    'index': {'header': '#', 'align': 'r', 'aliases': ['#', 'idx', 'num', 'row']},
     'encoded': {'header': 'Encoded', 'align': 'l', 'aliases': []},
 }
 
@@ -233,6 +234,11 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
         return card.summary(ansi_color=ansi_color).replace('\u2014', '-')
     elif canon == 'signature':
         return ""
+    elif canon == 'index':
+        res = str(getattr(card, '_index', ''))
+        if ansi_color and res:
+            res = utils.colorize(res, utils.Ansi.BOLD + utils.Ansi.YELLOW)
+        return res
     elif canon == 'encoded':
         return card.encode()
     else:
@@ -250,7 +256,7 @@ def get_field_value(card, field, ansi_color=False, multi_sep=" // "):
 
 def handle_search(args):
     cards = cli_utils.load_and_filter_cards(args)
-    _execute_search(cards, args)
+    return _execute_search(cards, args)
 
 def _build_search_map(cards):
     search_map = {}
@@ -281,8 +287,12 @@ def _build_search_map(cards):
             curr = curr.bside
     return search_map
 
-def _execute_search(cards, args):
+def _execute_search(cards, args, include_indices=False):
     total_matches = len(cards)
+    use_color = args.color if args.color is not None else sys.stdout.isatty()
+
+    for i, c in enumerate(cards):
+        c._index = i + 1
     
     if not cards:
         if not args.quiet:
@@ -302,9 +312,11 @@ def _execute_search(cards, args):
                     if orig not in seen:
                         print(f"  - {orig}", file=sys.stderr)
                         seen.add(orig)
-        return
+        return []
 
     field_list = [f.strip() for f in args.fields.split(',')]
+    if include_indices and 'index' not in [get_field_canonical_name(f) for f in field_list]:
+        field_list.insert(0, 'index')
     invalid_fields = [f for f in field_list if get_field_canonical_name(f) not in FIELD_MAP]
     if invalid_fields and not args.quiet:
         print(f"Warning: Unrecognized fields: {', '.join(invalid_fields)}", file=sys.stderr)
@@ -428,6 +440,7 @@ def _execute_search(cards, args):
                         f.write("  " + line + '\n')
             else:
                 datalib.printrows(padded, indent=2)
+        return cards
     elif getattr(args, 'summary', False):
         if getattr(args, 'outfile', None):
             with open(args.outfile, 'w') as f:
@@ -435,7 +448,14 @@ def _execute_search(cards, args):
                     f.write(get_field_value(c, 'summary', ansi_color=False) + '\n')
         else:
             for c in cards:
-                print(get_field_value(c, 'summary', ansi_color=use_color))
+                idx_prefix = ""
+                if include_indices:
+                    idx_val = str(getattr(c, '_index', ''))
+                    if use_color:
+                        idx_val = utils.colorize(idx_val, utils.Ansi.BOLD + utils.Ansi.YELLOW)
+                    idx_prefix = f"[{idx_val}] "
+                print(idx_prefix + get_field_value(c, 'summary', ansi_color=use_color))
+        return cards
     else:
         if getattr(args, 'outfile', None):
             with open(args.outfile, 'w') as f:
@@ -446,6 +466,7 @@ def _execute_search(cards, args):
             for c in cards:
                 line = args.delimiter.join([get_field_value(c, f, ansi_color=use_color) for f in field_list])
                 print(line)
+        return cards
 
 # --- Oracle Logic (from mtg_oracle.py) ---
 
@@ -457,13 +478,16 @@ def handle_oracle(args):
         args.infile = temp
 
     cards = cli_utils.load_and_filter_cards(args)
-    _execute_oracle(cards, args)
+    return _execute_oracle(cards, args)
 
-def _execute_oracle(cards, args):
+def _execute_oracle(cards, args, include_indices=False):
     if not cards:
         if not args.quiet:
             print("No cards found matching the criteria.", file=sys.stderr)
-        return
+        return []
+
+    for i, c in enumerate(cards):
+        c._index = i + 1
 
     use_color = args.color if args.color is not None else sys.stdout.isatty()
     if getattr(args, 'sort', None):
@@ -556,8 +580,7 @@ def _execute_oracle(cards, args):
     if any(getattr(args, f, False) for f in search_formats) or getattr(args, 'outfile', None):
         if not hasattr(args, 'fields'):
             args.fields = 'name,cost,type,stats,rarity,text'
-        _execute_search(display_cards, args)
-        return
+        return _execute_search(display_cards, args)
 
     prelimit_count = len(display_cards)
     if args.limit > 0:
@@ -575,13 +598,20 @@ def _execute_oracle(cards, args):
         utils.print_header(header_title, count=count_str, use_color=use_color)
 
     for c in display_cards:
+        idx_prefix = ""
+        if include_indices:
+            idx_val = str(getattr(c, '_index', ''))
+            if use_color:
+                idx_val = utils.colorize(idx_val, utils.Ansi.BOLD + utils.Ansi.YELLOW)
+            idx_prefix = f"[{idx_val}] "
+
         if getattr(args, 'gatherer', False):
-            print("  " + c.format(gatherer=True, ansi_color=use_color).replace('\n', '\n  '))
+            print("  " + idx_prefix + c.format(gatherer=True, ansi_color=use_color).replace('\n', '\n  '))
         elif show_summary:
-            print("  " + c.summary(ansi_color=use_color).replace('\u2014', '-'))
+            print("  " + idx_prefix + c.summary(ansi_color=use_color).replace('\u2014', '-'))
         else:
             # Detailed View
-            print("  " + c.header(ansi_color=use_color).replace('\u2014', '-'))
+            print("  " + idx_prefix + c.header(ansi_color=use_color).replace('\u2014', '-'))
 
             def print_face(face, is_bside=False):
                 if is_bside:
@@ -751,6 +781,7 @@ def _execute_oracle(cards, args):
                         date = utils.colorize(date, utils.Ansi.BOLD)
                     print(f"  - {date}: {text}")
             print()
+    return display_cards
 
 # --- Shell Logic ---
 
@@ -761,6 +792,21 @@ def handle_shell(args):
         if not args.quiet:
             print("Error: Could not load card database.", file=sys.stderr)
         return
+
+    last_results = []
+
+    def _resolve_args(cmd_args):
+        resolved = []
+        for arg in cmd_args:
+            if arg.isdigit():
+                idx = int(arg)
+                if 1 <= idx <= len(last_results):
+                    resolved.append(last_results[idx-1].name)
+                else:
+                    resolved.append(arg)
+            else:
+                resolved.append(arg)
+        return resolved
 
     # Set up tab completion and history
     try:
@@ -820,7 +866,8 @@ def handle_shell(args):
         welcome = utils.colorize(welcome, utils.Ansi.BOLD + utils.Ansi.CYAN)
     print(welcome)
     print("Type a card name for official rules text, or /search for bulk queries.")
-    print("Type '/help' for commands, or 'exit' to leave.\n")
+    print("Type '/help' for commands, or 'exit' to leave.")
+    print("Tip: You can use numeric indices from the last search result (e.g. typing '1').\n")
 
     prompt = "mtg> "
     if use_color:
@@ -834,9 +881,18 @@ def handle_shell(args):
             if line.lower() in ['exit', 'quit', '/exit', '/quit', 'q', '/q']:
                 break
 
-            if line.startswith('/clear'):
+            if line.lower() in ['/clear', '/cls']:
                 os.system('cls' if os.name == 'nt' else 'clear')
                 continue
+
+            if line.isdigit():
+                idx = int(line)
+                if 1 <= idx <= len(last_results):
+                    o_args = copy.copy(args)
+                    o_args.query = last_results[idx-1].name
+                    if not hasattr(o_args, 'limit'): o_args.limit = 0
+                    _execute_oracle(all_cards, o_args)
+                    continue
 
             if line.startswith('/'):
                 try:
@@ -848,6 +904,7 @@ def handle_shell(args):
                 cmd_args = parts[1:]
 
                 if cmd in ['/search', '/s']:
+                    cmd_args = _resolve_args(cmd_args)
                     query = " ".join(cmd_args)
                     query_pat = re.compile(re.escape(query.replace('-', utils.dash_marker)), re.IGNORECASE)
                     matched_cards = [c for c in all_cards if c.search(query_pat)]
@@ -856,12 +913,13 @@ def handle_shell(args):
                     s_args.fields = getattr(args, 'fields', 'name,cost,type,stats,rarity')
                     s_args.table = True
                     if not hasattr(s_args, 'limit'): s_args.limit = 0
-                    _execute_search(matched_cards, s_args)
+                    last_results = _execute_search(matched_cards, s_args, include_indices=True)
                 elif cmd in ['/oracle', '/o']:
+                    cmd_args = _resolve_args(cmd_args)
                     o_args = copy.copy(args)
                     o_args.query = " ".join(cmd_args)
                     if not hasattr(o_args, 'limit'): o_args.limit = 0
-                    _execute_oracle(all_cards, o_args)
+                    last_results = _execute_oracle(all_cards, o_args, include_indices=True)
                 elif cmd in ['/random', '/r']:
                     if not all_cards:
                         err_msg = "No cards loaded."
@@ -877,11 +935,12 @@ def handle_shell(args):
                     sampled = random.sample(all_cards, min(count, len(all_cards)))
                     r_args = copy.copy(args)
                     r_args.query = None
+                    r_args.count = count
                     if not hasattr(r_args, 'limit'): r_args.limit = 0
-                    _execute_oracle(sampled, r_args)
+                    last_results = handle_random(r_args, include_indices=True)
                 elif cmd in ['/sets', '/st']:
                     st_args = copy.copy(args)
-                    st_args.grep = cmd_args
+                    st_args.grep = _resolve_args(cmd_args)
                     st_args.sort = 'date'
                     st_args.reverse = False
                     st_args.limit = 0
@@ -893,11 +952,11 @@ def handle_shell(args):
                     handle_sets(st_args)
                 elif cmd in ['/functional', '/f']:
                     f_args = copy.copy(args)
-                    f_args.grep = cmd_args
-                    handle_functional(f_args)
+                    f_args.grep = _resolve_args(cmd_args)
+                    last_results = handle_functional(f_args, include_indices=True)
                 elif cmd in ['/compare', '/c']:
                     c_args = copy.copy(args)
-                    c_args.names = cmd_args
+                    c_args.names = _resolve_args(cmd_args)
                     handle_compare_cards(c_args)
                 elif cmd in ['/reprints', '/rep']:
                     if not cmd_args:
@@ -906,8 +965,8 @@ def handle_shell(args):
                         print(err_msg)
                         continue
                     rep_args = copy.copy(args)
-                    rep_args.query = " ".join(cmd_args)
-                    handle_reprints(rep_args)
+                    rep_args.query = " ".join(_resolve_args(cmd_args))
+                    last_results = handle_reprints(rep_args, include_indices=True)
                 elif cmd in ['/superior', '/sup']:
                     if not cmd_args:
                         err_msg = "Error: /superior requires a card name."
@@ -915,8 +974,8 @@ def handle_shell(args):
                         print(err_msg)
                         continue
                     sup_args = copy.copy(args)
-                    sup_args.query = " ".join(cmd_args)
-                    handle_superior(sup_args)
+                    sup_args.query = " ".join(_resolve_args(cmd_args))
+                    last_results = handle_superior(sup_args, include_indices=True)
                 elif cmd in ['/inferior', '/inf']:
                     if not cmd_args:
                         err_msg = "Error: /inferior requires a card name."
@@ -924,8 +983,8 @@ def handle_shell(args):
                         print(err_msg)
                         continue
                     inf_args = copy.copy(args)
-                    inf_args.query = " ".join(cmd_args)
-                    handle_inferior(inf_args)
+                    inf_args.query = " ".join(_resolve_args(cmd_args))
+                    last_results = handle_inferior(inf_args, include_indices=True)
                 elif cmd in ['/substitutes', '/sub']:
                     if not cmd_args:
                         err_msg = "Error: /substitutes requires a card name."
@@ -933,8 +992,8 @@ def handle_shell(args):
                         print(err_msg)
                         continue
                     sub_args = copy.copy(args)
-                    sub_args.query = " ".join(cmd_args)
-                    handle_substitutes(sub_args)
+                    sub_args.query = " ".join(_resolve_args(cmd_args))
+                    last_results = handle_substitutes(sub_args, include_indices=True)
                 elif cmd in ['/extract', '/e']:
                     if len(cmd_args) < 2:
                         err_msg = "Error: /extract requires <set_code> and <card_name>."
@@ -975,9 +1034,11 @@ def handle_shell(args):
                     fmt_cmd("/superior <n>", "/sup", "Find cards generally better than the named card.")
                     fmt_cmd("/inferior <n>", "/inf", "Find cards generally worse than the named card.")
                     fmt_cmd("/extract <s> <n>", "/e", "Extract raw card JSON by set code and name.")
-                    fmt_cmd("/clear", None, "Clear the terminal screen.")
+                    fmt_cmd("/clear", "/cls", "Clear the terminal screen.")
                     fmt_cmd("/help", "/h, /?", "Show this help message.")
                     fmt_cmd("/exit", "/quit, /q", "Exit the interactive shell.")
+                    print("  Note: You can use numeric indices (e.g. '1', '2') in place of card names")
+                    print("        for any command, referring to the results of the last search.")
                     print()
                 else:
                     err_msg = f"Unknown command: {cmd}. Type /help for assistance."
@@ -988,7 +1049,7 @@ def handle_shell(args):
                 o_args = copy.copy(args)
                 o_args.query = line
                 if not hasattr(o_args, 'limit'): o_args.limit = 0
-                _execute_oracle(all_cards, o_args)
+                last_results = _execute_oracle(all_cards, o_args, include_indices=True)
         except EOFError:
             print()
             break
@@ -1219,10 +1280,10 @@ def get_functional_key(card):
         key = (key, get_functional_key(card.bside))
     return key
 
-def handle_functional(args):
+def handle_functional(args, include_indices=False):
     cards = cli_utils.load_and_filter_cards(args)
     if not cards:
-        return
+        return []
 
     groups = defaultdict(list)
     for card in cards:
@@ -1237,8 +1298,7 @@ def handle_functional(args):
         if args.dedupe != '-':
             args.outfile = args.dedupe
 
-        _execute_search(unique_cards, args)
-        return
+        return _execute_search(unique_cards, args, include_indices=include_indices)
 
     functional_reprints = []
     for key, group in groups.items():
@@ -1249,7 +1309,7 @@ def handle_functional(args):
     if not functional_reprints:
         if not args.quiet:
             print("No cards with the same mechanics found.", file=sys.stderr)
-        return
+        return []
 
     if not args.quiet:
         print("Check for cards with the same mechanics complete.", file=sys.stderr)
@@ -1276,6 +1336,8 @@ def handle_functional(args):
             print("-" * 20)
             print(group[0].summary(ansi_color=use_color).replace('\u2014', '-'))
             print()
+
+        return [g[0] for g in functional_reprints]
 
 def is_superior(candidate, target):
     if candidate.name.lower() == target.name.lower():
@@ -1422,25 +1484,25 @@ def _resolve_target_from_args(args):
 
     return target_card, cards
 
-def handle_superior(args):
+def handle_superior(args, include_indices=False):
     target_card, cards = _resolve_target_from_args(args)
     if not target_card:
-        return
+        return []
 
     superior_cards = [c for c in cards if is_superior(c, target_card)]
 
     if not superior_cards:
         if not args.quiet:
             print(f"No cards found that are superior to {target_card.display_name}.", file=sys.stderr)
-        return
+        return []
 
     # Use search display for results
-    _execute_search(superior_cards, args)
+    return _execute_search(superior_cards, args, include_indices=include_indices)
 
-def handle_inferior(args):
+def handle_inferior(args, include_indices=False):
     target_card, cards = _resolve_target_from_args(args)
     if not target_card:
-        return
+        return []
 
     # A card is inferior if the target card is superior to it
     inferior_cards = [c for c in cards if is_superior(target_card, c)]
@@ -1448,15 +1510,15 @@ def handle_inferior(args):
     if not inferior_cards:
         if not args.quiet:
             print(f"No cards found that are inferior to {target_card.display_name}.", file=sys.stderr)
-        return
+        return []
 
     # Use search display for results
-    _execute_search(inferior_cards, args)
+    return _execute_search(inferior_cards, args, include_indices=include_indices)
 
-def handle_reprints(args):
+def handle_reprints(args, include_indices=False):
     target_card, cards = _resolve_target_from_args(args)
     if not target_card:
-        return
+        return []
 
     target_key = get_functional_key(target_card)
     reprints = [c for c in cards if get_functional_key(c) == target_key and c.name.lower() != target_card.name.lower()]
@@ -1464,10 +1526,10 @@ def handle_reprints(args):
     if not reprints:
         if not args.quiet:
             print(f"No functional reprints found for {target_card.display_name}.", file=sys.stderr)
-        return
+        return []
 
     # Use search display for results
-    _execute_search(reprints, args)
+    return _execute_search(reprints, args, include_indices=include_indices)
 
 def find_substitutes(target, pool, limit=10):
     """Finds functional alternatives to a reference card."""
@@ -1534,10 +1596,10 @@ def find_substitutes(target, pool, limit=10):
     final_ranked.sort(key=lambda x: x[0], reverse=True)
     return [c for score, c in final_ranked[:limit]]
 
-def handle_substitutes(args):
+def handle_substitutes(args, include_indices=False):
     target_card, cards = _resolve_target_from_args(args)
     if not target_card:
-        return
+        return []
 
     limit = getattr(args, 'limit', 10) or 10
     subs = find_substitutes(target_card, cards, limit=limit)
@@ -1545,12 +1607,12 @@ def handle_substitutes(args):
     if not subs:
         if not args.quiet:
             print(f"No suitable substitutes found for {target_card.display_name}.", file=sys.stderr)
-        return
+        return []
 
     # Use search display for results
-    _execute_search(subs, args)
+    return _execute_search(subs, args, include_indices=include_indices)
 
-def handle_random(args):
+def handle_random(args, include_indices=False):
     # Smart Positional Argument Handling
     if args.count and not str(args.count).isdigit() and os.path.exists(str(args.count)) and args.infile == '-':
         args.infile = str(args.count)
@@ -1560,7 +1622,7 @@ def handle_random(args):
     if not cards:
         if not args.quiet:
             print("No cards found matching the criteria.", file=sys.stderr)
-        return
+        return []
 
     try:
         count = int(args.count)
@@ -1570,16 +1632,16 @@ def handle_random(args):
         count = len(cards)
 
     if count <= 0:
-        return
+        return []
 
     sampled = random.sample(cards, count)
 
     # If any search-specific output format is requested, use search display
     search_formats = ['json', 'jsonl', 'csv', 'table', 'md_table', 'summary', 'text']
     if any(getattr(args, f, False) for f in search_formats) or getattr(args, 'outfile', None):
-        _execute_search(sampled, args)
+        return _execute_search(sampled, args, include_indices=include_indices)
     else:
-        _execute_oracle(sampled, args)
+        return _execute_oracle(sampled, args, include_indices=include_indices)
 
 # --- Compare Logic ---
 


### PR DESCRIPTION
Implemented index-based navigation and selection in the `scripts/mtg_query.py` interactive shell. This allows users to reference cards from the most recent search results using numeric indices (e.g., typing '1' or '/compare 1 2') instead of typing full names. Also added `/clear` and `/cls` commands to the shell and fixed a bug in argument propagation for the `/random` command.

---
*PR created automatically by Jules for task [14501314587444021587](https://jules.google.com/task/14501314587444021587) started by @RainRat*