### PR TITLE
[TEST] Expand token extraction and utility coverage

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -192,7 +192,7 @@ def extract_tokens_from_text(text):
     text = text.replace('\n', ' ').strip()
     # 1. Regex for creature tokens with P/T and optional abilities
     # Supports both singular and multiple tokens (e.g., "Create two... and a...")
-    c_regex = r"(?:[Cc]reate[sd]?|and)\s+(?:[Aa]n?|two|three|four|five|six|seven|eight|nine|ten|X)\s+([0-9/X+&^]+)\s+([a-zA-Z\s,]+?)\s+token[s]?(?:\s+with\s+([^,.]+?))?(?=(?:\s*(?:and|[,.])|$))"
+    c_regex = r"(?:[Cc]reate[sd]?|and)\s+(?:[Aa]n?|two|three|four|five|six|seven|eight|nine|ten|X)\s+([0-9/X+&^]+)\s+([-a-zA-Z\s,]+?)\s+token[s]?(?:\s+with\s+([^,.]+?))?(?=(?:\s*(?:and|[,.])|$))"
     for m in re.finditer(c_regex, text, re.IGNORECASE):
         pt, ct, ab = m.group(1), m.group(2).strip(), m.group(3).strip() if m.group(3) else ""
         if ct.lower().endswith(' creature'): ct = ct[:-9]
@@ -203,11 +203,11 @@ def extract_tokens_from_text(text):
         found.append({'name': f"{pt} {', '.join(cols) if cols else 'Colorless'} {ty} Token", 'pt': pt, 'color': ", ".join(cols) if cols else "Colorless", 'type': f"{ty} Creature".strip(), 'abilities': ab})
 
     # 2. Regex for predefined tokens (Treasure, Food, etc.)
-    ntks = ['Treasure','Food','Clue','Blood','Map','Role','Incubator','Powerstone','Walker']
-    n_regex = r"(?:[Cc]reate[sd]?)\s+(?:[Aa]n?|two|three|four|five|X)\s+(" + "|".join(ntks) + r")\s+token[s]?"
+    ntks = ['Treasure','Food','Clue','Blood','Map','Role','Incubator','Powerstone','Walker','Gold']
+    n_regex = r"(?:[Cc]reate[sd]?)\s+(?:[Aa]n?|two|three|four|five|six|seven|eight|nine|ten|X)\s+(" + "|".join(ntks) + r")\s+token[s]?"
     for m in re.finditer(n_regex, text, re.IGNORECASE):
         n = m.group(1).capitalize(); t = {'name': f"{n} Token", 'pt': "", 'color': "Colorless", 'type': n, 'abilities': ""}
-        if n=='Treasure': t['type']='Artifact'; t['abilities']='Sacrifice this artifact: Add one mana of any color.'
+        if n in ['Treasure', 'Gold']: t['type']='Artifact'; t['abilities']='Sacrifice this artifact: Add one mana of any color.'
         elif n=='Food': t['type']='Artifact'; t['abilities']='{2}, {T}, Sacrifice this artifact: gain 3 life.'
         elif n=='Clue': t['type']='Artifact'; t['abilities']='{2}, Sac: Draw a card.'
         found.append(t)

--- a/tests/test_cap_coverage.py
+++ b/tests/test_cap_coverage.py
@@ -1,0 +1,32 @@
+from lib.cardlib import cap
+from lib import utils
+
+def test_cap_basic():
+    assert cap("hello") == "Hello"
+
+def test_cap_with_mana_at_start():
+    assert cap("{2U} remove a counter") == "{2U} Remove a counter"
+
+def test_cap_with_choice_at_start():
+    assert cap("[choice] text") == "[Choice] Text"
+
+def test_cap_empty():
+    assert cap("") == ""
+
+def test_cap_no_alpha():
+    assert cap("{2}") == "{2}"
+
+def test_cap_this_marker():
+    assert cap("@ does something") == "@ does something"
+
+def test_cap_reserved_marker():
+    assert cap("\v does something") == "\v does something"
+
+def test_cap_mana_and_markers():
+    assert cap("{t}: @ does something") == "{T}: @ does something"
+
+def test_cap_only_choice():
+    assert cap("[choice]") == "[Choice]"
+
+def test_cap_choice_unclosed():
+    assert cap("[abc") == "[Abc"

