### PR TITLE
[UI/UX] Optimize card comparison headers for multi-faced cards

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1875,14 +1875,12 @@ def handle_compare_cards(args):
                 ]),
             ]
 
-        def get_full_name(c):
-            res = cardlib.titlecase(c.name.replace(utils.dash_marker, '-'))
-            if c.bside:
-                res += " // " + get_full_name(c.bside)
-            return res
+        def get_header_name(c):
+            # For clean columns and high density in comparisons, we only show the primary face's name
+            return cardlib.titlecase(c.name.replace(utils.dash_marker, '-'))
 
         rows = []
-        header = ["Field"] + [get_full_name(c) for c in comparison_cards]
+        header = ["Field"] + [get_header_name(c) for c in comparison_cards]
         if use_color:
             header = [utils.colorize(h, utils.Ansi.BOLD + utils.Ansi.UNDERLINE) for h in header]
         rows.append(header)

--- a/tests/test_mtg_query_compare.py
+++ b/tests/test_mtg_query_compare.py
@@ -35,12 +35,12 @@ def test_query_compare_fuzzy():
     assert "Invasion of Alara" in result.stdout
 
 def test_query_compare_multi_face():
-    """Test comparison of multiple card faces."""
+    """Test comparison of multiple card faces with cleaner primary face headers."""
     # Compare front and back of the same card
     cmd = ["python3", SCRIPT_PATH, "compare", "Double Front", "Double Back", "testdata/manual.json", "--no-color"]
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 0
-    assert "Double Front // Double Back" in result.stdout
+    assert "Double Front" in result.stdout
     assert "Double Back" in result.stdout
     # Check that they are identified as different in the table
     # Since Double Front matches the whole card (both faces) and Double Back matches only one face


### PR DESCRIPTION
Optimized side-by-side card comparison name headers in mtg_query.py compare subcommand to use only the primary/front face's name instead of joining all faces with " // ". This significantly reduces visual clutter and prevents column stretching for double-faced/split cards while maintaining clean alignments.

---
*PR created automatically by Jules for task [8714457249682409324](https://jules.google.com/task/8714457249682409324) started by @RainRat*