### PR TITLE
[UI/UX] Gracefully handle missing dataset in mtg_deckgen.py

### DIFF
--- a/scripts/mtg_deckgen.py
+++ b/scripts/mtg_deckgen.py
@@ -166,6 +166,14 @@ Usage Examples:
             if not args.quiet:
                 print(f"Notice: Using default dataset: {args.infile}", file=sys.stderr)
 
+    # Graceful check for dataset requirements in interactive terminal (prevent hangs/misleading errors when default dataset is missing)
+    if args.infile == '-' and sys.stdin.isatty():
+        parser.print_help()
+        print("\nError: Deck generation requires an input dataset or card pool. "
+              "Please specify a file or pipe input, or make data/AllPrintings.json available.",
+              file=sys.stderr)
+        sys.exit(1)
+
     # Determine if we should use color
     use_color = False
     if args.color is True:

--- a/tests/test_mtg_deckgen.py
+++ b/tests/test_mtg_deckgen.py
@@ -135,5 +135,15 @@ class TestMtgDeckgen(unittest.TestCase):
             mtg_deckgen.main()
         self.assertIn("Warning: No non-creature spells found", mock_stderr.getvalue())
 
+    @patch('sys.stdin.isatty', return_value=True)
+    @patch('os.path.exists', return_value=False)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_main_interactive_missing_dataset(self, mock_stdout, mock_stderr, mock_exists, mock_isatty):
+        with patch('sys.argv', ['mtg_deckgen.py']), self.assertRaises(SystemExit) as cm:
+            mtg_deckgen.main()
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("Error: Deck generation requires an input dataset or card pool.", mock_stderr.getvalue())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Context
* **Context:** CLI (Command Line Interface)
* **Problem:** In `mtg_deckgen.py`, when run interactively in a TTY with no arguments or standard input, and the default dataset `AllPrintings.json` is missing, the tool previously printed a confusing and cryptic "No cards found in the card pool matching criteria" error.
* **Solution:** Added a check to print the parser's help message and a clean error to stderr, then exit with status 1. This prevents silent hangs/misleading errors in interactive TTY when standard input is selected but the default dataset is missing. Also added a comprehensive unit test to verify this behavior.

---
*PR created automatically by Jules for task [6671835014153913665](https://jules.google.com/task/6671835014153913665) started by @RainRat*