### PR TITLE
Standardize sorting criteria and improve terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Customization options for formatting data:
 *   `--nolinetrans`: Disables the automatic reordering and normalization of card text lines.
 *   `-r`, `--randomize`: Randomizes mana symbol order (e.g., `{U}{W}` vs `{W}{U}`) to help the AI learn better.
 *   `-s`, `--stable`: Preserve the original order of cards from the input (the tool shuffles cards by default).
-*   `--sort`: Sorts cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, or `box` before encoding. Automatically enables `--stable`.
+*   `--sort`: Sorts cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, `box`, `complexity`, `score`, `rating`, or `power_rating` before encoding. Automatically enables `--stable`.
 *   `--seed N`: Seed for the random number generator (Default: 1371367).
 *   `--limit N`: Only process the first N cards.
 *   `--sample N`: Shorthand for `--limit N`. The tool shuffles cards by default unless you use `--stable`.
@@ -141,7 +141,7 @@ Options for formatting the output. While primarily used for AI output, this tool
 *   `-d`, `--dump`: Show detailed debug information for cards that were not processed correctly.
 *   `--color` / `--no-color`: Manually enable or disable ANSI color output in your terminal.
 *   `--shuffle`: Randomizes the order of cards (the tool does not shuffle cards by default for decoding).
-*   `--sort`: Sorts cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, or `box`.
+*   `--sort`: Sorts cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, `box`, `complexity`, `score`, `rating`, or `power_rating`.
 *   `--seed N`: Seed for the random number generator.
 *   `--limit N`: Only process the first N cards.
 *   `--sample N`: Pick N random cards (shorthand for `--shuffle --limit N`).
@@ -409,7 +409,7 @@ python3 sortcards.py data/AllPrintings.json sorted_output.txt
 # Sort encoded cards with filters and sampling
 python3 sortcards.py encoded_output.txt sorted_sample.txt --sample 50 --grep "Elf"
 ```
-*   **Options:** Supports `--encoding`, `--limit`, `--shuffle`, `--sample`, `--booster`, `--box`, and all **Advanced Filtering** flags.
+*   **Options:** Supports `--sort` (`name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, `box`, `complexity`, `score`, `rating`, `power_rating`), `--encoding`, `--limit`, `--shuffle`, `--sample`, `--booster`, `--box`, and all **Advanced Filtering** flags.
 *   `-S`, `--summary`: Output compact card summaries instead of full text.
 *   `--md`, `--markdown`: Output in Markdown format with collapsible sections.
 *   `--color` / `--no-color`: Enable or disable ANSI color output.
