### PR TITLE
feat: Add decklist output format to mana base advisor

### DIFF
--- a/scripts/mtg_manabase.py
+++ b/scripts/mtg_manabase.py
@@ -5,7 +5,7 @@ import argparse
 import math
 import json
 import csv
-from collections import Counter
+from collections import Counter, OrderedDict
 
 # Add lib directory to path
 libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
@@ -138,6 +138,8 @@ Usage Examples:
     fmt_group.add_argument('--table', action='store_true', help='Generate a formatted table (Default).')
     fmt_group.add_argument('-j', '--json', action='store_true', help='Generate a structured JSON file.')
     fmt_group.add_argument('--csv', action='store_true', help='Generate a CSV file.')
+    fmt_group.add_argument('--deck', '--decklist', dest='deck_out', action='store_true',
+                           help='Generate a complete MTG decklist containing original spells and recommended basic lands.')
 
     # Group: Filtering Options (Standard across tools)
     filter_group = parser.add_argument_group('Filtering Options')
@@ -180,10 +182,11 @@ Usage Examples:
                 print(f"Notice: Using default dataset: {args.infile}", file=sys.stderr)
 
     # Auto-detect format from extension
-    if not (args.json or args.csv or args.table):
+    if not (args.json or args.csv or args.table or args.deck_out):
         if args.outfile:
             if args.outfile.endswith('.json'): args.json = True
             elif args.outfile.endswith('.csv'): args.csv = True
+            elif args.outfile.endswith('.deck') or args.outfile.endswith('.dek'): args.deck_out = True
             else: args.table = True
         else:
             args.table = True
@@ -192,7 +195,7 @@ Usage Examples:
     use_color = False
     if args.color is True:
         use_color = True
-    elif args.color is None and not (args.json or args.csv) and sys.stdout.isatty():
+    elif args.color is None and not (args.json or args.csv or args.deck_out) and sys.stdout.isatty():
         use_color = True
 
     # Load and filter cards
@@ -227,6 +230,33 @@ Usage Examples:
                 'recommendation': recommendation
             }
             output_f.write(json.dumps(result, indent=2) + '\n')
+        elif args.deck_out:
+            try:
+                from titlecase import titlecase
+            except ImportError:
+                def titlecase(text):
+                    return text.title()
+
+            counts = OrderedDict()
+            for card in cards:
+                if card.name.lower() in ['plains', 'island', 'swamp', 'mountain', 'forest', 'wastes']:
+                    continue
+                key = (card.name, card.set_code, card.number)
+                counts[key] = counts.get(key, 0) + 1
+
+            for (name, set_code, number), count in counts.items():
+                line = f"{count} {titlecase(name)}"
+                if set_code:
+                    line += f" ({set_code.upper()})"
+                    if number:
+                        line += f" {number}"
+                output_f.write(line + '\n')
+
+            land_order = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest', 'Wastes']
+            for land in land_order:
+                count = recommendation.get(land, 0)
+                if count > 0:
+                    output_f.write(f"{count} {land}\n")
         elif args.csv:
             writer = csv.writer(output_f)
             writer.writerow(['Category', 'Item', 'Value', 'Percent'])

