### PR TITLE
Fix duplicated command and subcommand documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,12 +539,10 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `functional`: Identify and group cards with the same mechanics but different names.
 *   `reprints`: Find functional reprints (identical mechanics) of a reference card.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
-*   `reprints`: Find functional reprints (identical mechanics) of a reference card.
 *   `substitutes`: Find functional alternatives to a reference card.
 *   `counterparts`: Find mechanical clones in different colors (color shifts).
 *   `superior`: Find cards that are generally better than a reference card.
 *   `inferior`: Find cards that are generally worse than a reference card.
-*   `substitutes`: Find functional alternatives to a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -624,19 +622,6 @@ python3 scripts/mtg_query.py functional
 
 # Create a deduplicated dataset
 python3 scripts/mtg_query.py functional --dedupe unique_cards.json
-```
-
----
-
-#### **Subcommand: `reprints`**
-Identifies functional reprints (cards with identical mana cost, types, stats, and mechanics) of a reference card.
-
-```bash
-# Find reprints of Grizzly Bears
-python3 scripts/mtg_query.py reprints "Grizzly Bears"
-
-# Find reprints of Lightning Bolt in a specific set
-python3 scripts/mtg_query.py reprints "Lightning Bolt" --set MOM
 ```
 
 ---
@@ -730,22 +715,6 @@ python3 scripts/mtg_query.py inferior "Black Vise"
 
 # Find worse cards in a specific set
 python3 scripts/mtg_query.py inferior "Lightning Bolt" --set MOM
-```
-
----
-
-#### **Subcommand: `substitutes`**
-Finds functional alternatives to a reference card. It identifies cards with shared types, compatible color identities (subset), similar mana costs (+/- 1), and overlapping functional actions (e.g., Removal, Card Advantage).
-
-```bash
-# Find substitutes for Lightning Bolt
-python3 scripts/mtg_query.py substitutes "Lightning Bolt"
-
-# Find budget (common/uncommon) substitutes for a rare card
-python3 scripts/mtg_query.py substitutes "Damnation" --rarity common --rarity uncommon
-
-# Find substitutes within a specific set
-python3 scripts/mtg_query.py substitutes "Counterspell" --set MOM
 ```
 
 ---


### PR DESCRIPTION
Fixed documentation duplication issues in `README.md` by cleanly removing redundant bullet points in the subcommand summary list and redundant detailed sections of `reprints` and `substitutes` while preserving the actual documentation and usage examples for all subcommands.

---
*PR created automatically by Jules for task [16586267421605824241](https://jules.google.com/task/16586267421605824241) started by @RainRat*