### PR TITLE
[FEAT] Add Tribal subcommand and interactive shell command to mtg_query

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -454,14 +454,15 @@ def _execute_search(cards, args, include_indices=False):
                 print(idx_prefix + get_field_value(c, 'summary', ansi_color=use_color))
         return cards
     else:
+        delimiter = getattr(args, 'delimiter', ' | ')
         if getattr(args, 'outfile', None):
             with open(args.outfile, 'w') as f:
                 for c in cards:
-                    line = args.delimiter.join([get_field_value(c, f, ansi_color=False) for f in field_list])
+                    line = delimiter.join([get_field_value(c, f, ansi_color=False) for f in field_list])
                     f.write(line + '\n')
         else:
             for c in cards:
-                line = args.delimiter.join([get_field_value(c, f, ansi_color=use_color) for f in field_list])
+                line = delimiter.join([get_field_value(c, f, ansi_color=use_color) for f in field_list])
                 print(line)
         return cards
 
@@ -858,6 +859,7 @@ def handle_shell(args):
                     '/reprints ', '/rep ',
                     '/substitutes ', '/sub ',
                     '/counterparts ', '/cp ',
+                    '/tribal ', '/tr ',
                     '/similar ',
                     '/extract ', '/e ',
                     '/list', '/l', '/results',
@@ -1049,6 +1051,15 @@ def handle_shell(args):
                     cp_args = copy.copy(args)
                     cp_args.query = " ".join(_resolve_args(cmd_args))
                     last_results = handle_counterparts(cp_args, include_indices=True)
+                elif cmd in ['/tribal', '/tr']:
+                    if not cmd_args:
+                        err_msg = "Error: /tribal requires a card name."
+                        if use_color: err_msg = utils.colorize(err_msg, utils.Ansi.BOLD + utils.Ansi.RED)
+                        print(err_msg)
+                        continue
+                    tr_args = copy.copy(args)
+                    tr_args.query = " ".join(_resolve_args(cmd_args))
+                    last_results = handle_tribal(tr_args, include_indices=True)
                 elif cmd in ['/similar']:
                     cmd_args = _resolve_args(cmd_args)
                     o_args = copy.copy(args)
@@ -1095,6 +1106,7 @@ def handle_shell(args):
                     fmt_cmd("/reprints <n>", "/rep", "Find cards with identical mechanics/cost to the named card.")
                     fmt_cmd("/substitutes <n>", "/sub", "Find functional alternatives to the named card.")
                     fmt_cmd("/counterparts <n>", "/cp", "Find mechanical clones in different colors.")
+                    fmt_cmd("/tribal <n>", "/tr", "Find cards related to the named card's subtypes.")
                     fmt_cmd("/superior <n>", "/sup", "Find cards generally better than the named card.")
                     fmt_cmd("/inferior <n>", "/inf", "Find cards generally worse than the named card.")
                     fmt_cmd("/similar <n>", "", "Find cards mechanically similar to the named card.")
@@ -1120,6 +1132,7 @@ def handle_shell(args):
                         '/reprints', '/rep',
                         '/substitutes', '/sub',
                         '/counterparts', '/cp',
+                        '/tribal', '/tr',
                         '/similar',
                         '/extract', '/e',
                         '/list', '/l', '/results',
@@ -1657,6 +1670,81 @@ def handle_counterparts(args, include_indices=False):
     # Use search display for results
     return _execute_search(counterparts, args, include_indices=include_indices)
 
