### PR TITLE
Inline premature abstraction cosine_similarity_name in lib/cbow.py

### DIFF
--- a/lib/cbow.py
+++ b/lib/cbow.py
@@ -116,9 +116,6 @@ def cosine_similarity(v1,v2):
 
     return cosine[0][1]
 
-def cosine_similarity_name(cardvec, v, name):
-    return (cosine_similarity(cardvec, v), name)
-
 # we need to put the logic in a regular function (as opposed to a method of an object)
 # so that we can pass the function to multiprocessing
 def f_nearest(card, vocab, vecs, cardvecs, n):
@@ -133,7 +130,7 @@ def f_nearest(card, vocab, vecs, cardvecs, n):
 
     cardvec = makevector(vocab, vecs, words)
 
-    comparisons = [cosine_similarity_name(cardvec, v, name) for (name, v) in cardvecs]
+    comparisons = [(cosine_similarity(cardvec, v), name) for (name, v) in cardvecs]
 
     comparisons.sort(reverse = True)
     comp_n = comparisons[:n]


### PR DESCRIPTION
Remove the thin, redundant helper `cosine_similarity_name` in `lib/cbow.py` by inlining its logic directly into the list comprehension in `f_nearest`. This achieves cleaner, more maintainable code and eliminates premature abstraction.

---
*PR created automatically by Jules for task [4667193438728050210](https://jules.google.com/task/4667193438728050210) started by @RainRat*