### PR TITLE
[UI/UX] Implement Graceful Suggestion System for Unknown Shell Commands

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -1108,7 +1108,30 @@ def handle_shell(args):
                     print("        indices (e.g., '/compare 1-3, 5').")
                     print()
                 else:
-                    err_msg = f"Unknown command: {cmd}. Type /help for assistance."
+                    valid_commands = [
+                        '/search', '/s',
+                        '/oracle', '/o',
+                        '/random', '/r',
+                        '/sets', '/st',
+                        '/functional', '/f',
+                        '/compare', '/c',
+                        '/superior', '/sup',
+                        '/inferior', '/inf',
+                        '/reprints', '/rep',
+                        '/substitutes', '/sub',
+                        '/counterparts', '/cp',
+                        '/similar',
+                        '/extract', '/e',
+                        '/list', '/l', '/results',
+                        '/help', '/h', '/?',
+                        '/clear', '/cls',
+                        '/exit', '/quit', '/q'
+                    ]
+                    close_cmds = difflib.get_close_matches(cmd, valid_commands, n=1, cutoff=0.5)
+                    err_msg = f"Unknown command: {cmd}."
+                    if close_cmds:
+                        err_msg += f" Did you mean {close_cmds[0]}?"
+                    err_msg += " Type /help for assistance."
                     if use_color: err_msg = utils.colorize(err_msg, utils.Ansi.BOLD + utils.Ansi.RED)
                     print(err_msg)
             else:

--- a/tests/test_mtg_shell.py
+++ b/tests/test_mtg_shell.py
@@ -214,5 +214,31 @@ class TestMtgShell(unittest.TestCase):
                 self.assertEqual(completer('/l', 0), '/list')
                 self.assertEqual(completer('/l', 1), '/l')
 
+    def test_shell_unknown_command_suggestion(self):
+        """Test that unknown commands suggest the closest valid command."""
+        # Test command with a close match (e.g., /serch -> /search)
+        with patch('builtins.input', side_effect=['/serch', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Unknown command: /serch.", output)
+                self.assertIn("Did you mean /search?", output)
+
+        # Test command with another close match (e.g., /comp -> /compare)
+        with patch('builtins.input', side_effect=['/comp', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Unknown command: /comp.", output)
+                self.assertIn("Did you mean /compare?", output)
+
+        # Test completely unrecognized command (no suggestions)
+        with patch('builtins.input', side_effect=['/xyzabc123', 'exit']):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                handle_shell(self.args)
+                output = fake_out.getvalue()
+                self.assertIn("Unknown command: /xyzabc123.", output)
+                self.assertNotIn("Did you mean", output)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** In the `mtg_query.py` interactive shell, typing an incorrect or misspelled slash command (e.g., `/serch` or `/comp`) outputs a generic `Unknown command` error message without any guidance, which increases user friction.
* **Solution:** Added a graceful command suggestion system to `handle_shell` using `difflib.get_close_matches`. If the user inputs an unknown command that closely matches a canonical command or alias, the system suggests it (e.g., "Did you mean /search?"). Added a comprehensive test suite covering multiple suggestion scenarios and fully verified that all tests pass without regressions.

---
*PR created automatically by Jules for task [17359346870198461667](https://jules.google.com/task/17359346870198461667) started by @RainRat*