### PR TITLE
Fix case-sensitivity bug in extract subcommand

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1080,13 +1080,14 @@ def handle_extract(args):
             return
 
         sets_to_search = []
-        if target_set_code.upper() in ['ANY', 'ALL', '*']:
+        target_set_code_upper = target_set_code.upper()
+        if target_set_code_upper in ['ANY', 'ALL', '*']:
             sets_to_search = content['data'].keys()
-        elif target_set_code not in content['data']:
+        elif target_set_code_upper not in content['data']:
             print(f"Error: Set code '{target_set_code}' not found.", file=sys.stderr)
             return
         else:
-            sets_to_search = [target_set_code]
+            sets_to_search = [target_set_code_upper]
 
         found_card = None
         for code in sets_to_search:

--- a/tests/test_mtg_query_extract.py
+++ b/tests/test_mtg_query_extract.py
@@ -59,6 +59,14 @@ class TestMtgQueryExtract(unittest.TestCase):
         output = json.loads(mock_stdout.getvalue())
         self.assertEqual(output['name'], 'Grizzly Bears')
 
+    @patch('builtins.open', new_callable=mock_open, read_data='{"data": {"TEST": {"cards": [{"name": "Grizzly Bears"}]}}}')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_handle_extract_lowercase_set_code(self, mock_stdout, mock_file):
+        self.args.set_code = 'test'
+        handle_extract(self.args)
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output['name'], 'Grizzly Bears')
+
     @patch('builtins.open', side_effect=Exception("File not found"))
     @patch('sys.stderr', new_callable=io.StringIO)
     def test_handle_extract_exception(self, mock_stderr, mock_file):


### PR DESCRIPTION
This PR resolves a logic and usability bug where querying set codes in the extract subcommand of mtg_query.py was case-sensitive. By normalizing the set code to uppercase, users can now search/extract cards regardless of set code casing. A unit test verifying this functionality has been added.

---
*PR created automatically by Jules for task [17740356606682811442](https://jules.google.com/task/17740356606682811442) started by @RainRat*