### PR TITLE
Refactor broad except block in Markdown stdin detection to catch specific exceptions

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -1353,7 +1353,7 @@ def mtg_open_file(fname, verbose = False,
                     cards = _process_json_srcs(md_srcs, bad_sets, verbose, linetrans,
                                                exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                                decklist_names=decklist_names)
-                except Exception:
+                except (ValueError, TypeError):
                     pass
         else:
             # Check if it's a decklist file based on extension or content


### PR DESCRIPTION
Narrowed down the broad catch-all `except Exception` during Markdown stdin detection to only catch expected parsing and type errors (`ValueError` and `TypeError`). This improves code maintainability and debugging safety.

---
*PR created automatically by Jules for task [10783093304027422848](https://jules.google.com/task/10783093304027422848) started by @RainRat*