### PR TITLE
Remove redundant integer conversion in list_split

### DIFF
--- a/lib/namediff.py
+++ b/lib/namediff.py
@@ -27,7 +27,7 @@ def list_split(l, n):
     split_size = len(l) // n
     if len(l) % n > 0:
         split_size += 1
-    return [l[i:i+split_size] for i in range(0, len(l), int(split_size))]
+    return [l[i:i+split_size] for i in range(0, len(l), split_size)]
 
 # flatten a list of lists into a single list of all their contents, in order
 def list_flatten(l):


### PR DESCRIPTION
This PR removes a redundant integer conversion in `lib/namediff.py`.

### Changes
* Removed `int()` cast around `split_size` in the `list_split` function under `lib/namediff.py`. Since `split_size` is calculated using floor division (`//`), its type is already guaranteed to be `int`.

### Benefits
* Improved code hygiene and readability.
* Removes redundant validation on type guarantees.

---
*PR created automatically by Jules for task [237294902013680526](https://jules.google.com/task/237294902013680526) started by @RainRat*