### PR TITLE
[UI/UX] Improve compare and balance CLI defaults to prevent terminal hangs

### DIFF
--- a/scripts/mtg_analyze.py
+++ b/scripts/mtg_analyze.py
@@ -1018,6 +1018,7 @@ def handle_archetypes(args):
     datalib.add_separator_row(rows); datalib.printrows(datalib.padrows(rows, aligns=['l','r','l','l','r','r']), indent=2)
 
 def handle_balance(args):
+    _resolve_compare_inputs(args)
     datasets = []
     for f in args.infiles:
         cards = jdecode.mtg_open_file(f, verbose=args.verbose, sets=args.set, rarities=args.rarity)
@@ -1499,8 +1500,19 @@ def handle_audit(args):
 
     print()
 
-def handle_compare(args):
-    # Smart Baseline Detection: if only one file is provided, try to find a standard baseline
+def _resolve_compare_inputs(args):
+    """
+    Resolves infiles comparison arguments to apply smart defaults:
+    - If empty and stdin is a TTY, exit with a helpful error to prevent terminal hang.
+    - If empty and stdin is not a TTY (piped/redirected), default to standard input ('-').
+    - If exactly one input is provided, attempt smart baseline detection.
+    """
+    if not getattr(args, 'infiles', None):
+        if sys.stdin.isatty():
+            print("Error: Please specify at least one file to compare, or pipe card data into standard input.", file=sys.stderr)
+            sys.exit(1)
+        args.infiles = ['-']
+
     if len(args.infiles) == 1:
         script_dir = os.path.dirname(os.path.realpath(__file__))
         options = [
@@ -1512,9 +1524,12 @@ def handle_compare(args):
         for opt in options:
             if os.path.exists(opt) and os.path.abspath(opt) != os.path.abspath(args.infiles[0]):
                 args.infiles.insert(0, opt)
-                if not args.quiet:
+                if not getattr(args, 'quiet', False):
                     print(f"Notice: Comparing against baseline: {opt}", file=sys.stderr)
                 break
+
+def handle_compare(args):
+    _resolve_compare_inputs(args)
 
     def get_stats_for_file(path, args):
         ss = {}
@@ -1965,7 +1980,7 @@ def main():
 
     # compare
     p_comp = subparsers.add_parser('compare', help='Provide a side-by-side statistical comparison of two or more datasets.')
-    p_comp.add_argument('infiles', nargs='+', help='Two or more card data files to compare.')
+    p_comp.add_argument('infiles', nargs='*', help='Card data files to compare. Defaults to AllPrintings.json and stdin if empty.')
     add_std(p_comp)
     p_comp.set_defaults(func=handle_compare)
 

--- a/tests/test_mtg_analyze_compare_defaults.py
+++ b/tests/test_mtg_analyze_compare_defaults.py
@@ -1,0 +1,100 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import io
+import sys
+import os
+
+# Add lib and scripts to path
+sys.path.append(os.getcwd())
+sys.path.append(os.path.join(os.getcwd(), 'lib'))
+
+from scripts.mtg_analyze import main as analyze_main, _resolve_compare_inputs
+
+class TestMtgAnalyzeCompareDefaults(unittest.TestCase):
+
+    @patch('sys.stdin.isatty', return_value=True)
+    def test_compare_interactive_tty_empty_infiles(self, mock_isatty):
+        # When infiles is empty and stdin is interactive, it should print error to stderr and exit(1)
+        mock_args = MagicMock()
+        mock_args.infiles = []
+
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            with self.assertRaises(SystemExit) as cm:
+                _resolve_compare_inputs(mock_args)
+
+            self.assertEqual(cm.exception.code, 1)
+            err_msg = fake_err.getvalue()
+            self.assertIn("Error: Please specify at least one file to compare, or pipe card data into standard input.", err_msg)
+
+    @patch('sys.stdin.isatty', return_value=False)
+    @patch('os.path.exists', return_value=False)
+    def test_compare_non_interactive_empty_infiles(self, mock_exists, mock_isatty):
+        # When infiles is empty and stdin is piped, it should default to ['-']
+        mock_args = MagicMock()
+        mock_args.infiles = []
+        mock_args.quiet = True
+
+        _resolve_compare_inputs(mock_args)
+        self.assertEqual(mock_args.infiles, ['-'])
+
+    @patch('sys.stdin.isatty', return_value=False)
+    @patch('os.path.exists')
+    def test_compare_one_infile_smart_baseline(self, mock_exists, mock_isatty):
+        # Mock exists to say our custom file exists and AllPrintings.json exists
+        def exists_side_effect(path):
+            if 'AllPrintings.json' in path:
+                return True
+            if path == 'custom.json':
+                return True
+            return False
+
+        mock_exists.side_effect = exists_side_effect
+
+        mock_args = MagicMock()
+        mock_args.infiles = ['custom.json']
+        mock_args.quiet = True
+
+        _resolve_compare_inputs(mock_args)
+        # It should have inserted data/AllPrintings.json (or another path) at index 0
+        self.assertEqual(len(mock_args.infiles), 2)
+        self.assertEqual(mock_args.infiles[1], 'custom.json')
+        self.assertTrue(mock_args.infiles[0].endswith('AllPrintings.json'))
+
+    @patch('sys.stdin.isatty', return_value=False)
+    @patch('os.path.exists', return_value=False)
+    def test_handle_balance_smart_defaults(self, mock_exists, mock_isatty):
+        # Verify handle_balance processes standard input as default when infiles is empty and stdin is not interactive
+        card1 = MagicMock()
+        card1.name = "Grizzly Bears"
+        card1.valid = True
+        card1.parsed = True
+        card1.cost = MagicMock()
+        card1.cost.cmc = 2.0
+        card1.cost.colors = "G"
+        card1.pt_p = "&^"
+        card1.pt_t = "&^"
+        card1.pt = "&^/&^"
+        card1.loyalty = ""
+        card1.rarity_name = "common"
+        card1.types = ["creature"]
+        card1.supertypes = []
+        card1.subtypes = []
+        card1.text = MagicMock()
+        card1.text.encode.return_value = "text"
+        card1.text.text = "text"
+        card1.text_lines = [card1.text]
+        card1.text_words = ["text"]
+        card1.mechanics = set()
+        card1.color_identity = "G"
+        card1.complexity_score = 10
+
+        # When mtg_open_file is called for '-', return a list with card1
+        with patch('scripts.mtg_analyze.jdecode.mtg_open_file', return_value=[card1]):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                with patch('sys.argv', ['mtg_analyze.py', 'balance', '--no-color']):
+                    analyze_main()
+                    output = fake_out.getvalue()
+                    self.assertIn("ARCHETYPE BALANCE COMPARISON", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Context:
CLI (Command Line Interface)

### Problem:
The `compare` and `balance` subcommands under the unified metric and profiling tool `scripts/mtg_analyze.py` lacked intuitive defaulting behavior:
1. Running `compare` with zero arguments failed due to `nargs='+'` restriction, requiring users to explicitly pass standard input (`-`) to compare piped data.
2. Running `compare` or `balance` without any arguments in an interactive terminal would result in the CLI tool reading from standard input and hanging indefinitely on empty input.
3. Only the `compare` subcommand supported smart baseline detection (injecting `AllPrintings.json` as the baseline), while `balance` lacked this consistency.

### Solution:
1. Updated `compare`'s subcommand parser to use `nargs='*'` for `infiles`.
2. Implemented a robust `_resolve_compare_inputs(args)` function in `scripts/mtg_analyze.py` that checks for empty input files and gracefully exits with a helpful error message if in an interactive TTY, avoiding terminal hangs. If stdin is piped, it defaults to standard input (`-`).
3. Added smart baseline detection (injecting `AllPrintings.json` at index 0) for both `compare` and `balance` when exactly one target file/stdin is specified.
4. Integrated this helper across both `handle_compare` and `handle_balance` to ensure full behavioral consistency.
5. Implemented a complete unit test suite `tests/test_mtg_analyze_compare_defaults.py` ensuring the UX is robust and behaves exactly as expected.

---
*PR created automatically by Jules for task [11997531071534993972](https://jules.google.com/task/11997531071534993972) started by @RainRat*