### PR TITLE
[FEAT] Add search-and-replace and generic mana cost adjustment modifiers to mtg_forge.py

### DIFF
--- a/scripts/mtg_forge.py
+++ b/scripts/mtg_forge.py
@@ -256,6 +256,112 @@ def apply_scale(card_dict, factor, multiply=True):
         card_dict['bside'] = apply_scale(card_dict['bside'], factor, multiply)
     return card_dict
 
+def parse_sed_replace(replace_str):
+    """
+    Parses a sed-like replacement string of the form s/pattern/replacement/flags
+    """
+    if len(replace_str) < 4 or not replace_str.startswith('s'):
+        return None
+    delim = replace_str[1]
+    if delim.isalnum():
+        return None
+    parts = replace_str.split(delim)
+    if len(parts) < 3:
+        return None
+    pattern = parts[1]
+    replacement = parts[2]
+    flags = parts[3] if len(parts) > 3 else ""
+    return pattern, replacement, flags
+
+def apply_replacement(val, replace_arg):
+    if val is None or not isinstance(val, str):
+        return val
+    sed_parts = parse_sed_replace(replace_arg)
+    if sed_parts:
+        pattern, replacement, flags = sed_parts
+        re_flags = 0
+        if 'i' in flags:
+            re_flags |= re.IGNORECASE
+        count = 0 if 'g' in flags else 1
+        try:
+            return re.sub(pattern, replacement, val, count=count, flags=re_flags)
+        except Exception:
+            return val
+    else:
+        # Standard substring replacement
+        if '->' in replace_arg:
+            parts = replace_arg.split('->', 1)
+            old, new = parts[0], parts[1]
+            return val.replace(old, new)
+        return val
+
+def adjust_mana_cost(mana_cost, amount):
+    if not mana_cost:
+        # If there is no mana cost, and amount > 0, create generic mana cost
+        if amount > 0:
+            return f"{{{amount}}}"
+        return mana_cost
+
+    # Check for existing generic mana in braces, e.g. {2} or {X}
+    generic_match = re.search(r'\{(\d+)\}', mana_cost)
+    if generic_match:
+        current_generic = int(generic_match.group(1))
+        new_generic = max(0, current_generic + amount)
+        if new_generic == 0:
+            # Remove generic mana cost brace
+            new_cost = re.sub(r'\{\d+\}', '', mana_cost)
+        else:
+            new_cost = re.sub(r'\{\d+\}', f"{{{new_generic}}}", mana_cost)
+        return new_cost
+    else:
+        # If no generic mana cost but we want to add some
+        if amount > 0:
+            # Prepend generic mana
+            return f"{{{amount}}}" + mana_cost
+        return mana_cost
+
+def apply_text_replacements(card_dict, args):
+    if args.replace_name:
+        if 'name' in card_dict:
+            card_dict['name'] = apply_replacement(card_dict['name'], args.replace_name)
+    if args.replace_type:
+        current_type = card_dict.get('type')
+        if not current_type:
+            sups = card_dict.get('supertypes', [])
+            typs = card_dict.get('types', [])
+            subs = card_dict.get('subtypes', [])
+            full_parts = []
+            if sups or typs:
+                full_parts.append(" ".join(sups + typs))
+            if subs:
+                full_parts.append(" ".join(subs))
+            current_type = " - ".join(full_parts)
+        if current_type:
+            new_type = apply_replacement(current_type, args.replace_type)
+            card_dict['type'] = new_type
+            # Re-evaluate types
+            card_dict.pop('supertypes', None)
+            card_dict.pop('types', None)
+            card_dict.pop('subtypes', None)
+            supertypes, types, subtypes = utils.parse_type_line(new_type)
+            if supertypes: card_dict['supertypes'] = supertypes
+            if types: card_dict['types'] = types
+            if subtypes: card_dict['subtypes'] = subtypes
+    if args.replace:
+        if 'text' in card_dict:
+            card_dict['text'] = apply_replacement(card_dict['text'], args.replace)
+
+    if 'bside' in card_dict:
+        card_dict['bside'] = apply_text_replacements(card_dict['bside'], args)
+    return card_dict
+
+def apply_mana_adjust(card_dict, amount):
+    if 'manaCost' in card_dict:
+        card_dict['manaCost'] = adjust_mana_cost(card_dict['manaCost'], amount)
+    if 'bside' in card_dict:
+        card_dict['bside'] = apply_mana_adjust(card_dict['bside'], amount)
+    return card_dict
+
 def print_detailed_card(c, use_color=False, output_f=sys.stdout):
     term_width = utils.get_terminal_width()
 
