### PR TITLE
[DOCS] Fix outdated ZIP extraction instructions in DEPENDENCIES.md

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -10,15 +10,25 @@ When you download files from MTGJSON, they often download as `.zip` compressed a
 
 ### Option A: Extract the ZIP (Recommended)
 Extract the downloaded file (such as `AllPrintings.json.zip`) to get the raw `.json` file inside.
+
+**Using your terminal:**
 1. Create a folder named `data` in this project if it does not exist yet:
    ```bash
    mkdir -p data
    ```
-2. Move and extract your JSON file into that folder:
+2. Extract the JSON file from the downloaded `.zip` file into the `data/` folder:
    ```bash
-   mv ~/Downloads/AllPrintings.json data/
+   unzip ~/Downloads/AllPrintings.json.zip -d data/
    ```
-   If you extract the raw `AllPrintings.json` file into the `data/` folder, our scripts will automatically detect and load it. You do not need to specify the filename when running commands.
+
+**Using a graphical file manager:**
+Alternatively, you can extract the files using your computer's built-in file manager:
+1. Locate the downloaded `AllPrintings.json.zip` file in your file manager.
+2. Double-click the file (or right-click and select "Extract" or "Unzip") to extract its contents.
+3. Create a folder named `data` in this project if it does not exist yet.
+4. Drag and drop the extracted `AllPrintings.json` file into that `data/` folder.
+
+If you extract the raw `AllPrintings.json` file into the `data/` folder, our scripts will automatically detect and load it. You do not need to specify the filename when running commands.
 
 ### Option B: Keep the ZIP intact
 You do not have to extract the file. Our tools natively support reading directly from `.zip` files.


### PR DESCRIPTION
This pull request improves the MTGJSON setup documentation in `DEPENDENCIES.md` by fixing outdated and incomplete instructions. 

### What
Previously, the "Extract the ZIP" option instructed the user to extract the `.zip` file, but only provided a move command (`mv`) for an already-extracted `.json` file. This pull request replaces that confusing step with:
1. A precise terminal `unzip` command that extracts the dataset directly into the `data/` directory.
2. A friendly, step-by-step alternative for users of graphical file managers.

### Why
This ensures a seamless and clear onboarding experience for all developers and casual users regardless of their operating system or comfort level with command-line tools.

---
*PR created automatically by Jules for task [120770674800171155](https://jules.google.com/task/120770674800171155) started by @RainRat*