### PR TITLE
[FEAT] Add JSON, CSV, and file export options to mtg_diff.py

### DIFF
--- a/scripts/mtg_diff.py
+++ b/scripts/mtg_diff.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import argparse
+import json
 from collections import OrderedDict
 
 # Add lib directory to path
@@ -99,6 +100,9 @@ Usage Examples:
     io_group = parser.add_argument_group('Input / Output')
     io_group.add_argument('file1', help='Base card dataset (JSON, CSV, XML, or encoded text) to compare from.')
     io_group.add_argument('file2', help='Target card dataset to compare against the base.')
+    io_group.add_argument('-o', '--outfile', help='Path to save the diff results. If not provided, results print to the console.')
+    io_group.add_argument('-j', '--json', action='store_true', help='Output in JSON format.')
+    io_group.add_argument('--csv', action='store_true', help='Output in CSV format.')
 
     # Group: Processing Options
     proc_group = parser.add_argument_group('Processing Options')
@@ -167,12 +171,20 @@ Usage Examples:
 
     args = parser.parse_args()
 
+    # Auto-detect format based on outfile extension
+    if getattr(args, 'outfile', None):
+        if args.outfile.endswith('.json'):
+            args.json = True
+        elif args.outfile.endswith('.csv'):
+            args.csv = True
+
     # Determine if we should use color
     use_color = False
     if args.color is True:
         use_color = True
-    elif args.color is None and sys.stdout.isatty():
-        use_color = True
+    elif args.color is None:
+        if not getattr(args, 'json', False) and not getattr(args, 'csv', False) and not getattr(args, 'outfile', None) and sys.stdout.isatty():
+            use_color = True
 
     # Load datasets
     if args.verbose:
@@ -228,14 +240,75 @@ Usage Examples:
         if name not in map1:
             added.append(c2)
 
+    total_distinct = len(map1.keys() | map2.keys())
+    unchanged_count = len(map1.keys() & map2.keys()) - len(modified)
+
+    if getattr(args, 'json', False):
+        res_dict = {
+            "summary": {
+                "added": len(added),
+                "removed": len(removed),
+                "modified": len(modified),
+                "unchanged": unchanged_count
+            },
+            "added": [c.to_dict() for c in added],
+            "removed": [c.to_dict() for c in removed],
+            "modified": [
+                {
+                    "name": c.name,
+                    "differences": [
+                        {"field": field, "old": old, "new": new}
+                        for field, old, new in diffs
+                    ]
+                }
+                for c, diffs in modified
+            ]
+        }
+        res_text = json.dumps(res_dict, indent=2)
+        if args.outfile:
+            with open(args.outfile, 'w', encoding='utf-8') as f:
+                f.write(res_text + '\n')
+        else:
+            print(res_text)
+        return
+
+    elif getattr(args, 'csv', False):
+        import io
+        import csv
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["Status", "Card", "Field", "Old", "New"])
+        for c in added:
+            writer.writerow(["Added", c.display_name, "", "", ""])
+        for c in removed:
+            writer.writerow(["Removed", c.display_name, "", "", ""])
+        for c, diffs in modified:
+            for field, old, new in diffs:
+                writer.writerow(["Modified", c.display_name, field, old, new])
+        res_text = output.getvalue()
+        if args.outfile:
+            with open(args.outfile, 'w', encoding='utf-8', newline='') as f:
+                f.write(res_text)
+        else:
+            sys.stdout.write(res_text)
+        return
+
+    # If args.outfile is set and we're not outputting JSON or CSV, we capture the stdout
+    import io
+    from contextlib import redirect_stdout
+    if args.outfile:
+        stdout_capture = io.StringIO()
+        redirect_context = redirect_stdout(stdout_capture)
+        redirect_context.__enter__()
+    else:
+        redirect_context = None
+
     # Output report
     added_color = utils.Ansi.BOLD + utils.Ansi.GREEN
     removed_color = utils.Ansi.BOLD + utils.Ansi.RED
     mod_color = utils.Ansi.BOLD + utils.Ansi.YELLOW
 
     utils.print_header("SUMMARY", use_color=use_color)
