### PR TITLE
[FEAT] Add design and color pie validation to custom card forging

### DIFF
--- a/scripts/mtg_forge.py
+++ b/scripts/mtg_forge.py
@@ -486,6 +486,33 @@ def apply_modifiers(card_dict, args):
 
     return card_dict
 
+def validate_forged_card(card, use_color=False):
+    """
+    Validates a forged card using standard validation checks from mtg_validate.
+    Prints warning messages to stderr for any failed checks.
+    """
+    import mtg_validate
+
+    failed_checks = []
+    for prop_name, check_fn in mtg_validate.props.items():
+        res = check_fn(card)
+        if res is False:
+            failed_checks.append(prop_name)
+
+    if failed_checks:
+        label = "WARNING"
+        if use_color:
+            label = utils.colorize(label, utils.Ansi.BOLD + utils.Ansi.RED)
+
+        print(f"[{label}] Card '{card.display_name}' failed design validation: {', '.join(failed_checks)}", file=sys.stderr)
+
+        if "color_pie" in failed_checks:
+            cp_res = card.check_color_pie()
+            if isinstance(cp_res, str):
+                if use_color:
+                    cp_res = utils.colorize(cp_res, utils.Ansi.RED)
+                print(f"  - {cp_res}", file=sys.stderr)
+
 def main():
     parser = argparse.ArgumentParser(
         description="Forge a new Magic card or reforge existing ones in batch from the command line.",
@@ -568,6 +595,7 @@ Usage Examples:
     out_group.add_argument('-S', '--summary', action='store_true', help='Output a one-line summary.')
     out_group.add_argument('-V', '--view', action='store_true', help='Output a human-readable detailed card view.')
     out_group.add_argument('-G', '--gatherer', action='store_true', help='Output in official card database (Gatherer) format.')
+    out_group.add_argument('--validate', action='store_true', help='Validate the forged card(s) against design rules and color pie, printing warnings to stderr.')
 
     # Color options
     color_group = parser.add_mutually_exclusive_group()
@@ -640,7 +668,10 @@ Usage Examples:
             card_dict = card.to_dict()
             card_dict = apply_modifiers(card_dict, args)
             try:
-                final_cards.append(cardlib.Card(card_dict))
+                fc = cardlib.Card(card_dict)
+                final_cards.append(fc)
+                if args.validate:
+                    validate_forged_card(fc, use_color=use_color)
             except Exception as e:
                 if args.verbose:
                     print(f"Warning: Failed to validate modified card '{card.name}': {e}", file=sys.stderr)
@@ -701,6 +732,8 @@ Usage Examples:
         # Create a Card object to ensure all internal properties are populated
         try:
             final_card = cardlib.Card(card_dict)
+            if args.validate:
+                validate_forged_card(final_card, use_color=use_color)
         except Exception as e:
             print(f"Error validating forged card: {e}", file=sys.stderr)
             sys.exit(1)

--- a/tests/test_mtg_forge_validate.py
+++ b/tests/test_mtg_forge_validate.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import json
+import io
+
+# Add lib and scripts directory to path
+libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+scriptsdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../scripts')
+sys.path.append(libdir)
+sys.path.append(scriptsdir)
+
+from scripts.mtg_forge import main
+
+class TestMtgForgeValidate(unittest.TestCase):
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_forge_validate_invalid_bear(self, mock_stderr, mock_stdout):
+        # A creature must have power and toughness, otherwise it's invalid.
+        test_args = [
+            'mtg_forge.py',
+            '--name', 'Invalid Bear',
+            '--type', 'Creature',
+            '--validate'
+        ]
+
+        with patch('sys.argv', test_args):
+            main()
+
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output['name'], 'Invalid Bear')
+        self.assertEqual(output['types'], ['Creature'])
+
+        err_output = mock_stderr.getvalue()
+        self.assertIn('WARNING', err_output)
+        self.assertIn("Card 'Invalid Bear' failed design validation", err_output)
+        self.assertIn('pt', err_output)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_forge_validate_color_pie_break(self, mock_stderr, mock_stdout):
+        # Red counter target spell is a color pie break (Uncast expects UC)
+        test_args = [
+            'mtg_forge.py',
+            '--name', 'Red Counter',
+            '--cost', '{R}',
+            '--type', 'Instant',
+            '--text', 'Counter target spell.',
+            '--validate'
+        ]
+
+        with patch('sys.argv', test_args):
+            main()
+
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output['name'], 'Red Counter')
+
+        err_output = mock_stderr.getvalue()
+        self.assertIn('WARNING', err_output)
+        self.assertIn("Card 'Red Counter' failed design validation", err_output)
+        self.assertIn('color_pie', err_output)
+        self.assertIn('Color Pie Break: Uncast (Expected UC)', err_output)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_forge_validate_valid_card(self, mock_stderr, mock_stdout):
+        # A normal, valid creature with P/T and correct color pie keywords
+        test_args = [
+            'mtg_forge.py',
+            '--name', 'Valid Bear',
+            '--cost', '{1}{G}',
+            '--type', 'Creature - Bear',
+            '--pt', '2/2',
+            '--text', 'Trample',
+            '--validate'
+        ]
+
+        with patch('sys.argv', test_args):
+            main()
+
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output['name'], 'Valid Bear')
+        self.assertEqual(output['power'], '2')
+        self.assertEqual(output['toughness'], '2')
+
+        err_output = mock_stderr.getvalue()
+        # Should not have any warning printed to stderr
+        self.assertEqual(err_output.strip(), "")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented a new `--validate` feature in the custom card forge tool (`scripts/mtg_forge.py`) to allow designers to instantly audit their card creations against MTG design rules and mechanical color-pie guidelines. Built a comprehensive test suite (`tests/test_mtg_forge_validate.py`) to verify behavior.

---
*PR created automatically by Jules for task [15586582875750211780](https://jules.google.com/task/15586582875750211780) started by @RainRat*