### PR TITLE
[FEAT] Intelligent land distribution in mtg_deckgen.py based on card pips

### DIFF
--- a/scripts/mtg_deckgen.py
+++ b/scripts/mtg_deckgen.py
@@ -15,6 +15,11 @@ import cardlib
 import datalib
 import cli_utils
 
+# Add scripts directory to path to allow importing from mtg_manabase
+scripts_dir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(scripts_dir)
+from mtg_manabase import calculate_manabase
+
 def get_color_identity_set(card):
     # Returns a set of characters like {'W', 'U'}
     if not hasattr(card, 'color_identity') or not card.color_identity:
@@ -254,18 +259,11 @@ Usage Examples:
         deck_spells = pick_cards_with_curve(spells_pool, spells_target)
         
         deck_lands = []
-        basics_to_add = []
-        if 'W' in cmd_id: basics_to_add.append('Plains')
-        if 'U' in cmd_id: basics_to_add.append('Island')
-        if 'B' in cmd_id: basics_to_add.append('Swamp')
-        if 'R' in cmd_id: basics_to_add.append('Mountain')
-        if 'G' in cmd_id: basics_to_add.append('Forest')
-        
-        if not basics_to_add:
-            basics_to_add.append('Wastes')
-            
-        for i in range(lands_target):
-            deck_lands.append(random.choice(basics_to_add))
+        spells_for_manabase = [commander_card] + deck_creatures + deck_spells
+        recommendation, _, _ = calculate_manabase(spells_for_manabase, lands_target)
+        for land, count in recommendation.items():
+            if count > 0:
+                deck_lands.extend([land] * count)
             
         decklist.append(f"1 {commander_card.display_name} *CMDR*")
         actual_composition['Commander'] = 1
@@ -300,32 +298,31 @@ Usage Examples:
                 print("Warning: No non-creature spells found in pool for standard deck.", file=sys.stderr)
             spells_target = 0
 
