### PR TITLE
[FEAT] Proportional Mana Base Generation in mtg_deckgen

### DIFF
--- a/scripts/mtg_deckgen.py
+++ b/scripts/mtg_deckgen.py
@@ -8,12 +8,14 @@ from collections import defaultdict, Counter
 # Add lib directory to path
 libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
 sys.path.append(libdir)
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 import utils
 import jdecode
 import cardlib
 import datalib
 import cli_utils
+import mtg_manabase
 
 def get_color_identity_set(card):
     # Returns a set of characters like {'W', 'U'}
@@ -253,19 +255,13 @@ Usage Examples:
         deck_creatures = pick_cards_with_curve(creatures_pool, creatures_target, curve=curve)
         deck_spells = pick_cards_with_curve(spells_pool, spells_target)
         
-        deck_lands = []
-        basics_to_add = []
-        if 'W' in cmd_id: basics_to_add.append('Plains')
-        if 'U' in cmd_id: basics_to_add.append('Island')
-        if 'B' in cmd_id: basics_to_add.append('Swamp')
-        if 'R' in cmd_id: basics_to_add.append('Mountain')
-        if 'G' in cmd_id: basics_to_add.append('Forest')
+        deck_cards_for_mana = [commander_card] + deck_creatures + deck_spells
+        recommendation, _, _ = mtg_manabase.calculate_manabase(deck_cards_for_mana, lands_target)
         
-        if not basics_to_add:
-            basics_to_add.append('Wastes')
-            
-        for i in range(lands_target):
-            deck_lands.append(random.choice(basics_to_add))
+        deck_lands = []
+        for land, count in recommendation.items():
+            for _ in range(count):
+                deck_lands.append(land)
             
         decklist.append(f"1 {commander_card.display_name} *CMDR*")
         actual_composition['Commander'] = 1
@@ -301,6 +297,8 @@ Usage Examples:
             spells_target = 0
 
         raw_decklist = []
+        c_sample = []
+        s_sample = []
         
         if creatures_target > 0:
             # In standard, we allow multiple copies, so we sample a smaller unique pool and then repeat
@@ -318,13 +316,17 @@ Usage Examples:
             
         grouped = Counter(raw_decklist)
 
+        # Map name -> Card object to calculate mana base
+        card_obj_map = {c.display_name: c for c in (c_sample + s_sample)}
+        deck_cards_for_mana = [card_obj_map[name] for name in raw_decklist if name in card_obj_map]
+
+        recommendation, _, _ = mtg_manabase.calculate_manabase(deck_cards_for_mana, lands_target)
+
         # Basic land distribution
-        basics_to_add = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest']
-        # Pick 2 colors at random for standard deck unless filtered
-        land_choices = random.sample(basics_to_add, 2)
-        for i in range(lands_target):
-            l = random.choice(land_choices)
-            grouped[l] += 1
+        basics_to_add = {'Plains', 'Island', 'Swamp', 'Mountain', 'Forest', 'Wastes'}
+        for land, count in recommendation.items():
+            if count > 0:
+                grouped[land] += count
             
         for name, count in sorted(grouped.items()):
             decklist.append(f"{count} {name}")

--- a/scripts/mtg_manabase.py
+++ b/scripts/mtg_manabase.py
@@ -138,6 +138,7 @@ Usage Examples:
     fmt_group.add_argument('--table', action='store_true', help='Generate a formatted table (Default).')
     fmt_group.add_argument('-j', '--json', action='store_true', help='Generate a structured JSON file.')
     fmt_group.add_argument('--csv', action='store_true', help='Generate a CSV file.')
+    fmt_group.add_argument('--deck', '--decklist', action='store_true', dest='deck_out', help='Generate a standard MTG decklist combining input cards and recommended lands.')
 
     # Group: Filtering Options (Standard across tools)
     filter_group = parser.add_argument_group('Filtering Options')
@@ -180,10 +181,11 @@ Usage Examples:
                 print(f"Notice: Using default dataset: {args.infile}", file=sys.stderr)
 
     # Auto-detect format from extension
-    if not (args.json or args.csv or args.table):
+    if not (args.json or args.csv or args.table or getattr(args, 'deck_out', False)):
         if args.outfile:
             if args.outfile.endswith('.json'): args.json = True
             elif args.outfile.endswith('.csv'): args.csv = True
+            elif args.outfile.endswith('.deck') or args.outfile.endswith('.dek'): args.deck_out = True
             else: args.table = True
         else:
             args.table = True
@@ -192,7 +194,7 @@ Usage Examples:
     use_color = False
     if args.color is True:
         use_color = True
-    elif args.color is None and not (args.json or args.csv) and sys.stdout.isatty():
+    elif args.color is None and not (args.json or args.csv or getattr(args, 'deck_out', False)) and sys.stdout.isatty():
         use_color = True
 
     # Load and filter cards
@@ -227,6 +229,28 @@ Usage Examples:
                 'recommendation': recommendation
             }
             output_f.write(json.dumps(result, indent=2) + '\n')
+        elif getattr(args, 'deck_out', False):
+            basic_land_names = {'Plains', 'Island', 'Swamp', 'Mountain', 'Forest', 'Wastes'}
+            counts = {}
+            for card in cards:
+                if card.display_name in basic_land_names:
+                    continue
+                key = (card.display_name, card.set_code, card.number)
+                counts[key] = counts.get(key, 0) + 1
+
+            for (name, set_code, number), count in counts.items():
+                line = f"{count} {name}"
+                if set_code:
+                    line += f" ({set_code.upper()})"
+                    if number:
+                        line += f" {number}"
+                output_f.write(line + '\n')
+
+            land_order = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest', 'Wastes']
+            for land in land_order:
+                count = recommendation.get(land, 0)
+                if count > 0:
+                    output_f.write(f"{count} {land}\n")
         elif args.csv:
             writer = csv.writer(output_f)
             writer.writerow(['Category', 'Item', 'Value', 'Percent'])

--- a/tests/test_mtg_deckgen.py
+++ b/tests/test_mtg_deckgen.py
@@ -135,5 +135,40 @@ class TestMtgDeckgen(unittest.TestCase):
             mtg_deckgen.main()
         self.assertIn("Warning: No non-creature spells found", mock_stderr.getvalue())
 
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_land_proportional_to_pips(self, mock_stderr, mock_stdout, mock_open):
+        # Pool with only Green spells
+        commander = cardlib.Card({
+            'name': 'Galia',
+            'supertypes': ['Legendary'],
+            'types': ['Creature'],
+            'manaCost': '{G}',
+            'rarity': 'rare',
+            'text': ''
+        })
+
+        card1 = cardlib.Card({
+            'name': 'Green Creature',
+            'types': ['Creature'],
+            'manaCost': '{1}{G}',
+            'rarity': 'common',
+            'text': ''
+        })
+
+        mock_open.return_value = [commander, card1]
+
+        # Test commander format - should recommend only Forest and no other basic lands
+        with patch('sys.argv', ['mtg_deckgen.py', 'dummy.json', '--format', 'commander', '--commander', 'Galia']):
+            mtg_deckgen.main()
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Forest", output)
+        self.assertNotIn("Plains", output)
+        self.assertNotIn("Island", output)
+        self.assertNotIn("Swamp", output)
+        self.assertNotIn("Mountain", output)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Integrate the proportional basic land calculation logic from mtg_manabase into mtg_deckgen for high-fidelity deck generation. Additionally, add a standard MTG decklist output option to mtg_manabase to output full decks with basic lands included.

---
*PR created automatically by Jules for task [16815622297871213980](https://jules.google.com/task/16815622297871213980) started by @RainRat*