### PR TITLE
[TEST] Add comprehensive unit tests for Card.activate_printing to achieve 100% statement coverage on cardlib.py

### DIFF
--- a/tests/test_qa_cardlib_gaps.py
+++ b/tests/test_qa_cardlib_gaps.py
@@ -53,3 +53,57 @@ def test_display_data_ansi_mechanics_colorization():
     assert "Flying" in mechanics_str
     assert "Haste" in mechanics_str
     assert utils.Ansi.RESET in mechanics_str
+
+
+def test_activate_printing_with_invalid_or_missing_set_code():
+    card_data = {
+        "name": "Test Card",
+        "types": ["Sorcery"],
+        "rarity": "Common"
+    }
+    card = Card(card_data)
+    assert not card.activate_printing(None)
+    assert not card.activate_printing("")
+
+
+def test_activate_printing_with_set_code_not_in_printings():
+    card_data = {
+        "name": "Test Card",
+        "types": ["Sorcery"],
+        "rarity": "Common",
+        "setCode": "XYZ"
+    }
+    card = Card(card_data)
+    assert not card.activate_printing("NOTFOUND")
+
+
+def test_activate_printing_with_valid_printing_unmapped_rarity():
+    card_data = {
+        "name": "Test Card",
+        "types": ["Sorcery"],
+        "rarity": "Common",
+        "setCode": "XYZ",
+        "number": "1"
+    }
+    card = Card(card_data)
+    card.add_printing("ABC", "CustomRarity", "123")
+    assert card.activate_printing("ABC")
+    assert card.set_code == "ABC"
+    assert card.rarity == "CustomRarity"
+    assert card.number == "123"
+
+
+def test_activate_printing_with_valid_printing_mapped_rarity():
+    card_data = {
+        "name": "Test Card",
+        "types": ["Sorcery"],
+        "rarity": "Common",
+        "setCode": "XYZ",
+        "number": "1"
+    }
+    card = Card(card_data)
+    card.add_printing("M10", "Rare", "42")
+    assert card.activate_printing("M10")
+    assert card.set_code == "M10"
+    assert card.rarity == "A"
+    assert card.number == "42"


### PR DESCRIPTION
**Type:** New Coverage

**What:** Added robust unit tests covering `Card.activate_printing()` edge cases and branches:
- Calling `activate_printing` with `None` or empty string `""` (returning `False`).
- Calling `activate_printing` with a set code not present in the card's registered printings (returning `False`).
- Calling `activate_printing` with a valid printing that has a custom/unmapped rarity (verifying that it falls back to raw rarity setting).
- Calling `activate_printing` with a valid printing that has a mapped rarity (verifying successful mapping using `utils.json_rarity_map` and updating set_code/number).

**Why:** The `activate_printing` method of the `Card` class was identified as having three statement gaps in `lib/cardlib.py` (lines 824, 835, 839). With these new tests, `lib/cardlib.py` achieves 100% statement coverage (all 1311 statements covered), ensuring complete reliability of this core card representation module.

---
*PR created automatically by Jules for task [3195887631130411404](https://jules.google.com/task/3195887631130411404) started by @RainRat*