### PR TITLE
[DOCS] Clarify the capitalization logic intent in cardlib.py

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -133,7 +133,8 @@ def cap(s):
         return s
 
     chars = list(s)
-    # 1. Capitalize the first letter overall
+    # Pass 1: Capitalize the very first English letter in standard sentences
+    # (e.g., "draw a card"). This handles standard text starting directly with words.
     for i, char in enumerate(chars):
         if char.isalpha():
             chars[i] = char.upper()
@@ -141,7 +142,9 @@ def cap(s):
         if char in [utils.this_marker, utils.reserved_marker]:
             break
 
-    # 2. Find the first letter outside of delimiters {} and []
+    # Pass 2: Capitalize the first English letter located outside of brackets.
+    # This handles sentences that start with delimited mana costs or choices
+    # (e.g., "{2U}, remove...", "[Choose one —] draw...").
     i = 0
     while i < len(s):
         if s[i] == utils.mana_open_delimiter:


### PR DESCRIPTION
This pull request improves the internal code comments of the `cap` function in `lib/cardlib.py`. It replaces the mechanical numbering comments with clear, Plain English explanations of the intent of each capitalization pass:
- Pass 1 handles standard sentences starting directly with words.
- Pass 2 handles sentences starting with delimited elements (like bracketed mana symbols or choices), skipping past them to capitalize the first English word.

These changes conform to the strict style guidelines:
- Casual but professional tone
- Simple sentences in Plain English
- Exclusively explaining 'why' (intent) rather than 'what' (mechanics)
- Safe, zero-risk comment-only change with full test suite passing.

---
*PR created automatically by Jules for task [1674589606894884960](https://jules.google.com/task/1674589606894884960) started by @RainRat*