### PR TITLE
Fix NameError in scripts/analysis.py when sep=False

### DIFF
--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -133,7 +133,7 @@ def get_statistics(fname, lm = None, sep = False, verbose=False):
                 perp = lm.perplexity(vtext)
                 perp_per = perp / float(len(vtext))
                 perp_max = perp
-                perp_per_max = perps_per
+                perp_per_max = perp_per
 
             ngram['perp'] += [perp]
             ngram['perp_per'] += [perp_per]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+import sys
+import os
+
+# Add scripts directory to sys.path so we can import analysis and ngrams
+scripts_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), '../scripts'))
+if scripts_dir not in sys.path:
+    sys.path.append(scripts_dir)
+
+import analysis
+import cardlib
+import ngrams
+
+def test_get_statistics_sep_false():
+    # Mock jdecode.mtg_open_file to return a list of cardlib.Card objects
+    mock_cards = [
+        cardlib.Card({
+            'name': 'Giant Growth',
+            'manaCost': '{G}',
+            'text': 'Target creature gets +3/+3 until end of turn.',
+            'type': 'Instant',
+            'rarity': 'Common',
+            'types': ['Instant']
+        })
+    ]
+
+    lm = ngrams.build_ngram_model(mock_cards, 3, separate_lines=False)
+
+    with patch('jdecode.mtg_open_file', return_value=mock_cards):
+        # We call get_statistics with sep=False (which triggers the else block where NameError was raised)
+        stats = analysis.get_statistics("dummy_path.txt", lm=lm, sep=False)
+
+        # Verify that we got statistics and no NameError was raised!
+        assert 'ngram' in stats
+        assert 'perp' in stats['ngram']
+        assert len(stats['ngram']['perp']) == 1
+        assert len(stats['ngram']['perp_per_max']) == 1
+
+def test_get_statistics_sep_true():
+    mock_cards = [
+        cardlib.Card({
+            'name': 'Giant Growth',
+            'manaCost': '{G}',
+            'text': 'Target creature gets +3/+3 until end of turn.',
+            'type': 'Instant',
+            'rarity': 'Common',
+            'types': ['Instant']
+        })
+    ]
+
+    lm = ngrams.build_ngram_model(mock_cards, 3, separate_lines=True)
+
+    with patch('jdecode.mtg_open_file', return_value=mock_cards):
+        stats = analysis.get_statistics("dummy_path.txt", lm=lm, sep=True)
+        assert 'ngram' in stats
+        assert 'perp' in stats['ngram']
+        assert len(stats['ngram']['perp']) == 1


### PR DESCRIPTION
This pull request resolves a logic bug/typo in scripts/analysis.py where calling get_statistics with sep=False caused a NameError due to referencing an undefined variable perps_per. It also includes unit tests in tests/test_analysis.py to prevent regressions.

---
*PR created automatically by Jules for task [6434918700022351542](https://jules.google.com/task/6434918700022351542) started by @RainRat*