### PR TITLE
[UI/UX] Smart context-aware tab completion for MTG interactive shell

### DIFF
--- a/scripts/mtg_query.py
+++ b/scripts/mtg_query.py
@@ -845,36 +845,85 @@ def handle_shell(args):
         card_names = sorted(list(set(cardlib.titlecase(c.name.replace(utils.dash_marker, '-')) for c in all_cards)))
 
         def completer(text, state):
-            if text.startswith('/'):
-                commands = [
-                    '/search ', '/s ',
-                    '/oracle ', '/o ',
-                    '/random ', '/r ',
-                    '/sets ', '/st ',
-                    '/functional ', '/f ',
-                    '/compare ', '/c ',
-                    '/superior ', '/sup ',
-                    '/inferior ', '/inf ',
-                    '/reprints ', '/rep ',
-                    '/substitutes ', '/sub ',
-                    '/counterparts ', '/cp ',
-                    '/similar ',
-                    '/extract ', '/e ',
-                    '/list', '/l', '/results',
-                    '/help', '/h', '/?',
-                    '/clear',
-                    '/exit', '/quit', '/q'
-                ]
-                options = [c for c in commands if c.startswith(text.lower())]
-            else:
-                options = [n for n in card_names if n.lower().startswith(text.lower())]
+            if state == 0:
+                completer.options = []
+                if not text:
+                    return None
 
-            if state < len(options):
-                return options[state]
+                if text.startswith('/'):
+                    # Command name completion (if there's no space in text)
+                    if ' ' not in text:
+                        commands = [
+                            '/search ', '/s ',
+                            '/oracle ', '/o ',
+                            '/random ', '/r ',
+                            '/sets ', '/st ',
+                            '/functional ', '/f ',
+                            '/compare ', '/c ',
+                            '/superior ', '/sup ',
+                            '/inferior ', '/inf ',
+                            '/reprints ', '/rep ',
+                            '/substitutes ', '/sub ',
+                            '/counterparts ', '/cp ',
+                            '/similar ',
+                            '/extract ', '/e ',
+                            '/list', '/l', '/results',
+                            '/help', '/h', '/?',
+                            '/clear', '/cls',
+                            '/exit', '/quit', '/q'
+                        ]
+                        completer.options = [c for c in commands if c.lower().startswith(text.lower())]
+                    else:
+                        parts = text.split(' ', 1)
+                        cmd = parts[0].lower()
+                        rest = parts[1] if len(parts) > 1 else ""
+
+                        card_cmds = [
+                            '/oracle', '/o', '/reprints', '/rep', '/substitutes', '/sub',
+                            '/counterparts', '/cp', '/superior', '/sup', '/inferior', '/inf',
+                            '/similar', '/compare', '/c', '/search', '/s', '/functional', '/f'
+                        ]
+
+                        if cmd in card_cmds:
+                            # Completing card names
+                            matches = [n for n in card_names if n.lower().startswith(rest.lower())]
+                            completer.options = [f"{parts[0]} {m}" for m in matches]
+
+                        elif cmd in ['/sets', '/st']:
+                            # Completing set codes
+                            set_codes = sorted(list(set(c.set_code.upper() for c in all_cards if c.set_code)))
+                            matches = [code for code in set_codes if code.lower().startswith(rest.lower())]
+                            completer.options = [f"{parts[0]} {m}" for m in matches]
+
+                        elif cmd in ['/extract', '/e']:
+                            # Completing /extract <set> <name>
+                            set_codes = sorted(list(set(c.set_code.upper() for c in all_cards if c.set_code)))
+                            rest_parts = rest.split(' ', 1)
+                            if len(rest_parts) == 1:
+                                # Completing the set code
+                                set_query = rest_parts[0]
+                                matches = [code for code in set_codes if code.lower().startswith(set_query.lower())]
+                                completer.options = [f"{parts[0]} {m} " for m in matches]
+                            else:
+                                # Completing the card name in that set
+                                set_code = rest_parts[0].upper()
+                                card_query = rest_parts[1]
+                                set_cards = [c for c in all_cards if c.set_code and c.set_code.upper() == set_code]
+                                set_card_names = sorted(list(set(cardlib.titlecase(c.name.replace(utils.dash_marker, '-')) for c in set_cards)))
+                                matches = [n for n in set_card_names if n.lower().startswith(card_query.lower())]
+                                completer.options = [f"{parts[0]} {rest_parts[0]} {m}" for m in matches]
+                else:
+                    # No slash command: completing card names
+                    matches = [n for n in card_names if n.lower().startswith(text.lower())]
+                    completer.options = matches
+
+            if state < len(completer.options):
+                return completer.options[state]
             return None
 
+        completer.options = []
         readline.set_completer(completer)
-        readline.set_completer_delims(' \t\n`@=#|\\')
+        readline.set_completer_delims('\t\n`@=#|\\')
         if 'libedit' in readline.__doc__: # macOS fix
             readline.parse_and_bind("bind ^I rl_complete")
         else:

--- a/tests/test_mtg_shell.py
+++ b/tests/test_mtg_shell.py
@@ -240,5 +240,29 @@ class TestMtgShell(unittest.TestCase):
                 self.assertIn("Unknown command: /xyzabc123.", output)
                 self.assertNotIn("Did you mean", output)
 
+    def test_shell_advanced_tab_completion(self):
+        """Test advanced slash command argument, set code, and extract completion logic."""
+        with patch('readline.set_completer') as mock_set_completer:
+            with patch('builtins.input', side_effect=['exit']):
+                handle_shell(self.args)
+                self.assertTrue(mock_set_completer.called)
+                completer = mock_set_completer.call_args[0][0]
+
+                # Test card name completion under a slash command (e.g. /oracle)
+                self.assertEqual(completer('/oracle inv', 0), '/oracle Invasion of Tarkir')
+                self.assertEqual(completer('/o inv', 0), '/o Invasion of Tarkir')
+
+                # Test set code completion under /sets or /st
+                self.assertEqual(completer('/sets cu', 0), '/sets CUS')
+                self.assertEqual(completer('/st cu', 0), '/st CUS')
+
+                # Test extract set code completion (first arg)
+                self.assertEqual(completer('/extract cu', 0), '/extract CUS ')
+                self.assertEqual(completer('/e cu', 0), '/e CUS ')
+
+                # Test extract card name completion (second arg)
+                self.assertEqual(completer('/extract CUS inv', 0), '/extract CUS Invasion of Tarkir')
+                self.assertEqual(completer('/e CUS inv', 0), '/e CUS Invasion of Tarkir')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR enhances the MTG interactive shell (`mtg_query.py shell`) by adding smart, context-aware command and argument autocompletion. Previously, the autocompleter was naive and could only complete command names or all card names regardless of the active command, causing terminal clutter and friction. Now:
1. Card-query commands (like `/oracle`, `/reprints`, `/similar`, `/compare`, etc.) correctly complete card names.
2. Set-filtering commands (like `/sets` and `/st`) complete set codes from the database.
3. The `/extract` command supports dual-stage completion: first completing set codes, then completing card names belonging to that specific set.
4. Delimiters exclude space to support seamless multi-word card names (e.g. 'Invasion of Tarkir').
Comprehensive tests have been added to verify these changes.

---
*PR created automatically by Jules for task [14841622536817581220](https://jules.google.com/task/14841622536817581220) started by @RainRat*