### PR TITLE
[UI/UX] Prevent interactive terminal hangs in mtg_manabase.py

### DIFF
--- a/scripts/mtg_manabase.py
+++ b/scripts/mtg_manabase.py
@@ -179,6 +179,14 @@ Usage Examples:
             if not args.quiet:
                 print(f"Notice: Using default dataset: {args.infile}", file=sys.stderr)
 
+    # Graceful check for dataset requirements in interactive terminal (prevent hangs)
+    if args.infile == '-' and sys.stdin.isatty():
+        parser.print_help()
+        print("\nError: Mana base calculation requires an input dataset or decklist. "
+              "Please specify a file or pipe input, or make data/AllPrintings.json available.",
+              file=sys.stderr)
+        sys.exit(1)
+
     # Auto-detect format from extension
     if not (args.json or args.csv or args.table):
         if args.outfile:

--- a/tests/test_mtg_manabase_gaps.py
+++ b/tests/test_mtg_manabase_gaps.py
@@ -184,5 +184,25 @@ class TestMtgManabaseGaps(unittest.TestCase):
             self.assertGreaterEqual(val, 0, f"Value for {val} is negative")
         self.assertEqual(sum(recommendation.values()), 3)
 
+    def test_main_interactive_no_args(self):
+        with patch('sys.stdin.isatty', return_value=True):
+            with patch('sys.argv', ['mtg_manabase.py']):
+                with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                    with patch('sys.stderr', new=io.StringIO()) as fake_err:
+                        with self.assertRaises(SystemExit) as cm:
+                            main()
+                        self.assertEqual(cm.exception.code, 1)
+                        self.assertIn("Recommend a basic land distribution", fake_out.getvalue())
+                        self.assertIn("Error: Mana base calculation requires an input dataset", fake_err.getvalue())
+
+    def test_main_interactive_missing_dataset_error(self):
+        with patch('sys.stdin.isatty', return_value=True):
+            with patch('sys.argv', ['mtg_manabase.py', '-']):
+                with patch('sys.stderr', new=io.StringIO()) as fake_err:
+                    with self.assertRaises(SystemExit) as cm:
+                        main()
+                    self.assertEqual(cm.exception.code, 1)
+                    self.assertIn("Error: Mana base calculation requires an input dataset", fake_err.getvalue())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request addresses a CLI usability friction point in `scripts/mtg_manabase.py` where running the script interactively on empty standard input (when AllPrintings.json is not present) would cause the terminal to hang on `sys.stdin.read()`. It now outputs the help description and exits gracefully with status 1, matching the high standards of standard interactive CLI tools. Unit tests have also been added to cover this behavior.

---
*PR created automatically by Jules for task [15741952713688170261](https://jules.google.com/task/15741952713688170261) started by @RainRat*