### PR TITLE
UX improvement: support range and comma-separated index selection in interactive shell

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -796,10 +796,39 @@ def handle_shell(args):
     last_results = []
 
     def _resolve_args(cmd_args):
+        arg_str = " ".join(cmd_args)
+        if re.match(r'^[0-9,\-\s]+$', arg_str):
+            parts = [p.strip() for p in re.split(r',', arg_str) if p.strip()]
+            resolved = []
+            valid_parse = True
+            for p in parts:
+                range_match = re.match(r'^(\d+)-(\d+)$', p)
+                if range_match:
+                    start, end = int(range_match.group(1)), int(range_match.group(2))
+                    step = 1 if start <= end else -1
+                    indices = list(range(start, end + step, step))
+                    for idx in indices:
+                        if 1 <= idx <= len(last_results):
+                            resolved.append(last_results[idx-1].name)
+                        else:
+                            resolved.append(str(idx))
+                elif re.match(r'^\d+$', p):
+                    idx = int(p)
+                    if 1 <= idx <= len(last_results):
+                        resolved.append(last_results[idx-1].name)
+                    else:
+                        resolved.append(str(idx))
+                else:
+                    valid_parse = False
+                    break
+            if valid_parse and resolved:
+                return resolved
+
         resolved = []
         for arg in cmd_args:
-            if arg.isdigit():
-                idx = int(arg)
+            clean_arg = arg.strip(', ')
+            if clean_arg.isdigit():
+                idx = int(clean_arg)
                 if 1 <= idx <= len(last_results):
                     resolved.append(last_results[idx-1].name)
                 else:
@@ -1039,6 +1068,8 @@ def handle_shell(args):
                     fmt_cmd("/exit", "/quit, /q", "Exit the interactive shell.")
                     print("  Note: You can use numeric indices (e.g. '1', '2') in place of card names")
                     print("        for any command, referring to the results of the last search.")
+                    print("        The compare command (/c) also supports ranges and comma-separated")
+                    print("        indices (e.g., '/compare 1-3, 5').")
                     print()
                 else:
                     err_msg = f"Unknown command: {cmd}. Type /help for assistance."

--- a/tests/test_mtg_shell.py
+++ b/tests/test_mtg_shell.py
@@ -50,6 +50,22 @@ class TestMtgShell(unittest.TestCase):
                 handle_shell(self.args)
                 output = fake_out.getvalue()
                 self.assertIn("Invasion of Tarkir", output)
+
+    def test_shell_compare_range(self):
+        """Test the /compare command with index ranges and comma separation."""
+        with patch('builtins.input', side_effect=['/search tarkir', '/compare 1-1, 1', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Invasion of Tarkir", output)
+
+    def test_shell_compare_comma_fallback(self):
+        """Test fallback and trailing commas in /compare command."""
+        with patch('builtins.input', side_effect=['/search tarkir', '/compare 1,', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Invasion of Tarkir", output)
                 self.assertIn("Battle", output)
 
     def test_shell_search(self):


### PR DESCRIPTION
Enhance the MTG query interactive shell to support ranges and comma-separated index selections (e.g., `/compare 1-3, 5`), drastically reducing the friction of typing individual indices one-by-one.

---
*PR created automatically by Jules for task [6121637316995215642](https://jules.google.com/task/6121637316995215642) started by @RainRat*