### PR TITLE
[DOCS] Improve internal help and error strings in decode.py

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -74,7 +74,8 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
         # However, argparse logic below ensures text defaults to True only if others are False.
         # But if someone calls main() directly with multiple True, we should respect that or fail.
         # The original code errored on >1 format.
-        print('ERROR - decode.py - incompatible output formats (choose one of --html, --mse, --json, --text, --table)', file=sys.stderr)
+        print('ERROR - decode.py: Incompatible output formats selected. Please specify at most one of the following output format flags:\n'
+              '  --text, --table (-t), --html (-H), --json (-j), --jsonl, --csv, --md (-M), --md-table, --summary (-S), --deck, --xml, --mse', file=sys.stderr)
         sys.exit(1)
 
     if for_mse:
@@ -650,7 +651,9 @@ def main(fname, oname = None, verbose = True, encoding = 'std',
                 mse_oname += '.mse-set'
 
             if os.path.isfile('set'):
-                print('ERROR: tried to overwrite existing file "set" - aborting.', file=sys.stderr)
+                print('ERROR: A file named "set" already exists in the current directory.\n'
+                      'This script uses a temporary "set" file to build the Magic Set Editor package.\n'
+                      'Please delete or rename the existing "set" file and try again.', file=sys.stderr)
                 return
 
             if verbose:


### PR DESCRIPTION
This pull request addresses Target Issue Category 2: Internal Help Strings in decode.py.

Specifically, it implements two major improvements to error outputs:
1. Updates the safety check error for conflicting output formats to completely and accurately list all twelve supported output formats (including newer formats like markdown, XML, JSON lines, CSV, etc.) instead of the outdated list of five.
2. Rewrites the low-level technical error when a 'set' file collision occurs during Magic Set Editor set building to be helpful and actionable for the casual user. It explains why the collision occurred, why the temporary file is needed, and how they can resolve it.

These improvements are written in plain, friendly English, avoiding unnecessary jargon, and maintaining a professional yet casual tone. All unit tests pass successfully.

---
*PR created automatically by Jules for task [15930970420653066459](https://jules.google.com/task/15930970420653066459) started by @RainRat*