-        raw_decklist = []
+        chosen_cards = []
         
         if creatures_target > 0:
             # In standard, we allow multiple copies, so we sample a smaller unique pool and then repeat
             # Heuristic: about 4-of each unique card
             c_sample = pick_cards_with_curve(creatures_pool, max(1, creatures_target // 4))
             if c_sample:
-                for i in range(creatures_target):
-                    raw_decklist.append(random.choice(c_sample).display_name)
+                for _ in range(creatures_target):
+                    chosen_cards.append(random.choice(c_sample))
             
         if spells_target > 0:
             s_sample = pick_cards_with_curve(spells_pool, max(1, spells_target // 4))
             if s_sample:
-                for i in range(spells_target):
-                    raw_decklist.append(random.choice(s_sample).display_name)
+                for _ in range(spells_target):
+                    chosen_cards.append(random.choice(s_sample))
             
-        grouped = Counter(raw_decklist)
+        grouped = Counter([c.display_name for c in chosen_cards])
 
-        # Basic land distribution
-        basics_to_add = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest']
-        # Pick 2 colors at random for standard deck unless filtered
-        land_choices = random.sample(basics_to_add, 2)
-        for i in range(lands_target):
-            l = random.choice(land_choices)
-            grouped[l] += 1
+        # Basic land distribution using calculate_manabase
+        recommendation, _, _ = calculate_manabase(chosen_cards, lands_target)
+        for land, count in recommendation.items():
+            if count > 0:
+                grouped[land] += count
             
+        basics_to_add = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest', 'Wastes']
         for name, count in sorted(grouped.items()):
             decklist.append(f"{count} {name}")
             if name in basics_to_add:

--- a/tests/test_mtg_deckgen_manabase.py
+++ b/tests/test_mtg_deckgen_manabase.py
@@ -1,0 +1,111 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import io
+
+# Add lib and scripts directory to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../scripts'))
+
+import mtg_deckgen
+import cardlib
+
+class TestMtgDeckgenManabase(unittest.TestCase):
+
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_commander_proportional_manabase(self, mock_stderr, mock_stdout, mock_open):
+        """
+        Verify that in Commander format, land allocation is proportional to the selected spell pips.
+        """
+        commander = cardlib.Card({
+            'name': 'Uthros, the Glimmering',
+            'supertypes': ['Legendary'],
+            'types': ['Creature'],
+            'manaCost': '{R}{G}',
+            'colorIdentity': ['R', 'G'],
+            'rarity': 'rare',
+            'text': ''
+        })
+
+        # All spells only cost Green ({G})
+        green_spell = cardlib.Card({
+            'name': 'Grizzly Bears',
+            'types': ['Creature'],
+            'manaCost': '{1}{G}',
+            'rarity': 'common',
+            'text': ''
+        })
+
+        # Mock the cards loaded from file
+        mock_open.return_value = [commander, green_spell]
+
+        with patch('sys.argv', ['mtg_deckgen.py', 'dummy.json', '--format', 'commander', '--commander', 'Uthros, the Glimmering', '--creatures', '2', '--spells', '0', '--lands', '10']):
+            mtg_deckgen.main()
+
+        output = mock_stdout.getvalue()
+        # Since green_spell has 1 green pip and commander has {R}{G}, there are more green pips (2) than red pips (1).
+        # Green (Forest) should have more lands than Red (Mountain), but both should be present.
+        lines = output.strip().split('\n')
+        lands = {}
+        for line in lines:
+            parts = line.split(' ', 1)
+            if len(parts) == 2 and parts[1].strip() in ['Forest', 'Mountain', 'Plains', 'Island', 'Swamp', 'Wastes']:
+                lands[parts[1].strip()] = int(parts[0])
+
+        self.assertIn('Forest', lands)
+        self.assertIn('Mountain', lands)
+        self.assertGreater(lands['Forest'], lands['Mountain'])
+        self.assertEqual(sum(lands.values()), 10)
+
+    @patch('jdecode.mtg_open_file')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_standard_proportional_manabase(self, mock_stderr, mock_stdout, mock_open):
+        """
+        Verify that in Standard format, land allocation is proportional to spell pips.
+        """
+        # Blue spell
+        blue_spell = cardlib.Card({
+            'name': 'Counterspell',
+            'types': ['Instant'],
+            'manaCost': '{U}{U}',
+            'rarity': 'common',
+            'text': ''
+        })
+
+        # White spell
+        white_spell = cardlib.Card({
+            'name': 'Savannah Lions',
+            'types': ['Creature'],
+            'manaCost': '{W}',
+            'rarity': 'common',
+            'text': ''
+        })
+
+        # Mock the cards loaded from file
+        mock_open.return_value = [blue_spell, white_spell]
+
+        with patch('sys.argv', ['mtg_deckgen.py', 'dummy.json', '--format', 'standard', '--creatures', '4', '--spells', '4', '--lands', '10']):
+            mtg_deckgen.main()
+
+        output = mock_stdout.getvalue()
+        # Since counterspell has 2 blue pips and Savannah Lions has 1 white pip,
+        # there should be significantly more Islands than Plains, but both should be present.
+        lines = output.strip().split('\n')
+        lands = {}
+        for line in lines:
+            parts = line.split(' ', 1)
+            if len(parts) == 2 and parts[1].strip() in ['Forest', 'Mountain', 'Plains', 'Island', 'Swamp', 'Wastes']:
+                lands[parts[1].strip()] = int(parts[0])
+
+        self.assertIn('Island', lands)
+        self.assertIn('Plains', lands)
+        self.assertGreater(lands['Island'], lands['Plains'])
+        self.assertEqual(sum(lands.values()), 10)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In `scripts/mtg_deckgen.py`, when generating Standard and Commander format decks, proportional basic land distribution is now determined intelligently by calling `calculate_manabase` from `scripts/mtg_manabase.py` based on the color pips of the selected spells. This replaces the previous naive random choice land allocation and provides immediate, realistic land distributions for any generated deck. Added unit tests in `tests/test_mtg_deckgen_manabase.py` to verify this behavior.

---
*PR created automatically by Jules for task [17708876090837076947](https://jules.google.com/task/17708876090837076947) started by @RainRat*