### PR TITLE
Inline premature abstraction in lib/cbow.py

### DIFF
--- a/lib/cbow.py
+++ b/lib/cbow.py
@@ -116,8 +116,6 @@ def cosine_similarity(v1,v2):
 
     return cosine[0][1]
 
-def cosine_similarity_name(cardvec, v, name):
-    return (cosine_similarity(cardvec, v), name)
 
 # we need to put the logic in a regular function (as opposed to a method of an object)
 # so that we can pass the function to multiprocessing
@@ -133,7 +131,7 @@ def f_nearest(card, vocab, vecs, cardvecs, n):
 
     cardvec = makevector(vocab, vecs, words)
 
-    comparisons = [cosine_similarity_name(cardvec, v, name) for (name, v) in cardvecs]
+    comparisons = [(cosine_similarity(cardvec, v), name) for (name, v) in cardvecs]
 
     comparisons.sort(reverse = True)
     comp_n = comparisons[:n]


### PR DESCRIPTION
This change inlines the private helper function cosine_similarity_name directly into f_nearest to simplify the similarity calculation loop and eliminate premature abstraction. All tests pass with zero regressions.

---
*PR created automatically by Jules for task [11595030672196904387](https://jules.google.com/task/11595030672196904387) started by @RainRat*