--- a/tests/test_mtg_manabase_deck_out.py
+++ b/tests/test_mtg_manabase_deck_out.py
@@ -1,0 +1,107 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import io
+import sys
+import os
+import json
+
+# Add lib directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.append(libdir)
+
+from scripts.mtg_manabase import main
+import cardlib
+from manalib import Manacost, Manatext
+
+
+class TestMtgManabaseDeckOut(unittest.TestCase):
+
+    def test_deck_out_includes_original_spells_and_excludes_original_basic_lands_while_appending_recommended_lands(self):
+        # Create a card with {W} cost
+        card_spell = MagicMock(spec=cardlib.Card)
+        card_spell.name = "grizzly bears"
+        card_spell.is_land = False
+        card_spell.set_code = "lea"
+        card_spell.number = "101"
+        card_spell.cost = MagicMock(spec=Manacost)
+        card_spell.cost.allsymbols = {'W': 1}
+        card_spell.cost.cmc = 1.0
+        card_spell.cost.colors = ['W']
+        card_spell.text = MagicMock(spec=Manatext)
+        card_spell.text.costs = []
+        card_spell.bside = None
+
+        # Create an existing basic land that should be ignored/excluded from the output
+        card_basic_land = MagicMock(spec=cardlib.Card)
+        card_basic_land.name = "plains"
+        card_basic_land.is_land = True
+        card_basic_land.set_code = "lea"
+        card_basic_land.number = "200"
+        card_basic_land.cost = MagicMock(spec=Manacost)
+        card_basic_land.cost.allsymbols = {}
+        card_basic_land.cost.cmc = 0.0
+        card_basic_land.cost.colors = []
+        card_basic_land.text = MagicMock(spec=Manatext)
+        card_basic_land.text.costs = []
+        card_basic_land.bside = None
+
+        cards = [card_spell, card_spell, card_basic_land]
+
+        with patch('jdecode.mtg_open_file', return_value=cards):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                with patch('sys.argv', ['mtg_manabase.py', 'test_deck.txt', '--lands', '17', '--deck']):
+                    main()
+                    output = fake_out.getvalue()
+
+                    # Original non-basic spells must be in the output with correct counts
+                    self.assertIn("2 Grizzly Bears (LEA) 101", output)
+
+                    # Any existing Plains should not be copied from input cards (the test plains)
+                    self.assertNotIn("1 Plains (LEA) 200", output)
+                    self.assertNotIn("Plains (LEA) 200", output)
+
+                    # Recommended lands must be appended
+                    self.assertIn("17 Plains", output)
+
+    def test_deck_out_auto_detects_format_from_file_extension(self):
+        # Create a card with {U} cost
+        card_spell = MagicMock(spec=cardlib.Card)
+        card_spell.name = "opt"
+        card_spell.is_land = False
+        card_spell.set_code = "xlb"
+        card_spell.number = "12"
+        card_spell.cost = MagicMock(spec=Manacost)
+        card_spell.cost.allsymbols = {'U': 1}
+        card_spell.cost.cmc = 1.0
+        card_spell.cost.colors = ['U']
+        card_spell.text = MagicMock(spec=Manatext)
+        card_spell.text.costs = []
+        card_spell.bside = None
+
+        cards = [card_spell]
+
+        with patch('jdecode.mtg_open_file', return_value=cards):
+            with patch('sys.argv', ['mtg_manabase.py', 'test_deck.txt', 'out_deck.deck', '--lands', '12']):
+                # We patch the built-in open for writing
+                mock_file = MagicMock()
+                with patch('builtins.open', return_value=mock_file) as mock_open:
+                    main()
+                    mock_open.assert_called_with('out_deck.deck', 'w', encoding='utf-8')
+
+                    # Gather all calls to write
+                    write_calls = "".join(call.args[0] for call in mock_file.write.call_args_list)
+                    self.assertIn("1 Opt (XLB) 12", write_calls)
+                    self.assertIn("12 Island", write_calls)
+
+    def test_deck_out_with_empty_card_pool_prints_no_cards_found_message(self):
+        with patch('jdecode.mtg_open_file', return_value=[]):
+            with patch('sys.stderr', new=io.StringIO()) as fake_err:
+                with patch('sys.argv', ['mtg_manabase.py', 'test_deck.txt', '--deck', '--quiet']):
+                    main()
+                    # It should not raise an error or write decklist, just exit silently or with empty output
+                    # The main function returns without writing when cards list is empty
+                    pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This feature adds a --deck / --decklist flag (with dest='deck_out') to mtg_manabase.py. It generates a complete MTG decklist containing original spells and recommended basic lands, automatically excluding recommended basic lands from original counts and preserving non-basic lands. It also auto-detects this format for .deck / .dek file extensions.

---
*PR created automatically by Jules for task [400352396991039991](https://jules.google.com/task/400352396991039991) started by @RainRat*