### PR TITLE
Refactor: Inline premature abstraction cosine_similarity_name inside f_nearest

### DIFF
--- a/lib/cbow.py
+++ b/lib/cbow.py
@@ -116,9 +116,6 @@ def cosine_similarity(v1,v2):
 
     return cosine[0][1]
 
-def cosine_similarity_name(cardvec, v, name):
-    return (cosine_similarity(cardvec, v), name)
-
 # we need to put the logic in a regular function (as opposed to a method of an object)
 # so that we can pass the function to multiprocessing
 def f_nearest(card, vocab, vecs, cardvecs, n):
@@ -133,7 +130,7 @@ def f_nearest(card, vocab, vecs, cardvecs, n):
 
     cardvec = makevector(vocab, vecs, words)
 
-    comparisons = [cosine_similarity_name(cardvec, v, name) for (name, v) in cardvecs]
+    comparisons = [(cosine_similarity(cardvec, v), name) for (name, v) in cardvecs]
 
     comparisons.sort(reverse = True)
     comp_n = comparisons[:n]


### PR DESCRIPTION
The private helper function `cosine_similarity_name` was only used once within `f_nearest` in `lib/cbow.py` to create tuples from the output of `cosine_similarity` and the card name. Inlined the logic directly inside the list comprehension inside `f_nearest` to simplify the design, remove unnecessary function call overhead, and eliminate the premature abstraction. All tests continue to pass successfully.

---
*PR created automatically by Jules for task [11630393119642278873](https://jules.google.com/task/11630393119642278873) started by @RainRat*