### PR TITLE
[DOCS] Remove duplicate mtg_query subcommands and clean up sections in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,14 +537,12 @@ A unified tool for searching, extracting, and listing card data. It consolidates
 *   `random`: Display one or more random cards matching the filters.
 *   `sets`: List and filter sets in an MTGJSON file.
 *   `functional`: Identify and group cards with the same mechanics but different names.
-*   `reprints`: Find functional reprints (identical mechanics) of a reference card.
 *   `compare`: Compare two cards side-by-side by name to identify differences.
 *   `reprints`: Find functional reprints (identical mechanics) of a reference card.
 *   `substitutes`: Find functional alternatives to a reference card.
 *   `counterparts`: Find mechanical clones in different colors (color shifts).
 *   `superior`: Find cards that are generally better than a reference card.
 *   `inferior`: Find cards that are generally worse than a reference card.
-*   `substitutes`: Find functional alternatives to a reference card.
 *   `extract`: Extract a single card object from a large JSON database.
 *   `shell`: Launch an interactive terminal for quick card lookups and searches.
 
@@ -628,19 +626,6 @@ python3 scripts/mtg_query.py functional --dedupe unique_cards.json
 
 ---
 
-#### **Subcommand: `reprints`**
-Identifies functional reprints (cards with identical mana cost, types, stats, and mechanics) of a reference card.
-
-```bash
-# Find reprints of Grizzly Bears
-python3 scripts/mtg_query.py reprints "Grizzly Bears"
-
-# Find reprints of Lightning Bolt in a specific set
-python3 scripts/mtg_query.py reprints "Lightning Bolt" --set MOM
-```
-
----
-
 #### **Subcommand: `compare`**
 Side-by-side card comparison for identifying design differences. Supports comparing any number of cards, fuzzy matching, and automatic similarity finding.
 
@@ -664,7 +649,7 @@ python3 scripts/mtg_query.py compare "Uthros" "Invasion" testdata/ --color
 ---
 
 #### **Subcommand: `reprints`**
-Finds cards with identical mana cost, types, stats, and mechanics/text as the reference card, excluding the reference card itself.
+Finds functional reprints of a reference card (cards with identical mana cost, types, stats, and mechanics/text), excluding the reference card itself.
 
 ```bash
 # Find reprints of Grizzly Bears
@@ -677,7 +662,7 @@ python3 scripts/mtg_query.py reprints "Lightning Bolt" --set MOM
 ---
 
 #### **Subcommand: `substitutes`**
-Finds functional substitutes by identifying cards with shared types, compatible color identities (subset), similar mana costs (+/- 1), and overlapping functional actions (e.g., Removal, Card Advantage).
+Finds functional substitutes (alternatives) by identifying cards with shared types, compatible color identities, similar mana costs (+/- 1), and overlapping functional actions (such as Removal or Card Advantage).
 
 ```bash
 # Find substitutes for Lightning Bolt
@@ -730,22 +715,6 @@ python3 scripts/mtg_query.py inferior "Black Vise"
 
 # Find worse cards in a specific set
 python3 scripts/mtg_query.py inferior "Lightning Bolt" --set MOM
-```
-
----
-
-#### **Subcommand: `substitutes`**
-Finds functional alternatives to a reference card. It identifies cards with shared types, compatible color identities (subset), similar mana costs (+/- 1), and overlapping functional actions (e.g., Removal, Card Advantage).
-
-```bash
-# Find substitutes for Lightning Bolt
-python3 scripts/mtg_query.py substitutes "Lightning Bolt"
-
-# Find budget (common/uncommon) substitutes for a rare card
-python3 scripts/mtg_query.py substitutes "Damnation" --rarity common --rarity uncommon
-
-# Find substitutes within a specific set
-python3 scripts/mtg_query.py substitutes "Counterspell" --set MOM
 ```
 
 ---


### PR DESCRIPTION
This PR removes the duplicate 'reprints' and 'substitutes' subcommands from the main overview list under 'mtg_query.py' in `README.md`. It also consolidates and cleans up the corresponding subcommand detail sections so that each subcommand appears exactly once in a consistent, logical order. The descriptions have been simplified to use Plain English, active voice, and avoid parenthetical abbreviations.

---
*PR created automatically by Jules for task [17493763467878620741](https://jules.google.com/task/17493763467878620741) started by @RainRat*