### PR TITLE
[DOCS] Improve NumericFilter invalid format error message

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -825,7 +825,10 @@ class NumericFilter:
             self.val = float(exact_match.group(1))
             return
 
-        raise ValueError(f"Invalid numerical filter: {s}")
+        raise ValueError(
+            f"Invalid numerical filter: '{s}'. Expected an exact value (e.g., '5'), "
+            "an inequality (e.g., '>=3'), or a range (e.g., '2-4')."
+        )
 
     def evaluate(self, value):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -324,8 +324,9 @@ def test_numeric_filter_parsing():
     nf = utils.NumericFilter("2-4")
     assert nf.mode == 'range' and nf.val == 2.0 and nf.val2 == 4.0
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         utils.NumericFilter("abc")
+    assert "Expected an exact value" in str(exc_info.value)
 
 def test_numeric_filter_evaluation():
     nf = utils.NumericFilter("5")


### PR DESCRIPTION
Improved the ValueError message raised by NumericFilter in lib/utils.py when an invalid numerical filter string is parsed. The technical error has been replaced with a helpful, friendly message in Plain English that explains correct format examples (exact values, inequalities, and ranges) to guide users. The changes have been validated against the test suite, and the associated tests have been updated to assert this message.

---
*PR created automatically by Jules for task [11289632337542959924](https://jules.google.com/task/11289632337542959924) started by @RainRat*