### PR TITLE
[UI/UX] Add /list, /l, and /results commands to MTG interactive shell

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -825,7 +825,9 @@ def handle_shell(args):
                     '/reprints ', '/rep ',
                     '/superior ', '/sup ',
                     '/inferior ', '/inf ',
+                    '/substitutes ', '/sub ',
                     '/extract ', '/e ',
+                    '/list', '/l', '/results',
                     '/help', '/h', '/?',
                     '/clear',
                     '/exit', '/quit', '/q'
@@ -1005,6 +1007,17 @@ def handle_shell(args):
                     e_args.card_name = " ".join(cmd_args[1:])
                     e_args.outfile = '-'
                     handle_extract(e_args)
+                elif cmd in ['/list', '/l', '/results']:
+                    if not last_results:
+                        err_msg = "No previous results to display."
+                        if use_color: err_msg = utils.colorize(err_msg, utils.Ansi.BOLD + utils.Ansi.RED)
+                        print(err_msg)
+                        continue
+                    s_args = copy.copy(args)
+                    s_args.fields = getattr(args, 'fields', 'name,cost,type,stats,rarity')
+                    s_args.table = True
+                    if not hasattr(s_args, 'limit'): s_args.limit = 0
+                    _execute_search(last_results, s_args, include_indices=True)
                 elif cmd in ['/help', '/h', '/?']:
                     utils.print_header("SHELL COMMANDS", use_color=use_color)
 
@@ -1034,6 +1047,7 @@ def handle_shell(args):
                     fmt_cmd("/superior <n>", "/sup", "Find cards generally better than the named card.")
                     fmt_cmd("/inferior <n>", "/inf", "Find cards generally worse than the named card.")
                     fmt_cmd("/extract <s> <n>", "/e", "Extract raw card JSON by set code and name.")
+                    fmt_cmd("/list", "/l, /results", "Re-display the results of the last search or query.")
                     fmt_cmd("/clear", "/cls", "Clear the terminal screen.")
                     fmt_cmd("/help", "/h, /?", "Show this help message.")
                     fmt_cmd("/exit", "/quit, /q", "Exit the interactive shell.")

--- a/tests/test_mtg_shell.py
+++ b/tests/test_mtg_shell.py
@@ -137,6 +137,22 @@ class TestMtgShell(unittest.TestCase):
                 handle_shell(self.args)
                 self.assertIn("Error: No closing quotation", fake_out.getvalue())
 
+    def test_shell_list_empty(self):
+        """Test the /list command when no previous search results exist."""
+        with patch('builtins.input', side_effect=['/list', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                self.assertIn("No previous results to display.", fake_out.getvalue())
+
+    def test_shell_list_with_results(self):
+        """Test the /list, /l, and /results commands after a search."""
+        with patch('builtins.input', side_effect=['/search tarkir', '/list', '/l', '/results', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                # Verify search output is printed multiple times (from search, list, l, results)
+                self.assertEqual(output.count("Invasion of Tarkir"), 4)
+
     def test_shell_tab_completion(self):
         """Test the tab completion logic."""
         with patch('readline.set_completer') as mock_set_completer:
@@ -149,6 +165,14 @@ class TestMtgShell(unittest.TestCase):
                 self.assertEqual(completer('/', 0), '/search ')
                 self.assertEqual(completer('/s', 0), '/search ')
                 self.assertEqual(completer('/s', 1), '/s ')
+
+                # Test new list and substitutes command completion
+                self.assertEqual(completer('/li', 0), '/list')
+                self.assertEqual(completer('/l', 0), '/list')
+                self.assertEqual(completer('/l', 1), '/l')
+                self.assertEqual(completer('/res', 0), '/results')
+                self.assertEqual(completer('/sub', 0), '/substitutes ')
+                self.assertEqual(completer('/sub', 1), '/sub ')
 
                 # Test card name completion
                 self.assertEqual(completer('inv', 0), 'Invasion of Tarkir')


### PR DESCRIPTION
This PR addresses a usability friction point in the interactive query shell where users would have to re-type search queries in order to see previous results again after looking up a card's details.

By introducing `/list` (and aliases `/l`, `/results`), users can now instantly re-display the most recent search results in tabular format with indices intact. We also completed the tab completion options with missing commands (`/substitutes`, `/sub`, and the new `/list` commands) and added comprehensive unit tests.

---
*PR created automatically by Jules for task [17620558784474859838](https://jules.google.com/task/17620558784474859838) started by @RainRat*