### PR TITLE
Refactor broad exception handler in CSV stdin detection

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -1115,7 +1115,7 @@ def mtg_open_file(fname, verbose = False,
                     cards = _process_json_srcs(csv_srcs, bad_sets, verbose, linetrans,
                                                exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                                decklist_names=decklist_names)
-                except Exception:
+                except (csv.Error, ValueError, TypeError):
                     pass
         else:
             # Check if it's a decklist file based on extension or content


### PR DESCRIPTION
Refactored the overly broad `except Exception:` block inside the CSV stdin detection loop of `lib/jdecode.py` to catch only expected, specific exception classes (`csv.Error`, `ValueError`, `TypeError`). This prevents silent suppression of critical logic errors, such as `AttributeError` or `NameError`, while maintaining identical behavior for all valid input formats.

---
*PR created automatically by Jules for task [9267563156907377340](https://jules.google.com/task/9267563156907377340) started by @RainRat*