### PR TITLE
[DOCS] Fix ZIP extraction instructions in DEPENDENCIES.md

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -14,10 +14,24 @@ Extract the downloaded file (such as `AllPrintings.json.zip`) to get the raw `.j
    ```bash
    mkdir -p data
    ```
-2. Move and extract your JSON file into that folder:
+2. Move and extract your ZIP file into that folder.
+
+   **Using the terminal:**
+   Move the ZIP file to the `data/` folder:
    ```bash
-   mv ~/Downloads/AllPrintings.json data/
+   mv ~/Downloads/AllPrintings.json.zip data/
    ```
+   Go to the `data/` folder and unzip the file:
+   ```bash
+   cd data
+   unzip AllPrintings.json.zip
+   ```
+
+   **Using a graphical file manager:**
+   * Open your Downloads folder.
+   * Double-click (or right-click and extract) `AllPrintings.json.zip`.
+   * Drag or copy the extracted `AllPrintings.json` file into the `data/` folder of this project.
+
    If you extract the raw `AllPrintings.json` file into the `data/` folder, our scripts will automatically detect and load it. You do not need to specify the filename when running commands.
 
 ### Option B: Keep the ZIP intact


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Option A setup instructions in DEPENDENCIES.md were corrected.
* **Why:** In step 2 of Option A, the guide instructed the user to move and extract their JSON file, but only provided a command to move a pre-extracted file (`mv ~/Downloads/AllPrintings.json data/`). This was incorrect and confusing as the downloaded MTGJSON dataset is packaged as a `.zip` file. This change provides proper, clear, and simple terminal commands (`unzip`) and graphical file manager alternatives.

---
*PR created automatically by Jules for task [10633124782472615093](https://jules.google.com/task/10633124782472615093) started by @RainRat*