### PR TITLE
[TEST] Increase statement coverage of lib/utils.py to 100%

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -385,3 +385,38 @@ def test_scryfall_urls():
     assert utils.get_scryfall_image_url('LEA', '1') == 'https://api.scryfall.com/cards/lea/1?format=image&version=normal'
     assert utils.get_scryfall_url(None, '1') is None
     assert utils.get_scryfall_image_url(None, '1') is None
+
+
+def test_visible_len_non_string():
+    assert utils.visible_len(123) == 3
+    assert utils.visible_len(None) == 4
+
+
+def test_wrap_ansi_comprehensive():
+    assert utils.wrap_ansi("", 10) == ""
+    assert utils.wrap_ansi("hello world", 10) == "hello\nworld"
+    assert utils.wrap_ansi("hello world", 20) == "hello world"
+    assert utils.wrap_ansi("hello world", 10, indent=2) == "  hello\n  world"
+    assert utils.wrap_ansi("supercalifragilistic", 10) == "supercalifragilistic"
+    assert utils.wrap_ansi("supercalifragilistic expialidocious", 10) == "supercalifragilistic\nexpialidocious"
+    assert utils.wrap_ansi("hello\n\nworld", 10) == "hello\n\nworld"
+    assert utils.wrap_ansi(None, 10) == ""
+
+
+def test_get_terminal_width_fallback_behaviors():
+    with patch("shutil.get_terminal_size") as mock_size:
+        mock_size.return_value = MagicMock(columns=100)
+        assert utils.get_terminal_width() == 100
+
+        mock_size.return_value = MagicMock(columns=0)
+        assert utils.get_terminal_width(default=50) == 50
+
+        mock_size.side_effect = AttributeError
+        assert utils.get_terminal_width(default=40) == 40
+
+
+def test_get_rarity_color_basic_and_fallback():
+    assert utils.Ansi.get_rarity_color("basic land") == utils.Ansi.BOLD
+    assert utils.Ansi.get_rarity_color(utils.rarity_basic_land_marker) == utils.Ansi.BOLD
+    assert utils.Ansi.get_rarity_color("unknown_rarity") == utils.Ansi.BOLD
+    assert utils.Ansi.get_rarity_color(123) == utils.Ansi.BOLD


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Closed all remaining test coverage gaps in `lib/utils.py` by adding targeted, high-quality test cases.
* **Why:** The utility module `lib/utils.py` previously had several helper functions (`wrap_ansi`, `get_terminal_width`, specific branches of `visible_len` and `Ansi.get_rarity_color`) missing from the main test suite. This change raises `lib/utils.py` to 100% statement coverage (550/550 statements covered) and improves codebase reliability.

---
*PR created automatically by Jules for task [13479723049109100974](https://jules.google.com/task/13479723049109100974) started by @RainRat*