+def get_subtype_forms(subtype):
+    sub = subtype.lower()
+    forms = {sub}
+    # Irregular plural forms
+    irregulars = {
+        'elf': 'elves',
+        'wolf': 'wolves',
+        'merfolk': 'merfolk',
+        'fungus': 'fungi',
+        'octopus': 'octopuses',
+        'dwarf': 'dwarves',
+    }
+    # reverse lookup or mapping
+    for sing, plur in irregulars.items():
+        if sub == sing:
+            forms.add(plur)
+        elif sub == plur:
+            forms.add(sing)
+
+    # Generic rules
+    if sub.endswith('y') and sub[-2:] not in ['ay', 'ey', 'oy', 'uy']:
+        forms.add(sub[:-1] + 'ies')
+    elif sub.endswith('sh') or sub.endswith('ch') or sub.endswith('s') or sub.endswith('x') or sub.endswith('z'):
+        forms.add(sub + 'es')
+    else:
+        if sub not in irregulars and sub not in irregulars.values():
+            forms.add(sub + 's')
+
+    return forms
+
+def handle_tribal(args, include_indices=False):
+    target_card, cards = _resolve_target_from_args(args)
+    if not target_card:
+        return []
+
+    target_subtypes = [sub.lower() for sub in target_card.subtypes]
+    if not target_subtypes:
+        if not args.quiet:
+            print(f"Card {target_card.display_name} has no subtypes to query.", file=sys.stderr)
+        return []
+
+    tribal_cards = []
+    for c in cards:
+        if c.name.lower() == target_card.name.lower():
+            continue
+
+        candidate_subtypes = [sub.lower() for sub in c.subtypes]
+        is_related = False
+
+        # 1. Shares at least one subtype
+        if any(sub in candidate_subtypes for sub in target_subtypes):
+            is_related = True
+        else:
+            # 2. Mentions any of those subtypes (or their plural/irregular forms) in its rules text
+            candidate_text = c.get_text(force_unpass=True).lower()
+            for sub in target_subtypes:
+                forms = get_subtype_forms(sub)
+                for form in forms:
+                    pattern = r'\b' + re.escape(form) + r'\b'
+                    if re.search(pattern, candidate_text):
+                        is_related = True
+                        break
+                if is_related:
+                    break
+
+        if is_related:
+            tribal_cards.append(c)
+
+    if not tribal_cards:
+        if not args.quiet:
+            print(f"No tribal-related cards found for {target_card.display_name}.", file=sys.stderr)
+        return []
+
+    return _execute_search(tribal_cards, args, include_indices=include_indices)
+
 def find_substitutes(target, pool, limit=10):
     """Finds functional alternatives to a reference card."""
     if not target or not pool:
@@ -1992,6 +2080,7 @@ def main():
                          'sets', 'st', 'functional', 'f', 'reprints', 'rep',
                          'substitutes', 'sub', 'counterparts', 'cp',
                          'compare', 'c', 'superior', 'sup', 'inferior', 'inf',
+                         'tribal', 'tr',
                          'shell', 'sh', 'interactive', 'repl']
 
     has_subcommand = any(arg in valid_subcommands for arg in sys.argv[1:])
@@ -2399,6 +2488,38 @@ Usage Examples:
     p_counterparts.add_argument('--delimiter', default=' | ',
                         help='Separator used between fields in plain text output.')
     p_counterparts.set_defaults(func=handle_counterparts)