--- a/tests/test_token_extraction_enhanced.py
+++ b/tests/test_token_extraction_enhanced.py
@@ -1,0 +1,70 @@
+from lib.cardlib import extract_tokens_from_text
+
+def test_extract_predefined_tokens_quantities():
+    text_six = "Create six Treasure tokens."
+    tokens_six = extract_tokens_from_text(text_six)
+    assert len(tokens_six) == 1
+    assert tokens_six[0]['name'] == "Treasure Token"
+
+    text_ten = "Create ten Food tokens."
+    tokens_ten = extract_tokens_from_text(text_ten)
+    assert len(tokens_ten) == 1
+    assert tokens_ten[0]['name'] == "Food Token"
+
+    text_x = "Create X Clue tokens."
+    tokens_x = extract_tokens_from_text(text_x)
+    assert len(tokens_x) == 1
+    assert tokens_x[0]['name'] == "Clue Token"
+
+def test_extract_gold_tokens():
+    text = "Create a Gold token."
+    tokens = extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "Gold Token"
+    assert tokens[0]['type'] == "Artifact"
+    assert "Add one mana of any color" in tokens[0]['abilities']
+
+    text_multi = "Create three Gold tokens."
+    tokens_multi = extract_tokens_from_text(text_multi)
+    assert len(tokens_multi) == 1
+    assert tokens_multi[0]['name'] == "Gold Token"
+
+def test_extract_creature_tokens_complex():
+    text = "Create a 2/2 white Knight creature token with vigilance."
+    tokens = extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert tokens[0]['name'] == "2/2 White Knight Token"
+    assert tokens[0]['pt'] == "2/2"
+    assert tokens[0]['color'] == "White"
+    assert tokens[0]['type'] == "Knight Creature"
+    assert tokens[0]['abilities'] == "vigilance"
+
+    text_multi = "Create a 1/1 blue and red Elemental creature token."
+    tokens_multi = extract_tokens_from_text(text_multi)
+    assert len(tokens_multi) == 1
+    assert "Blue" in tokens_multi[0]['color']
+    assert "Red" in tokens_multi[0]['color']
+    assert tokens_multi[0]['type'] == "Elemental Creature"
+
+def test_extract_multiple_token_types():
+    text = "Create a Treasure token and a 1/1 green Saproling creature token."
+    tokens = extract_tokens_from_text(text)
+    assert len(tokens) == 2
+    names = [t['name'] for t in tokens]
+    assert "Treasure Token" in names
+    assert "1/1 Green Saproling Token" in names
+
+def test_extract_token_with_hyphenated_type():
+    text = "Create a 3/3 colorless Golem-Artifact creature token."
+    tokens = extract_tokens_from_text(text)
+    assert len(tokens) == 1
+    assert "Golem-artifact" in tokens[0]['type'] or "Golem-Artifact" in tokens[0]['type']
+
+def test_extract_non_token_text():
+    text = "Destroy all tokens."
+    tokens = extract_tokens_from_text(text)
+    assert len(tokens) == 0
+
+    text2 = "Sacrifice a Treasure: Draw a card."
+    tokens2 = extract_tokens_from_text(text2)
+    assert len(tokens2) == 0


### PR DESCRIPTION
* **Type:** New Coverage / Bug Fix
* **What:** 
    - Expanded `extract_tokens_from_text` in `lib/cardlib.py` to support 'Gold' tokens and number words up to 'ten' for predefined tokens.
    - Fixed a bug in `extract_tokens_from_text` where tokens with hyphenated types (e.g., "Golem-Artifact") were failing to match.
    - Added comprehensive unit tests in `tests/test_token_extraction_enhanced.py` covering predefined tokens, complex creature tokens, and edge cases.
    - Added unit tests for the `cap` utility in `tests/test_cap_coverage.py` to verify capitalization logic across mana and choice delimiters.
* **Why:** 
    - Increases test coverage for core library functions that had significant gaps.
    - Enhances the robustness of the card parsing toolkit, specifically for identifying mechanical features like tokens which are critical for card comparison and analysis.
    - Improves code hygiene by consolidating redundant test logic.

---
*PR created automatically by Jules for task [8514940154925369849](https://jules.google.com/task/8514940154925369849) started by @RainRat*