@@ -426,7 +426,7 @@ python3 scripts/mtg_analyze.py profile data/AllPrintings.json --set MOM
 # See the top 20 signature features for a decklist
 python3 scripts/mtg_analyze.py profile my_deck.txt --top 20
 ```
-*   **Metrics:** Calculates Avg CMC, Power, Toughness, and Complexity deltas.
+*   **Metrics:** Calculates Avg CMC, Power, Toughness, and Complexity differences.
 *   **Signature Features:** Identifies over-represented Mechanics, Actions, and Subtypes using a 'Lift' score (Relative Frequency vs. Baseline).
 *   **Options:** Supports all **Advanced Filtering** flags and the `--top N` argument.
 
@@ -449,7 +449,7 @@ python3 scripts/mtg_analyze.py summary encoded_output.txt summary.json
     *   `-x`, `--outliers`: Show extra details and unusual cards.
     *   `-a`, `--all`: Show all information, including dumping invalid cards.
     *   `--top N`: Limit the number of entries in breakdown tables (Default: 10).
-    *   `--sort CRITERIA`: Sort cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, `complexity`, or `score` before summarizing.
+    *   `--sort CRITERIA`: Sort cards by `name`, `color`, `identity`, `type`, `cmc`, `rarity`, `power`, `toughness`, `loyalty`, `set`, `pack`, `box`, `complexity`, `score`, `rating`, or `power_rating` before summarizing.
     *   `--booster N`: Simulate opening N booster packs and summarize the contents.
     *   `--box N`: Simulate opening N booster boxes (36 packs each) and summarize the contents.
     *   `-j`, `--json`: Force JSON output.

--- a/decode.py
+++ b/decode.py
@@ -825,7 +825,7 @@ Usage Examples:
                         help='Seed for the random number generator.')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --shuffle --limit N).')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score', 'rating', 'power_rating'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--reverse', action='store_true',
                         help='Reverse the sort order.')

--- a/encode.py
+++ b/encode.py
@@ -190,7 +190,7 @@ Usage Examples:
                         help='Seed for the random number generator (Default: 1371367).')
     proc_group.add_argument('--sample', type=int, default=0,
                         help='Pick N random cards from the input (shorthand for --limit N). Shuffling is enabled unless --stable is used.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score', 'rating', 'power_rating'],
                         help='Sort cards by a specific criterion (enables --stable).')
     proc_group.add_argument('--reverse', action='store_true',
                         help='Reverse the sort order.')

--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1537,7 +1537,7 @@ def main():
     p_sum.add_argument('-x', '--outliers', action='store_true', help='Show extra details and unusual cards (outliers).')
     p_sum.add_argument('-a', '--all', action='store_true', help='Show all information, including dumping invalid cards.')
     p_sum.add_argument('--top', type=int, default=10, help='Limit the number of entries in breakdown tables (Default: 10).')
-    p_sum.add_argument('--sort', choices=['name','color','identity','type','cmc','rarity','power','toughness','loyalty','set','pack','complexity','score'], help='Sort cards before summarizing.')
+    p_sum.add_argument('--sort', choices=['name','color','identity','type','cmc','rarity','power','toughness','loyalty','set','pack','box','complexity','score','rating','power_rating'], help='Sort cards before summarizing.')
     p_sum.add_argument('--reverse', action='store_true', help='Reverse the sort order.')
     p_sum.set_defaults(func=handle_summary)
 

--- a/sortcards.py
+++ b/sortcards.py
@@ -426,7 +426,7 @@ Usage Examples:
     proc_group = parser.add_argument_group('Processing Options')
     proc_group.add_argument('-n', '--limit', type=int, default=0,
                         help='Only process the first N cards.')
-    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score'],
+    proc_group.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'pack', 'box', 'complexity', 'score', 'rating', 'power_rating'],
                         help='Sort cards by a specific criterion.')
     proc_group.add_argument('--reverse', action='store_true',
                         help='Reverse the sort order.')


### PR DESCRIPTION
This PR improves the project documentation and internal help strings by standardizing the available sorting criteria and using clearer terminology.

**Type:** Documentation / Internal Help

**What:**
- **README.md:** Added missing sorting options (`complexity`, `score`, `rating`, `power_rating`, `box`) to the usage sections for `encode.py`, `decode.py`, `sortcards.py`, and `mtg_analyze.py`. Replaced the technical term "deltas" with "differences" in the mechanical profiling section.
- **CLI Scripts:** Updated the `argparse` choices for the `--sort` argument in `encode.py`, `decode.py`, `sortcards.py`, and `scripts/mtg_analyze.py` (summary subcommand) to include all criteria supported by the underlying logic in `lib/sortlib.py`.

**Why:**
- **Consistency:** Users can now see and use the same set of sorting criteria across all relevant tools in the toolkit.
- **Accuracy:** The documentation now matches the actual capabilities of the code (e.g., sorting by rating was supported in logic but not exposed in most CLI help strings).
- **Accessibility:** Following the project's 'No Jargon' and 'Plain English' guidelines, replacing "deltas" makes the documentation more accessible to a global audience.

---
*PR created automatically by Jules for task [8987759564644662292](https://jules.google.com/task/8987759564644662292) started by @RainRat*