+
+    # Tribal Subparser
+    p_tribal = subparsers.add_parser(
+        'tribal',
+        aliases=['tr'],
+        help="Find other cards related to a reference card's subtypes.",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""
+Finds other cards related to a reference card's subtypes.
+It identifies cards that share at least one subtype or mention any
+of those subtypes in their rules text.
+
+Usage Examples:
+  # Find cards related to Goblins
+  python3 scripts/mtg_query.py tribal "Goblin Piker"
+
+  # Find cards related to Elves in a specific set
+  python3 scripts/mtg_query.py tribal "Llanowar Elves" --set MOM
+"""
+    )
+    p_tribal.add_argument('query', help='The card name to use as a reference for comparison.')
+    p_tribal.add_argument('infile', nargs='?', default='-',
+                           help='Input card data file. Defaults to data/AllPrintings.json.')
+    cli_utils.add_standard_filters(p_tribal)
+    cli_utils.add_standard_output_args(p_tribal)
+    p_tribal.add_argument('-f', '--fields', default='name,cost,cmc,type,stats,rarity,mechanics',
+                           help=FIELDS_HELP)
+    p_tribal.add_argument('--sort', choices=['name', 'color', 'identity', 'type', 'cmc', 'rarity', 'power', 'toughness', 'loyalty', 'set', 'complexity', 'rating'],
+                           help='Sort the resulting tribal cards.')
+    p_tribal.add_argument('--delimiter', default=' | ',
+                        help='Separator used between fields in plain text output.')
+    p_tribal.set_defaults(func=handle_tribal)
 
     # Shell Subparser
     p_shell = subparsers.add_parser(

--- a/tests/test_mtg_query_tribal.py
+++ b/tests/test_mtg_query_tribal.py
@@ -1,0 +1,180 @@
+import json
+import io
+import sys
+import os
+import unittest
+import tempfile
+from unittest.mock import patch
+from scripts.mtg_query import main as query_main
+from scripts.mtg_query import get_subtype_forms
+
+class TestMtgQueryTribal(unittest.TestCase):
+
+    def run_main(self, args):
+        with patch('sys.argv', ['mtg_query.py', 'tribal'] + args):
+            with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                with patch('sys.stderr', new=io.StringIO()) as fake_err:
+                    try:
+                        query_main()
+                        code = 0
+                    except SystemExit as e:
+                        code = e.code if isinstance(e.code, int) else 0
+                    return code, fake_out.getvalue(), fake_err.getvalue()
+
+    def test_get_subtype_forms(self):
+        # Irregular plurals
+        self.assertIn("elves", get_subtype_forms("elf"))
+        self.assertIn("wolves", get_subtype_forms("wolf"))
+        self.assertIn("merfolk", get_subtype_forms("merfolk"))
+        self.assertIn("fungi", get_subtype_forms("fungus"))
+        self.assertIn("octopuses", get_subtype_forms("octopus"))
+        self.assertIn("dwarves", get_subtype_forms("dwarf"))
+
+        # Ending in -y
+        self.assertIn("allies", get_subtype_forms("ally"))
+        self.assertNotIn("allies", get_subtype_forms("donkey")) # Zombie exception or ay/ey/oy/uy check
+
+        # Ending in sh, ch, s, x, z
+        self.assertIn("fishes", get_subtype_forms("fish"))
+        self.assertIn("foxes", get_subtype_forms("fox"))
+
+        # Standard s
+        self.assertIn("goblins", get_subtype_forms("goblin"))
+
+    def test_tribal_basic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_tribal.json")
+            # Create a deck of cards representing Goblins, Elves, and Wizards
+            with open(test_file, "w") as f:
+                json.dump([
+                    {
+                        "name": "Goblin Piker",
+                        "manaCost": "{1}{R}",
+                        "types": ["Creature"],
+                        "subtypes": ["Goblin", "Warrior"],
+                        "power": "2",
+                        "toughness": "1",
+                        "text": "",
+                        "rarity": "Common"
+                    },
+                    {
+                        "name": "Goblin King",
+                        "manaCost": "{1}{R}{R}",
+                        "types": ["Creature"],
+                        "subtypes": ["Goblin"],
+                        "power": "2",
+                        "toughness": "2",
+                        "text": "Other Goblins get +1/+1 and have mountainwalk.",
+                        "rarity": "Rare"
+                    },
+                    {
+                        "name": "Llanowar Elves",
+                        "manaCost": "{G}",
+                        "types": ["Creature"],
+                        "subtypes": ["Elf", "Druid"],
+                        "power": "1",
+                        "toughness": "1",
+                        "text": "{T}: Add {G}.",
+                        "rarity": "Common"
+                    },
+                    {
+                        "name": "Elvish Archdruid",
+                        "manaCost": "{1}{G}{G}",
+                        "types": ["Creature"],
+                        "subtypes": ["Elf", "Druid"],
+                        "power": "2",
+                        "toughness": "2",
+                        "text": "Other Elves you control get +1/+1. {T}: Add {G} for each Elf you control.",
+                        "rarity": "Rare"
+                    },
+                    {
+                        "name": "Goblin Grenade",
+                        "manaCost": "{R}",
+                        "types": ["Sorcery"],
+                        "text": "As an additional cost to cast this spell, sacrifice a Goblin.",
+                        "rarity": "Uncommon"
+                    },
+                    {
+                        "name": "Divination",
+                        "manaCost": "{2}{U}",
+                        "types": ["Sorcery"],
+                        "text": "Draw two cards.",
+                        "rarity": "Common"
+                    }
+                ], f)
+
+            # 1. Test Goblin Piker -> should find Goblin King (shares Goblin subtype) and Goblin Grenade (mentions Goblin in text)
+            # but NOT Divination or Llanowar Elves
+            code, out, err = self.run_main(["Goblin Piker", test_file, "--no-color", "--fields", "name"])
+            self.assertEqual(code, 0)
+            self.assertIn("Goblin King", out)
+            self.assertIn("Goblin Grenade", out)
+            self.assertNotIn("Llanowar Elves", out)
+            self.assertNotIn("Divination", out)
+            self.assertNotIn("Goblin Piker", out) # Should not find itself
+
+            # 2. Test Llanowar Elves -> should find Elvish Archdruid (shares Elf, plus text mentions "Elves" which is irregular plural of "Elf")
+            code, out, err = self.run_main(["Llanowar Elves", test_file, "--no-color", "--fields", "name"])
+            self.assertEqual(code, 0)
+            self.assertIn("Elvish Archdruid", out)
+            self.assertNotIn("Goblin King", out)
+
+    def test_tribal_no_match(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_no_tribal.json")
+            with open(test_file, "w") as f:
+                json.dump([
+                    {
+                        "name": "Unique Card",
+                        "manaCost": "{W}",
+                        "types": ["Instant"],
+                        "text": "Gain 3 life.",
+                        "rarity": "Common"
+                    }
+                ], f)
+
+            code, out, err = self.run_main(["Unique Card", test_file, "--no-color"])
+            self.assertIn("has no subtypes to query.", err)
+
+    def test_shell_tribal_integration(self):
+        # Test executing /tribal under mtg_query shell subcommand
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_shell.json")
+            with open(test_file, "w") as f:
+                json.dump([
+                    {
+                        "name": "Goblin Piker",
+                        "manaCost": "{1}{R}",
+                        "types": ["Creature"],
+                        "subtypes": ["Goblin"],
+                        "power": "2",
+                        "toughness": "1",
+                        "text": ""
+                    },
+                    {
+                        "name": "Goblin King",
+                        "manaCost": "{1}{R}{R}",
+                        "types": ["Creature"],
+                        "subtypes": ["Goblin"],
+                        "power": "2",
+                        "toughness": "2",
+                        "text": ""
+                    }
+                ], f)
+
+            # We can mock input for the interactive shell to run `/tribal Goblin Piker` then `exit`
+            inputs = ["/tribal Goblin Piker", "exit"]
+            with patch('builtins.input', side_effect=inputs):
+                with patch('sys.argv', ['mtg_query.py', 'shell', test_file, '--no-color']):
+                    with patch('sys.stdout', new=io.StringIO()) as fake_out:
+                        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+                            try:
+                                query_main()
+                            except SystemExit:
+                                pass
+                            out = fake_out.getvalue()
+                            # We expect Goblin King to be listed in the output table of the /tribal command
+                            self.assertIn("Goblin King", out)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request introduces the `tribal` (alias `tr`) subcommand and interactive shell command to `scripts/mtg_query.py`. 

### What:
- Added a `tribal` subcommand that resolves a reference card and finds all other cards in the dataset related to its subtypes.
- Relationships are established if a candidate card shares at least one subtype with the reference card, or if it explicitly mentions any of those subtypes (including singular, common plural, or irregular plural forms like 'elf' -> 'elves') in its rules text.
- Integrated `/tribal` (alias `/tr`) into the interactive shell subcommand with complete autocomplete and help menu listings.
- Improved robustness of command output by utilizing safe attribute lookups for `delimiter`.
- Added a full test suite under `tests/test_mtg_query_tribal.py` covering singular/plural maps, relation matching rules, and shell integration.

### Why:
This feature completes the family of mechanical/flavor relationship query subcommands (`reprints`, `substitutes`, `counterparts`, `superior`, `inferior`) in `mtg_query.py`, enabling deckbuilders and design evaluators to discover subtype-synergistic and tribally related cards within datasets instantly.

---
*PR created automatically by Jules for task [11254291668352155122](https://jules.google.com/task/11254291668352155122) started by @RainRat*