### PR TITLE
Remove redundant assignment in mtg_query.py

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -289,7 +289,6 @@ def _build_search_map(cards):
 
 def _execute_search(cards, args, include_indices=False):
     total_matches = len(cards)
-    use_color = args.color if args.color is not None else sys.stdout.isatty()
 
     for i, c in enumerate(cards):
         c._index = i + 1


### PR DESCRIPTION
* **What:** Removed a redundant assignment of the `use_color` variable in the `_execute_search` function within `scripts/mtg_query.py`.
* **Why:** The variable was calculated at the beginning of the function and then recalculated with the exact same logic later on, before its first actual use. Removing the redundant first assignment improves code clarity and efficiency without any change in behavior. Verified with existing tests.

---
*PR created automatically by Jules for task [11281335268890843072](https://jules.google.com/task/11281335268890843072) started by @RainRat*