@@ -484,6 +590,11 @@ def apply_modifiers(card_dict, args):
     if args.scale_down:
         card_dict = apply_scale(card_dict, args.scale_down, multiply=False)
 
+    card_dict = apply_text_replacements(card_dict, args)
+
+    if args.mana_adjust is not None:
+        card_dict = apply_mana_adjust(card_dict, args.mana_adjust)
+
     return card_dict
 
 def main():
@@ -559,6 +670,10 @@ Usage Examples:
     trans_group.add_argument('--nerf', type=int, nargs='?', const=1, help='Decrement power, toughness, loyalty, or defense by an amount.')
     trans_group.add_argument('--scale-up', type=float, nargs='?', const=2.0, help='Scale up stats and generic mana costs proportionally by a factor.')
     trans_group.add_argument('--scale-down', type=float, nargs='?', const=2.0, help='Scale down stats and generic mana costs proportionally by a factor.')
+    trans_group.add_argument('--replace', help='Search and replace in rules text. Supports substring (old->new) or sed-like regex (s/pattern/replacement/flags).')
+    trans_group.add_argument('--replace-name', help='Search and replace in card name. Supports substring (old->new) or sed-like regex (s/pattern/replacement/flags).')
+    trans_group.add_argument('--replace-type', help='Search and replace in type line. Supports substring (old->new) or sed-like regex (s/pattern/replacement/flags).')
+    trans_group.add_argument('--mana-adjust', type=int, help='Increase or decrease generic mana costs by an integer value.')
 
     # Group: Output Options
     out_group = parser.add_argument_group('Output Options')