-    total_distinct = len(map1.keys() | map2.keys())
-    unchanged_count = len(map1.keys() & map2.keys()) - len(modified)
 
     rows = [[
         utils.colorize("Category", utils.Ansi.BOLD + utils.Ansi.UNDERLINE) if use_color else "Category",
@@ -314,6 +387,12 @@ Usage Examples:
 
     # Provide clear feedback on operation completion
     utils.print_operation_summary("Comparison", len(map2), 0, quiet=args.quiet)
+
+    if redirect_context:
+        redirect_context.__exit__(None, None, None)
+        res_text = stdout_capture.getvalue()
+        with open(args.outfile, 'w', encoding='utf-8') as f:
+            f.write(res_text)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_mtg_diff.py
+++ b/tests/test_mtg_diff.py
@@ -181,3 +181,93 @@ def test_diff_progress_bar_threshold():
     data2 = data1
     stdout, stderr = run_diff([], data1, data2)
     assert "Unchanged" in stdout
+
+def test_diff_json_output():
+    import json
+    data1 = [{"name": "A", "types": ["Land"]}]
+    data2 = [{"name": "B", "types": ["Land"]}]
+    stdout, stderr = run_diff(["--json"], data1, data2)
+    res = json.loads(stdout)
+    assert "summary" in res
+    assert res["summary"]["added"] == 1
+    assert res["summary"]["removed"] == 1
+    assert len(res["added"]) == 1
+    assert len(res["removed"]) == 1
+    assert res["added"][0]["name"] == "B"
+    assert res["removed"][0]["name"] == "A"
+
+def test_diff_csv_output():
+    data1 = [{"name": "A", "types": ["Land"]}]
+    data2 = [{"name": "B", "types": ["Land"]}]
+    stdout, stderr = run_diff(["--csv"], data1, data2)
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    assert len(lines) == 3
+    assert lines[0] == "Status,Card,Field,Old,New"
+    assert "Added,B" in stdout
+    assert "Removed,A" in stdout
+
+def test_diff_json_outfile_detection():
+    import tempfile
+    import os
+    import json
+    data1 = [{"name": "A", "types": ["Land"]}]
+    data2 = [{"name": "B", "types": ["Land"]}]
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        temp_path = tf.name
+    try:
+        stdout, stderr = run_diff(["-o", temp_path], data1, data2)
+        assert os.path.exists(temp_path)
+        with open(temp_path, 'r', encoding='utf-8') as f:
+            content = json.load(f)
+        assert "summary" in content
+        assert content["summary"]["added"] == 1
+        assert content["summary"]["removed"] == 1
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+def test_diff_csv_outfile_detection():
+    import tempfile
+    import os
+    data1 = [{"name": "A", "types": ["Land"]}]
+    data2 = [{"name": "B", "types": ["Land"]}]
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tf:
+        temp_path = tf.name
+    try:
+        stdout, stderr = run_diff(["-o", temp_path], data1, data2)
+        assert os.path.exists(temp_path)
+        with open(temp_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        assert "Status,Card,Field,Old,New" in content
+        assert "Added,B" in content
+        assert "Removed,A" in content
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+def test_diff_text_outfile():
+    import tempfile
+    import os
+    data1 = [{"name": "A", "types": ["Land"]}]
+    data2 = [{"name": "B", "types": ["Land"]}]
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tf:
+        temp_path = tf.name
+    try:
+        stdout, stderr = run_diff(["-o", temp_path], data1, data2)
+        assert os.path.exists(temp_path)
+        with open(temp_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        assert "SUMMARY" in content
+        assert "Added" in content
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+def test_diff_color_bypass():
+    data1 = [{"name": "A", "types": ["Land"]}]
+    data2 = [{"name": "B", "types": ["Land"]}]
+    stdout_json, _ = run_diff(["--json"], data1, data2, isatty=True)
+    assert "\033[" not in stdout_json
+
+    stdout_csv, _ = run_diff(["--csv"], data1, data2, isatty=True)
+    assert "\033[" not in stdout_csv


### PR DESCRIPTION
Implement JSON, CSV, and file export features for mtg_diff.py. Supports automatic format detection from file extensions and handles color bypassing on structured output. Adds comprehensive unit tests.

---
*PR created automatically by Jules for task [1884095930405708658](https://jules.google.com/task/1884095930405708658) started by @RainRat*