### PR TITLE
[TEST] [FIX] Extend predefined token count detection to ten

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -204,7 +204,7 @@ def extract_tokens_from_text(text):
 
     # 2. Regex for predefined tokens (Treasure, Food, etc.)
     ntks = ['Treasure','Food','Clue','Blood','Map','Role','Incubator','Powerstone','Walker']
-    n_regex = r"(?:[Cc]reate[sd]?)\s+(?:[Aa]n?|two|three|four|five|X)\s+(" + "|".join(ntks) + r")\s+token[s]?"
+    n_regex = r"(?:[Cc]reate[sd]?)\s+(?:[Aa]n?|two|three|four|five|six|seven|eight|nine|ten|X)\s+(" + "|".join(ntks) + r")\s+token[s]?"
     for m in re.finditer(n_regex, text, re.IGNORECASE):
         n = m.group(1).capitalize(); t = {'name': f"{n} Token", 'pt': "", 'color': "Colorless", 'type': n, 'abilities': ""}
         if n=='Treasure': t['type']='Artifact'; t['abilities']='Sacrifice this artifact: Add one mana of any color.'

--- a/tests/test_qa_token_counts_gap.py
+++ b/tests/test_qa_token_counts_gap.py
@@ -1,0 +1,21 @@
+from lib.cardlib import Card
+
+def test_extract_tokens_predefined_extended_counts():
+    # 'six' is currently NOT supported for predefined tokens
+    c6 = Card("|Creature|Legendary||||Create six Treasure tokens.|||Test|")
+    tokens6 = c6.tokens
+    assert len(tokens6) == 1, "Should identify Treasure tokens when count is 'six'"
+    assert tokens6[0]['name'] == "Treasure Token"
+
+    # 'ten' is currently NOT supported for predefined tokens
+    c10 = Card("|Creature|Legendary||||Create ten Food tokens.|||Test|")
+    tokens10 = c10.tokens
+    assert len(tokens10) == 1, "Should identify Food tokens when count is 'ten'"
+    assert tokens10[0]['name'] == "Food Token"
+
+def test_extract_tokens_predefined_existing_counts():
+    # 'five' IS currently supported
+    c5 = Card("|Creature|Legendary||||Create five Clue tokens.|||Test|")
+    tokens5 = c5.tokens
+    assert len(tokens5) == 1
+    assert tokens5[0]['name'] == "Clue Token"


### PR DESCRIPTION
This PR addresses a gap in the token extraction logic where predefined tokens (like Treasure and Food) were not being identified if created in quantities between six and ten, despite creature tokens already supporting this range.

### Changes:
- **lib/cardlib.py**: Expanded the `n_regex` in `extract_tokens_from_text` to include 'six', 'seven', 'eight', 'nine', and 'ten'.
- **tests/test_qa_token_counts_gap.py**: New test file verifying that the extractor correctly identifies tokens with these extended counts.

Verification:
- Ran `python3 -m pytest tests/test_qa_token_counts_gap.py` (Passed)
- Ran the full test suite `python3 -m pytest` (All 1174 tests passed)

---
*PR created automatically by Jules for task [5427946008343825425](https://jules.google.com/task/5427946008343825425) started by @RainRat*