### PR TITLE
Refactor broad except block during Markdown stdin detection

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -1353,7 +1353,7 @@ def mtg_open_file(fname, verbose = False,
                     cards = _process_json_srcs(md_srcs, bad_sets, verbose, linetrans,
                                                exclude_sets, exclude_types, exclude_layouts, report_fobj,
                                                decklist_names=decklist_names)
-                except Exception:
+                except (ValueError, TypeError):
                     pass
         else:
             # Check if it's a decklist file based on extension or content


### PR DESCRIPTION
Refactored the catch-all `except Exception:` during Markdown stdin detection in `lib/jdecode.py` to target only specific, anticipated exceptions (`ValueError`, `TypeError`), improving overall error hygiene and debuggability in compliance with the target issue categories (specifically "Error Handling Noise").

---
*PR created automatically by Jules for task [11736260975843076580](https://jules.google.com/task/11736260975843076580) started by @RainRat*