### PR TITLE
[UI/UX] Suggest closest valid slash command on typos in interactive shell

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1108,8 +1108,19 @@ def handle_shell(args):
                     print("        indices (e.g., '/compare 1-3, 5').")
                     print()
                 else:
-                    err_msg = f"Unknown command: {cmd}. Type /help for assistance."
-                    if use_color: err_msg = utils.colorize(err_msg, utils.Ansi.BOLD + utils.Ansi.RED)
+                    all_slash_cmds = [
+                        '/search', '/oracle', '/random', '/sets', '/functional',
+                        '/compare', '/reprints', '/substitutes', '/counterparts',
+                        '/superior', '/inferior', '/similar', '/extract', '/list',
+                        '/results', '/help', '/clear', '/exit', '/quit'
+                    ]
+                    closest = difflib.get_close_matches(cmd, all_slash_cmds, n=1, cutoff=0.5)
+                    if closest:
+                        err_msg = f"Unknown command: {cmd}. Did you mean {closest[0]}? Type /help for assistance."
+                    else:
+                        err_msg = f"Unknown command: {cmd}. Type /help for assistance."
+                    if use_color:
+                        err_msg = utils.colorize(err_msg, utils.Ansi.BOLD + utils.Ansi.RED)
                     print(err_msg)
             else:
                 # Oracle lookup

--- a/tests/test_mtg_shell.py
+++ b/tests/test_mtg_shell.py
@@ -214,5 +214,29 @@ class TestMtgShell(unittest.TestCase):
                 self.assertEqual(completer('/l', 0), '/list')
                 self.assertEqual(completer('/l', 1), '/l')
 
+    def test_shell_unknown_command_suggestions(self):
+        """Test suggestions for misspelled or unknown slash commands."""
+        # 1. Close match '/searc' -> Suggests '/search'
+        with patch('builtins.input', side_effect=['/searc', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Unknown command: /searc. Did you mean /search? Type /help for assistance.", output)
+
+        # 2. Close match '/orcl' -> Suggests '/oracle'
+        with patch('builtins.input', side_effect=['/orcl', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Unknown command: /orcl. Did you mean /oracle? Type /help for assistance.", output)
+
+        # 3. No close match '/xyz' -> No suggestion
+        with patch('builtins.input', side_effect=['/xyz', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Unknown command: /xyz. Type /help for assistance.", output)
+                self.assertNotIn("Did you mean", output)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* **Context:** CLI (Command Line Interface - Interactive Shell)
* **Problem:** If a user makes a typo when typing a slash command in the interactive shell (e.g., entering `/orcl` or `/searc`), the system simply outputs an unhelpful "Unknown command" error and forces them to manually view `/help`, causing friction and breaking user flow.
* **Solution:** We integrated Python's standard `difflib.get_close_matches` with a friendly similarity threshold to automatically suggest the closest valid command (e.g., "Did you mean `/oracle`?"). This provides clear, contextual feedback, improves error tolerance, and aligns with the existing fuzzy matching logic for card names.

### Changes:
```python
# scripts/mtg_query.py
                else:
                    all_slash_cmds = [
                        '/search', '/oracle', '/random', '/sets', '/functional',
                        '/compare', '/reprints', '/substitutes', '/counterparts',
                        '/superior', '/inferior', '/similar', '/extract', '/list',
                        '/results', '/help', '/clear', '/exit', '/quit'
                    ]
                    closest = difflib.get_close_matches(cmd, all_slash_cmds, n=1, cutoff=0.5)
                    if closest:
                        err_msg = f"Unknown command: {cmd}. Did you mean {closest[0]}? Type /help for assistance."
                    else:
                        err_msg = f"Unknown command: {cmd}. Type /help for assistance."
                    if use_color:
                        err_msg = utils.colorize(err_msg, utils.Ansi.BOLD + utils.Ansi.RED)
                    print(err_msg)
```

---
*PR created automatically by Jules for task [11934541840622429227](https://jules.google.com/task/11934541840622429227) started by @RainRat*