--- a/tests/test_mtg_forge_modifiers_enhanced.py
+++ b/tests/test_mtg_forge_modifiers_enhanced.py
@@ -1,0 +1,115 @@
+import unittest
+from unittest.mock import patch
+import sys
+import os
+import json
+import io
+
+# Add lib and scripts directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+scriptsdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../scripts')
+sys.path.append(libdir)
+sys.path.append(scriptsdir)
+
+from scripts.mtg_forge import main, apply_replacement, adjust_mana_cost, apply_text_replacements, apply_mana_adjust
+
+class TestMtgForgeModifiersEnhanced(unittest.TestCase):
+
+    def test_apply_replacement_simple(self):
+        # Substring replacement (old->new)
+        text = "When @ enters the battlefield, draw a card."
+        res = apply_replacement(text, "draw->discard")
+        self.assertEqual(res, "When @ enters the battlefield, discard a card.")
+
+    def test_apply_replacement_sed_regex(self):
+        # sed-like pattern (s/pattern/replacement/flags)
+        text = "When @ enters the battlefield, draw a card. Draw two cards."
+        # No 'g' flag -> only replace first match
+        res1 = apply_replacement(text, "s/draw/discard/")
+        self.assertEqual(res1, "When @ enters the battlefield, discard a card. Draw two cards.")
+
+        # With 'g' and 'i' (ignorecase) flags
+        res2 = apply_replacement(text, "s/draw/discard/gi")
+        self.assertEqual(res2, "When @ enters the battlefield, discard a card. discard two cards.")
+
+    def test_adjust_mana_cost(self):
+        # Test adjustment with existing generic mana
+        self.assertEqual(adjust_mana_cost("{2}{U}{R}", 2), "{4}{U}{R}")
+        self.assertEqual(adjust_mana_cost("{2}{U}{R}", -2), "{U}{R}")
+        self.assertEqual(adjust_mana_cost("{2}{U}{R}", -5), "{U}{R}") # shouldn't go below 0
+
+        # Test adjustment with no existing generic mana
+        self.assertEqual(adjust_mana_cost("{G}{W}", 1), "{1}{G}{W}")
+        self.assertEqual(adjust_mana_cost("{G}{W}", -1), "{G}{W}")
+
+        # Test adjustment on empty mana cost
+        self.assertEqual(adjust_mana_cost("", 3), "{3}")
+        self.assertEqual(adjust_mana_cost("", -3), "")
+
+    def test_apply_text_replacements_and_bside(self):
+        card = {
+            'name': 'Grizzly Bears',
+            'type': 'Creature - Bear',
+            'text': 'A simple bear.',
+            'bside': {
+                'name': 'Bside Bear',
+                'type': 'Creature - Bear Spirit',
+                'text': 'A spectral bear.'
+            }
+        }
+
+        # Mock args
+        class Args:
+            replace_name = "Bear->Beast"
+            replace_type = "s/Creature - (\\w+)/Creature - \\1 Spirit/g"
+            replace = "simple->mighty"
+
+        res = apply_text_replacements(card, Args())
+
+        # Verify front
+        self.assertEqual(res['name'], 'Grizzly Beasts')
+        self.assertEqual(res['type'], 'Creature - Bear Spirit')
+        self.assertEqual(res['text'], 'A mighty bear.')
+
+        # Verify B-side recursive behavior
+        self.assertEqual(res['bside']['name'], 'Bside Beast')
+        self.assertEqual(res['bside']['type'], 'Creature - Bear Spirit Spirit') # since \1 was Bear, and we replaced regex with Bear Spirit Spirit
+        self.assertEqual(res['bside']['text'], 'A spectral bear.')
+
+    def test_apply_mana_adjust_and_bside(self):
+        card = {
+            'manaCost': '{2}{G}',
+            'bside': {
+                'manaCost': '{1}{R}'
+            }
+        }
+        res = apply_mana_adjust(card, 2)
+        self.assertEqual(res['manaCost'], '{4}{G}')
+        self.assertEqual(res['bside']['manaCost'], '{3}{R}')
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_cli_integration_replace_and_mana_adjust(self, mock_stdout):
+        test_args = [
+            'mtg_forge.py',
+            '--name', 'Jules, Chrono-Mage',
+            '--type', 'Legendary Creature - Wizard',
+            '--cost', '{1}{U}{R}',
+            '--text', 'T: Draw a card.',
+            '--replace-name', 'Chrono->Temporal',
+            '--replace-type', 'Wizard->Human Wizard',
+            '--replace', 'Draw->Discard',
+            '--mana-adjust', '3'
+        ]
+        with patch('sys.argv', test_args):
+            main()
+
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output['name'], 'Jules, Temporal-Mage')
+        self.assertEqual(output['supertypes'], ['Legendary'])
+        self.assertEqual(output['types'], ['Creature'])
+        self.assertEqual(output['subtypes'], ['Human', 'Wizard'])
+        self.assertEqual(output['manaCost'], '{4}{U}{R}')
+        self.assertEqual(output['text'], '{T}: Discard a card.')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* **What:** Adds several advanced transformational modifiers to `scripts/mtg_forge.py` for automated substring and regex-based search-and-replace operations across Name, Type, and Rules Text, as well as a robust generic mana cost adjustment flag.
* **Why:** Extends the Forge command-line utility with symmetric and powerful text manipulation tools, allowing users to script balance shifts, flavor updates, typeline overhauls, and generic cost tuning without manual file edits.
* **Changes:**
  - Integrated `--replace`, `--replace-name`, `--replace-type`, and `--mana-adjust` arguments.
  - Implemented `parse_sed_replace` to parse standard sed replacement strings (`s/pattern/replacement/flags`) with safety validation to ensure non-alphanumeric delimiters are used.
  - Recursively applied all replacements and cost shifts across card faces (`bside`).
  - Added full test suite in `tests/test_mtg_forge_modifiers_enhanced.py` verifying replacements, numeric mana additions/reductions, and CLI invocation.

---
*PR created automatically by Jules for task [9107848389738106569](https://jules.google.com/task/9107848389738106569) started by @RainRat*