### PR TITLE
[DOCS] Clarify ZIP extraction instructions in DEPENDENCIES.md

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -10,15 +10,25 @@ When you download files from MTGJSON, they often download as `.zip` compressed a
 
 ### Option A: Extract the ZIP (Recommended)
 Extract the downloaded file (such as `AllPrintings.json.zip`) to get the raw `.json` file inside.
+
+**For Command Line Users:**
 1. Create a folder named `data` in this project if it does not exist yet:
    ```bash
    mkdir -p data
    ```
-2. Move and extract your JSON file into that folder:
+2. Extract the ZIP file directly into the `data` folder using `unzip`:
    ```bash
-   mv ~/Downloads/AllPrintings.json data/
+   unzip ~/Downloads/AllPrintings.json.zip -d data/
    ```
-   If you extract the raw `AllPrintings.json` file into the `data/` folder, our scripts will automatically detect and load it. You do not need to specify the filename when running commands.
+
+**For Graphical Interface Users:**
+1. Open your file manager.
+2. Create a new folder named `data` in the project directory.
+3. Find your downloaded `AllPrintings.json.zip` file (usually in your `Downloads` folder).
+4. Extract (unzip) the file.
+5. Move the extracted `AllPrintings.json` file into the `data` folder you created.
+
+Once the raw `AllPrintings.json` file is inside the `data/` folder, our scripts will automatically find and load it. You do not need to specify the filename when running commands.
 
 ### Option B: Keep the ZIP intact
 You do not have to extract the file. Our tools natively support reading directly from `.zip` files.


### PR DESCRIPTION
We updated DEPENDENCIES.md to replace outdated and incomplete usage instructions under the 'Option A: Extract the ZIP' section. The previous instructions used a 'mv' command that erroneously assumed a .json file was already extracted instead of actual extraction of the .zip file. We provided both a precise 'unzip' command for command-line users and friendly, step-by-step instructions for graphical interface users.

---
*PR created automatically by Jules for task [14196834074143334098](https://jules.google.com/task/14196834074143334098) started by @RainRat*