### PR TITLE
Fix NameError typo in scripts/analysis.py and add unit tests

### DIFF
--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -21,6 +21,8 @@ def gmean_nonzero(l):
 
 libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
 sys.path.append(libdir)
+scriptsdir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(scriptsdir)
 datadir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../data')
 import jdecode
 
@@ -133,7 +135,7 @@ def get_statistics(fname, lm = None, sep = False, verbose=False):
                 perp = lm.perplexity(vtext)
                 perp_per = perp / float(len(vtext))
                 perp_max = perp
-                perp_per_max = perps_per
+                perp_per_max = perp_per
 
             ngram['perp'] += [perp]
             ngram['perp_per'] += [perp_per]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,85 @@
+import sys
+import os
+import unittest
+import tempfile
+import json
+from collections import OrderedDict
+
+# Ensure root is in pythonpath
+sys.path.append(os.getcwd())
+
+from scripts.analysis import get_statistics
+from scripts.ngrams import build_ngram_model
+import lib.jdecode as jdecode
+
+class TestAnalysis(unittest.TestCase):
+    def setUp(self):
+        # Create a small dataset of cards in MTGJSON v5 format
+        self.cards_data = {
+            "data": {
+                "TEST": {
+                    "name": "Test Set",
+                    "code": "TEST",
+                    "type": "expansion",
+                    "cards": [
+                        {
+                            "name": "Plains",
+                            "types": ["Land"],
+                            "text": "{T}: Add {W}.",
+                            "rarity": "Common"
+                        },
+                        {
+                            "name": "Grizzly Bears",
+                            "manaCost": "{1}{G}",
+                            "types": ["Creature"],
+                            "text": "Bear power.",
+                            "rarity": "Common",
+                            "power": "2",
+                            "toughness": "2"
+                        }
+                    ]
+                }
+            }
+        }
+
+        # Write to a temporary JSON file
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.json_path = os.path.join(self.temp_dir.name, "test_cards.json")
+        with open(self.json_path, 'w', encoding='utf-8') as f:
+            json.dump(self.cards_data, f)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_get_statistics_without_lm(self):
+        stats = get_statistics(self.json_path, lm=None)
+        self.assertIn('cards', stats)
+        self.assertIn('props', stats)
+        self.assertEqual(len(stats['cards']), 2)
+
+    def test_get_statistics_with_lm_sep_true(self):
+        cards = jdecode.mtg_open_file(self.json_path)
+        # Build language model with sep=True
+        lm = build_ngram_model(cards, n=2, separate_lines=True)
+
+        # Test with sep=True
+        stats = get_statistics(self.json_path, lm=lm, sep=True)
+        self.assertIn('ngram', stats)
+        ngram_stats = stats['ngram']
+        self.assertIn('perp_mean', ngram_stats)
+        self.assertIn('perp_per_mean', ngram_stats)
+
+    def test_get_statistics_with_lm_sep_false(self):
+        cards = jdecode.mtg_open_file(self.json_path)
+        # Build language model with sep=False
+        lm = build_ngram_model(cards, n=2, separate_lines=False)
+
+        # Test with sep=False to exercise the else block
+        stats = get_statistics(self.json_path, lm=lm, sep=False)
+        self.assertIn('ngram', stats)
+        ngram_stats = stats['ngram']
+        self.assertIn('perp_mean', ngram_stats)
+        self.assertIn('perp_per_mean', ngram_stats)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix a NameError/typo logic bug in `scripts/analysis.py` where `perps_per` was referenced instead of `perp_per` in the `else` block of `get_statistics()`. Included a robust module import system path resolution to allow importing `scripts/analysis.py` as a module, and created a comprehensive test suite in `tests/test_analysis.py` verifying both line-by-line and whole-text perplexity calculations.

---
*PR created automatically by Jules for task [11268143257419933031](https://jules.google.com/task/11268143257419933031) started by @RainRat*